### PR TITLE
[BREAKING] Resolving styling issues + causes

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,8 +149,8 @@ See the [Languages page](SUPPORTED_LANGUAGES.md) for a list of supported languag
 
 <!-- prettier-ignore-start -->
 ```css
-pre.hljs[data-language="css"] {
-  /* custom style rules */
+pre[data-language="css"] {
+    /* custom style rules */
 }
 ```
 <!-- prettier-ignore-end -->
@@ -159,13 +159,21 @@ pre.hljs[data-language="css"] {
 
 All `Highlight` components allow for a tag to be added at the top-right of the codeblock displaying the language name.
 
-The language tag can be given a custom `background`, `color`, and `border-radius` through the custom properties shown.
+The language tag can be given a custom `background` , `color` , and `border-radius` through the custom properties shown.
 
 This is also compatible with custom languages.
 
+It is recommended that you set values for `--hljs-background` and `--hljs-foreground` to ensure the langtags remain readable on any theme.
+
 See the [Languages page](SUPPORTED_LANGUAGES.md) for a list of supported languages.
 
+Defaults:
+
+- `--hljs-background: inherit`
+- `--hljs-foreground: inherit`
+- `--hljs-border-radius: 0`
 <!-- prettier-ignore-start -->
+
 ```svelte
 <script>
   import { HighlightAuto } from "svelte-highlight";
@@ -173,16 +181,17 @@ See the [Languages page](SUPPORTED_LANGUAGES.md) for a list of supported languag
   $: code = `.body { padding: 0; margin: 0; }`;
 </script>
 
-<HighlightAuto {code} langtag="{true}" />
+<HighlightAuto code="{code}" langtag="{true}" />
 ```
 
 ```css
-pre.hljs[data-language="css"] {
+pre[data-language="css"] {
   --hljs-background: linear-gradient(135deg, #2996cf, 80%, white);
   --hljs-foreground: #fff;
   --hljs-radius: 8px;
 }
 ```
+
 <!-- prettier-ignore-end -->
 
 ## Custom Language

--- a/demo/app.css
+++ b/demo/app.css
@@ -13,6 +13,9 @@ pre[data-language="css"] {
   --hljs-foreground: #fff;
   --hljs-radius: 8px;
 }
+pre[data-language="svelte"] {
+  --hljs-foreground: #fff;
+}
 
 .code {
   position: relative;

--- a/demo/app.css
+++ b/demo/app.css
@@ -1,11 +1,17 @@
 .hljs {
   overflow-x: auto;
-}
-
-.hljs code {
   font-size: 0.8125rem;
   font-family: Menlo;
   line-height: 1.5;
+}
+
+pre {
+  max-width: 44rem;
+}
+pre[data-language="css"] {
+  --hljs-background: linear-gradient(135deg, #2996cf, 80%, white);
+  --hljs-foreground: #fff;
+  --hljs-radius: 8px;
 }
 
 .code {
@@ -23,11 +29,6 @@
 
 li > .code {
   font-size: 0.75rem;
-}
-
-pre.hljs {
-  padding: 1.25rem 1rem 1.375rem !important;
-  max-width: 44rem;
 }
 
 .mr-3 {

--- a/demo/lib/ScopedStyle.svelte
+++ b/demo/lib/ScopedStyle.svelte
@@ -27,9 +27,10 @@ ${
 <Highlight language={typescript} {code} />`;
 
   $: css = (styles[moduleName] || "")
-    .replace(/\.hljs/g, `.${moduleName}.hljs`)
-    .replace(/\.hljs /g, `.${moduleName}.hljs`)
-    .replace(/\.hljs-/g, `.${moduleName} .hljs-`);
+    // prefix all styles with a scope
+    .replace(/\.hljs/g, `.${moduleName} .hljs`)
+    // adjust for first two rules being `code.hljs` not `.hljs`
+    .replace(/\s?code\.[_0-9a-zA-Z]+\s\.hljs/g, `.${moduleName} code.hljs`);
 </script>
 
 <svelte:head>

--- a/demo/lib/ScopedStyleAuto.svelte
+++ b/demo/lib/ScopedStyleAuto.svelte
@@ -19,9 +19,10 @@
 <HighlightAuto {code} />`;
 
   $: css = (styles[moduleName] || "")
-    .replace(/\.hljs/g, `.${moduleName}.hljs`)
-    .replace(/\.hljs /g, `.${moduleName}.hljs`)
-    .replace(/\.hljs-/g, `.${moduleName} .hljs-`);
+    // prefix all styles with a scope
+    .replace(/\.hljs/g, `.${moduleName} .hljs`)
+    // adjust for first two rules being `code.hljs` not `.hljs`
+    .replace(/\s?code\.[_0-9a-zA-Z]+\s\.hljs/g, `.${moduleName} code.hljs`);
 </script>
 
 <svelte:head>

--- a/demo/lib/ScopedStyleSvelte.svelte
+++ b/demo/lib/ScopedStyleSvelte.svelte
@@ -19,9 +19,10 @@
 <HighlightSvelte {code} />`;
 
   $: css = (styles[moduleName] || "")
-    .replace(/\.hljs/g, `.${moduleName}.hljs`)
-    .replace(/\.hljs /g, `.${moduleName}.hljs`)
-    .replace(/\.hljs-/g, `.${moduleName} .hljs-`);
+    // prefix all styles with a scope
+    .replace(/\.hljs/g, `.${moduleName} .hljs`)
+    // adjust for first two rules being `code.hljs` not `.hljs`
+    .replace(/\s?code\.[_0-9a-zA-Z]+\s\.hljs/g, `.${moduleName} code.hljs`);
 </script>
 
 <svelte:head>

--- a/demo/routes/index.svelte
+++ b/demo/routes/index.svelte
@@ -258,6 +258,7 @@
 
 <HighlightAuto {code} langtag="{true}" \/>`}"
       class="atomOneDark"
+			langtag="{true}"
     />
     <HighlightAuto
       code="{`pre[data-language="css"] {

--- a/demo/routes/index.svelte
+++ b/demo/routes/index.svelte
@@ -207,7 +207,7 @@
   </Column>
   <Column noGutter>
     <HighlightAuto
-      code="{'pre.hljs[data-language="css"] {\n\t/* custom style rules */\n}'}"
+      code="{'pre[data-language="css"] {\n\t/* custom style rules */\n}'}"
       class="atomOneDark"
     />
   </Column>
@@ -232,6 +232,18 @@
     </p>
     <p class="mb-5">This is also compatible with custom languages.</p>
     <p class="mb-5">
+      It is recommended that you set values for
+      <code class="code">--hljs-background</code> and
+      <code class="code">--hljs-foreground</code> to ensure the langtags remain readable
+      on any theme.
+    </p>
+    <p class="mb-5">Defaults:</p>
+    <ul class="mb-5">
+      <li><code class="code">--hljs-background: inherit</code></li>
+      <li><code class="code">--hljs-foreground: inherit</code></li>
+      <li><code class="code">--hljs-border-radius: 0</code></li>
+    </ul>
+    <p class="mb-5">
       See the <Link size="lg" href="{base}/languages">Languages page</Link> for a
       list of supported languages.
     </p>
@@ -246,10 +258,9 @@
 
 <HighlightAuto {code} langtag="{true}" \/>`}"
       class="atomOneDark"
-      langtag="{true}"
     />
     <HighlightAuto
-      code="{`pre.hljs[data-language="css"] {
+      code="{`pre[data-language="css"] {
   --hljs-background: linear-gradient(135deg, #2996cf, 80%, white);
   --hljs-foreground: #fff;
   --hljs-radius: 8px;
@@ -257,7 +268,6 @@
       class="atomOneDark"
       langtag="{true}"
     />
-    <style></style>
   </Column>
 </Row>
 <!-- end: uses HighlightAuto and HighlightSvelte, refactor? -->

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -59,7 +59,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    padding: calc(1em + 3px) calc(1em + 5px);
+    padding: 1em;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -39,11 +39,10 @@
 
 <slot highlighted="{highlighted}">
   <pre
-    class:hljs="{true}"
     class:langtag
     data-language="{(language.name && language.name) || 'plaintext'}"
     {...$$restProps}>
-    <code>
+    <code class="hljs">
       {#if highlighted !== undefined}
         {@html highlighted}
       {:else}{code}{/if}

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -36,11 +36,10 @@
 
 <slot highlighted="{highlighted}">
   <pre
-    class:hljs="{true}"
     class:langtag
     data-language="{(language && language) || 'plaintext'}"
     {...$$restProps}>
-      <code>
+      <code class="hljs">
         {#if highlighted !== undefined}
         {@html highlighted}
       {:else}{code}{/if}

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -56,7 +56,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    padding: calc(1em + 3px) calc(1em + 5px);
+    padding: 1em;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -56,7 +56,7 @@
     position: absolute;
     top: 0;
     right: 0;
-    padding: calc(1em + 3px) calc(1em + 5px);
+    padding: 1em;
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -38,11 +38,10 @@
 
 <slot highlighted="{highlighted}">
   <pre
-    class:hljs="{true}"
     class:langtag
     data-language="svelte"
     {...$$restProps}>
-    <code>
+    <code class="hljs">
       {@html highlighted}
     </code>
   </pre>


### PR DESCRIPTION
### Breaking Change: The `.hljs` class is now applied to the `<code />` and _not_ the `<pre />` in each `Highlight` component.

- [x] Run `npm run format` before commit
- [x] Test features for bugs in `/demo`
- [x] Test features for bugs in external project
- [ ] No breaking changes

Closes #172 

I didn't have as much time to work on this as I thought this week, so this one took a little longer than I had hoped.

As well as the busy week, bug 4 had me scratching my head for some time.
In short, the issues caused by the fix to bug 1 mean that langtags would no longer receive the correct text color from `highlight.js`.
I tested various workarounds, however they all felt far too hacky, one of them included modifying `highlight.js`'s styles in a way that resulted in styles leaking out of scope. The solution I landed on was the documentation update.

#### Bug 1 - Mismatched classes

Summary: the use of the `.hljs` class deviates from the intended use from `highlight.js` .

As to not require a major version, I suggest simply adding the class to the `<code />` as well as the `<pre />` .

In implementing the fix per [#172](https://github.com/metonym/svelte-highlight/issues/172), I caused a breaking change by removing `.hljs` class from `<pre />` and adding it to `<code />`

##### Implementation

Breaking change:

- the `.hljs` class is now applied to the `<code />` and _not_ the `<pre />` in each `Highlight` component.

##### Implementation Issues

Drastically highlights [bug #4](#4-demo-project-css)

#### Bug 2 - Over Padded "langtags"

Summary: a small mistake was made when implementing langtags, and the padding was too large.

I suggest changing the padding by the ~4px it is off by.

In implementing the fix per [#172](https://github.com/metonym/svelte-highlight/issues/172), I decreased the padding on langtags to `1em` .

##### Implementation

Non-breaking change:

- the padding on the `pre.langtag::after` in each of the `Highlight` components is set to `1em` to match the padding of the `pre code.hljs` .

##### Implementation Issues

Highlights [bug #4](#4-demo-project-css)

#### Bug 3 - Mismatched Classes (cont.)

Summary: the css preprocessing done on `ScopedStyle` components in the `/demo` project causes some issues in the resulting CSS.

I suggest modifying one of the replacements to fix both of the issues.

In implementing the fix per [#172](https://github.com/metonym/svelte-highlight/issues/172), I modified the RegEx replacements to account for changes from [bug #1](#1-mismatched-classes).

##### Implementation

Non-breaking change:

- The RegEx replacements have been changed to first apply the scope to all selectors, then apply a modification to rules that don't start `.hljs` (rules 1 and 2).

##### Implementation Issues

Highlights [bug #4](#4-demo-project-css)

#### Bug 4 - Demo Project CSS

Summary: fixing the previous bugs has caused the `/demo` project's CSS to become partly outdated, requireing a refresh.

I suggest moving all styles from `.hljs code` to `pre.hljs` and removing padding from `pre.hljs` .

In implementing the fix per [#172](https://github.com/metonym/svelte-highlight/issues/172), I merged some classes in the `app.css` file as well as added styles to demo langtags correctly in the documentation.

##### Implementation

Non-breaking change:

- The `app.css` file has been modified to merge `.hljs` and `.hljs code`, remove `.hljs` from the `pre.hljs` selector, and apply styles to `pre[data-language="css"]`

##### Implementation Issues

Nothing observed, if issues do arise they will not effect users' code as the fix is scoped only to the `/demo` project.

---

Documentation change:
In order to prevent hacky code, I'm simply recommending that users who want to take advantage of langtags also use the exposed custom properties.
I'm unsure if this is a breaking change, however the fix for bug 1 requires a major version change either way.

This will likely be the last contribution from me, at least for a little while.
It's been a lot of fun working on the earlier feature and these fixes, and quite refreshing to read through the code and see your style of programming.