### PR TITLE
fix(highlight-auto): use default highlight.js library for `HighlightAuto`

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,9 +120,7 @@ The `HighlightAuto` component invokes the `highlightAuto` API from `highlight.js
   import { HighlightAuto } from "svelte-highlight";
   import github from "svelte-highlight/src/styles/github";
 
-  $: code = `<style>
-  .body { margin: 0; padding: 0; }
-<\/style>`;
+  $: code = `body {\n  padding: 0;\n  color: red;\n}`;
 </script>
 
 <svelte:head>

--- a/demo/routes/index.svelte
+++ b/demo/routes/index.svelte
@@ -267,7 +267,7 @@
       code={`<script>
   import { HighlightAuto } from "svelte-highlight";
 
-   $: code = \`.body { padding: 0; margin: 0; }\`;
+   $: code = \`body {\n  padding: 0;\n  color: red;\n}\`;
 <\/script>
 
 <HighlightAuto {code} langtag="{true}" \/>`}

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -12,7 +12,7 @@
    */
   export let langtag = false;
 
-  import hljs from "highlight.js/lib/core";
+  import hljs from "highlight.js";
   import { createEventDispatcher, afterUpdate } from "svelte";
 
   const dispatch = createEventDispatcher();

--- a/tests/SvelteHighlight.test.svelte
+++ b/tests/SvelteHighlight.test.svelte
@@ -27,6 +27,12 @@
   langtag={true}
 />
 
+<HighlightAuto
+  id="highlight-auto-css"
+  code={`body {\n  padding: 0;\n  color: red;\n}`}
+  langtag={true}
+/>
+
 <Highlight
   language={toggled ? javascript : typescript}
   {code}

--- a/tests/SvelteHighlight.test.ts
+++ b/tests/SvelteHighlight.test.ts
@@ -37,7 +37,7 @@ describe("SvelteHighlight", () => {
     expect(
       target.querySelector("#highlight-auto")?.innerHTML
     ).toMatchInlineSnapshot(
-      '"<code class=\\"hljs\\">const add = (a: number, b: number) =&gt; a + b;</code>"'
+      '"<code class=\\"hljs\\">const add = <span class=\\"hljs-function\\">(<span class=\\"hljs-params\\">a: <span class=\\"hljs-built_in\\">number</span>, b: <span class=\\"hljs-built_in\\">number</span></span>) =&gt;</span> a + b;</code>"'
     );
 
     userEvent.click(target.querySelector("button")!);
@@ -46,7 +46,7 @@ describe("SvelteHighlight", () => {
     expect(
       target.querySelector("#highlight-auto")?.innerHTML
     ).toMatchInlineSnapshot(
-      '"<code class=\\"hljs\\"><span class=\\"hljs-tag\\">&lt;<span class=\\"hljs-name\\">button</span> <span class=\\"hljs-attr\\">on:click</span>&gt;</span>Click me<span class=\\"hljs-tag\\">&lt;/<span class=\\"hljs-name\\">button</span>&gt;</span></code>"'
+      '"<code class=\\"hljs\\">&lt;<span class=\\"hljs-keyword\\">button</span> <span class=\\"hljs-keyword\\">on</span>:click&gt;Click me&lt;/<span class=\\"hljs-keyword\\">button</span>&gt;</code>"'
     );
   });
 });

--- a/tests/SvelteHighlight.test.ts
+++ b/tests/SvelteHighlight.test.ts
@@ -40,6 +40,15 @@ describe("SvelteHighlight", () => {
       '"<code class=\\"hljs\\">const add = <span class=\\"hljs-function\\">(<span class=\\"hljs-params\\">a: <span class=\\"hljs-built_in\\">number</span>, b: <span class=\\"hljs-built_in\\">number</span></span>) =&gt;</span> a + b;</code>"'
     );
 
+    expect(
+      target.querySelector("#highlight-auto-css")?.outerHTML
+    ).toMatchInlineSnapshot(`
+      "<pre data-language=\\"css\\" id=\\"highlight-auto-css\\" class=\\"langtag svelte-1xjucv4\\"><code class=\\"hljs\\"><span class=\\"hljs-selector-tag\\">body</span> {
+        <span class=\\"hljs-attribute\\">padding</span>: <span class=\\"hljs-number\\">0</span>;
+        <span class=\\"hljs-attribute\\">color</span>: red;
+      }</code></pre>"
+    `);
+
     userEvent.click(target.querySelector("button")!);
     await tick();
 


### PR DESCRIPTION
Fixes https://github.com/metonym/svelte-highlight/issues/197

```diff
- import hljs from "highlight.js/lib/core";
+ import hljs from "highlight.js";
```