### PR TITLE
test: resolve TS errors in test files

### DIFF
--- a/tests/SvelteHighlight.test.ts
+++ b/tests/SvelteHighlight.test.ts
@@ -1,6 +1,5 @@
 import { test, expect, describe, afterEach } from "vitest";
 import userEvent from "@testing-library/user-event";
-import { tick } from "svelte";
 import SvelteHighlight from "./SvelteHighlight.test.svelte";
 
 describe("SvelteHighlight", () => {
@@ -49,7 +48,6 @@ describe("SvelteHighlight", () => {
       `);
 
     await userEvent.click(target.querySelector("button")!);
-    await tick();
 
     expect(
       target.querySelector("#highlight-auto")?.innerHTML

--- a/tests/index.test.ts
+++ b/tests/index.test.ts
@@ -1,6 +1,6 @@
 import { test, expect } from "vitest";
 import * as API from "../src";
-import pkg from "../package.json";
+import * as pkg from "../package.json";
 
 test("Library dependencies", () => {
   expect(Object.keys(pkg.dependencies)).toMatchInlineSnapshot(`

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -4,7 +4,6 @@ import * as languages from "../src/languages";
 test("Languages", () => {
   const languageNames = Object.keys(languages);
 
-  // @ts-expect-error
   expect(languages.default).toBeUndefined();
   expect(languageNames.length).toMatchInlineSnapshot("192");
   expect(languageNames).toMatchInlineSnapshot(`

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -4,7 +4,6 @@ import * as styles from "../src/styles";
 test("Styles", () => {
   const styleNames = Object.keys(styles);
 
-  // @ts-expect-error
   expect(styles.default).toBeUndefined();
   expect(styleNames.length).toMatchInlineSnapshot("246");
   expect(styleNames).toMatchInlineSnapshot(`

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,10 +1,4 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
-  "include": [
-    "src/**/*.svelte",
-    "src/**/*.ts",
-    "demo/**/*.js",
-    "demo/**/*.svelte",
-    "tests/*.svelte"
-  ]
+  "include": ["src/**/*", "demo/**/*", "tests/**/*"]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,4 +1,7 @@
 {
   "extends": "./.svelte-kit/tsconfig.json",
+  "compilerOptions": {
+    "resolveJsonModule": true
+  },
   "include": ["src/**/*", "demo/**/*", "tests/**/*"]
 }


### PR DESCRIPTION
The updates `tsconfig.json` to:

- omit specific extensions in `tsconfig.json#include` to resolve type error for ".svelte" files and remove "unused `@ts-expect-error` directive" warnings
- remove useless `tick` usage since `@testing-library/user-event` is awaited
- enable `resolveJsonModules` to resolve type error when importing `package.json`
- remove unused 