### PR TITLE
Refactor scripts, use type-only import in type definitions

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "@sveltejs/kit": "next",
     "@testing-library/svelte": "^3.0.3",
     "@testing-library/user-event": "^13.5.0",
+    "@types/prettier": "^2.4.4",
     "carbon-components-svelte": "^0.59.0",
     "carbon-icons-svelte": "^10.44.4",
     "carbon-preprocess-svelte": "^0.6.0",

--- a/scripts/build-languages.js
+++ b/scripts/build-languages.js
@@ -10,6 +10,8 @@ export async function buildLanguages() {
     register: (hljs: any) => Record<string, any>;
   }\n\n`;
   let base = "";
+
+  /** @type {import("./build-styles").ModuleNames} */
   let lang = [];
 
   languages.forEach(async (name) => {

--- a/scripts/build-languages.js
+++ b/scripts/build-languages.js
@@ -2,8 +2,11 @@ import hljs from "highlight.js";
 import { writeTo } from "./utils/write-to.js";
 import { toCamelCase } from "./utils/to-pascal-case.js";
 import { createMarkdown } from "./utils/create-markdown.js";
+import { mkdir } from "./utils/fs.js";
 
 export async function buildLanguages() {
+  mkdir("src/languages");
+
   let languages = hljs.listLanguages();
   let markdown = createMarkdown("Languages", languages.length);
   let types = `interface HljsLanguage {

--- a/scripts/build-styles.js
+++ b/scripts/build-styles.js
@@ -5,8 +5,15 @@ import { writeTo } from "./utils/write-to.js";
 import { toCamelCase } from "./utils/to-pascal-case.js";
 import { createMarkdown } from "./utils/create-markdown.js";
 
+/**
+ * @typedef {Array<{ name: string; moduleName: string; }>} ModuleNames
+ */
+
 export async function buildStyles() {
+  /** @type {string[]} */
   let names = [];
+
+  /** @type {ModuleNames} */
   let styles = [];
 
   await totalist("node_modules/highlight.js/styles", async (file, absPath) => {

--- a/scripts/build-styles.js
+++ b/scripts/build-styles.js
@@ -4,12 +4,15 @@ import { readFile, copyFile } from "./utils/fs.js";
 import { writeTo } from "./utils/write-to.js";
 import { toCamelCase } from "./utils/to-pascal-case.js";
 import { createMarkdown } from "./utils/create-markdown.js";
+import { mkdir } from "./utils/fs.js";
 
 /**
  * @typedef {Array<{ name: string; moduleName: string; }>} ModuleNames
  */
 
 export async function buildStyles() {
+  mkdir("src/styles");
+
   /** @type {string[]} */
   let names = [];
 

--- a/scripts/index.js
+++ b/scripts/index.js
@@ -1,8 +1,5 @@
-import { mkdir } from "./utils/fs.js";
 import { buildLanguages } from "./build-languages.js";
 import { buildStyles } from "./build-styles.js";
 
-mkdir("src/styles");
-mkdir("src/languages");
 await buildLanguages();
 await buildStyles();

--- a/scripts/utils/create-markdown.js
+++ b/scripts/utils/create-markdown.js
@@ -6,15 +6,13 @@ const pkg = JSON.parse(
 
 /**
  * Creates header metadata for supported languages/styles
- * @param {"Languages" | "Styles"} type
- * @param {number} len
- * @returns {string}
+ * @type {(type: "Languages" | "Styles", len: number) => string}
  */
-export function createMarkdown(type, len) {
-  return `# Supported ${type}
+export const createMarkdown = (type, len) =>
+  `
+# Supported ${type}
 
 > ${len} ${type.toLowerCase()} exported from highlight.js@${
     pkg.dependencies["highlight.js"]
   }  
 `;
-}

--- a/scripts/utils/fs.js
+++ b/scripts/utils/fs.js
@@ -1,5 +1,5 @@
 import fs from "fs";
-import { promisify } from "util";
+import fsp from "fs/promises"
 
 /** @type {(dir: string) => void} */
 export const mkdir = (dir) => {
@@ -8,6 +8,6 @@ export const mkdir = (dir) => {
   }
   fs.mkdirSync(dir);
 };
-export const readFile = promisify(fs.readFile);
-export const writeFile = promisify(fs.writeFile);
-export const copyFile = promisify(fs.copyFile);
+export const readFile = fsp.readFile;
+export const writeFile = fsp.writeFile;
+export const copyFile = fsp.copyFile;

--- a/scripts/utils/fs.js
+++ b/scripts/utils/fs.js
@@ -1,6 +1,7 @@
 import fs from "fs";
 import { promisify } from "util";
 
+/** @type {(dir: string) => void} */
 export const mkdir = (dir) => {
   if (fs.existsSync(dir)) {
     fs.rmSync(dir, { recursive: true });

--- a/scripts/utils/index.js
+++ b/scripts/utils/index.js
@@ -1,6 +1,3 @@
-import { createMarkdown } from "./create-markdown.js";
-import { fs } from "./fs.js";
-import { toCamelCase } from "./to-pascal-case.js";
-import { writeTo } from "./write-to.js";
-
-export { createMarkdown, fs, toCamelCase, writeTo };
+export { createMarkdown } from "./create-markdown.js";
+export { toCamelCase } from "./to-pascal-case.js";
+export { writeTo } from "./write-to.js";

--- a/scripts/utils/to-pascal-case.js
+++ b/scripts/utils/to-pascal-case.js
@@ -1,16 +1,14 @@
 /**
+ * @type {(str: string) => string}
  * Converts a dash/period separated string into pascal case
  * @example
  * "one-two-three" --> "oneTwoThree"
- * @param {string} str
- * @returns {string}
  */
-export function toCamelCase(str) {
-  return str
+export const toCamelCase = (str) =>
+  str
     .split(new RegExp(/-|\./g))
     .map((fragment, index) => {
       if (index === 0) return fragment;
       return [fragment.slice(0, 1).toUpperCase(), fragment.slice(1)].join("");
     })
     .join("");
-}

--- a/scripts/utils/write-to.js
+++ b/scripts/utils/write-to.js
@@ -1,6 +1,6 @@
 import prettier from "prettier";
-import { writeFile } from "./fs.js";
 import path from "path";
+import { writeFile } from "./fs.js";
 
 const { format } = prettier;
 
@@ -12,6 +12,7 @@ const PARSER = {
   ".css": "css",
 };
 
+/** @type {(file: string, source: object | string) => Promise<void>} */
 export async function writeTo(file, source) {
   const value =
     typeof source === "string" ? source : JSON.stringify(source, null, 2);

--- a/scripts/utils/write-to.js
+++ b/scripts/utils/write-to.js
@@ -4,6 +4,7 @@ import { writeFile } from "./fs.js";
 
 const { format } = prettier;
 
+/** @type {Record<string, import ("prettier").BuiltInParserName>} */
 const PARSER = {
   ".md": "markdown",
   ".js": "babel",
@@ -16,9 +17,7 @@ const PARSER = {
 export async function writeTo(file, source) {
   const value =
     typeof source === "string" ? source : JSON.stringify(source, null, 2);
+  const parser = PARSER[path.parse(file).ext];
 
-  await writeFile(
-    file,
-    format(value, { parser: PARSER[path.parse(file).ext] })
-  );
+  await writeFile(file, format(value, { parser }));
 }

--- a/src/Highlight.svelte.d.ts
+++ b/src/Highlight.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HighlightProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["pre"]> {

--- a/src/HighlightAuto.svelte.d.ts
+++ b/src/HighlightAuto.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HighlightAutoProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["pre"]> {

--- a/src/HighlightSvelte.svelte.d.ts
+++ b/src/HighlightSvelte.svelte.d.ts
@@ -1,5 +1,5 @@
 /// <reference types="svelte" />
-import { SvelteComponentTyped } from "svelte";
+import type { SvelteComponentTyped } from "svelte";
 
 export interface HighlightSvelteProps
   extends svelte.JSX.HTMLAttributes<HTMLElementTagNameMap["pre"]> {

--- a/tests/SvelteHighlight.test.svelte
+++ b/tests/SvelteHighlight.test.svelte
@@ -3,7 +3,7 @@
   import Highlight2 from "../src/Highlight.svelte";
   import { typescript } from "../src/languages";
   import javascript from "../src/languages/javascript";
-  import { github, purebasic, _3024 } from "../src/styles";
+  import { github, purebasic, _3024 } from "../src/styles/index";
   import "../src/styles/3024.css";
 
   let toggled = true;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,17 +1,17 @@
 {
   "compilerOptions": {
     "allowJs": true,
+    "checkJs": true,
     "baseUrl": ".",
     "esModuleInterop": true,
     "isolatedModules": true,
     "lib": ["es2020", "DOM"],
-    "module": "es2020",
+    "module": "ESNext",
     "moduleResolution": "node",
     "resolveJsonModule": true,
     "skipLibCheck": true,
     "strict": true,
     "target": "es2020",
     "types": ["svelte"]
-  },
-  "include": ["tests/*"]
+  }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -179,6 +179,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-17.0.21.tgz#864b987c0c68d07b4345845c3e63b75edd143644"
   integrity sha512-DBZCJbhII3r90XbQxI8Y9IjjiiOGlZ0Hr32omXIZvwwZ7p4DMMXGrKXVyPfuoBOri9XNtL0UK69jYIBIsRX3QQ==
 
+"@types/prettier@^2.4.4":
+  version "2.4.4"
+  resolved "https://registry.yarnpkg.com/@types/prettier/-/prettier-2.4.4.tgz#5d9b63132df54d8909fce1c3f8ca260fdd693e17"
+  integrity sha512-ReVR2rLTV1kvtlWFyuot+d1pkpG2Fw/XKE3PDAdj57rbM97ttSp9JZ2UsP+2EHTylra9cUf6JA7tGwW1INzUrA==
+
 "@types/pug@^2.0.4":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/pug/-/pug-2.0.6.tgz#f830323c88172e66826d0bde413498b61054b5a6"


### PR DESCRIPTION
This PR adjusts the tsconfig.json to check JS files and adds JSDocs types based on TS errors.

It also uses [type-only imports](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-8.html#type-only-imports-and-export) in the Svelte component type definitions.