### PR TITLE
fix!: mark `code`, `language` props as required

### DIFF
--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -34,7 +34,7 @@
     /**
      * Specify the source code to highlight.
      */
-    code?: any;
+    code: any;
 
     /**
      * Provide the language grammar used to highlight the code.
@@ -42,7 +42,7 @@
      * @example
      * import typescript from "svelte-highlight/languages/typescript";
      */
-    language?: Language;
+    language: Language;
 
     /**
      * Set to `true` for the language name to be
@@ -77,12 +77,9 @@
 
   interface $$Events extends Events {}
 
-  export let language: Language = {
-    name: undefined,
-    register: undefined,
-  };
+  export let language: Language;
 
-  export let code = undefined;
+  export let code: any;
 
   export let langtag = false;
 

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -9,7 +9,7 @@
     /**
      * Specify the source code to highlight.
      */
-    code?: any;
+    code: any;
 
     /**
      * Set to `true` for the language name to be
@@ -44,7 +44,7 @@
 
   interface $$Events extends Events {}
 
-  export let code = undefined;
+  export let code;
 
   export let langtag = false;
 
@@ -60,9 +60,7 @@
     if (highlighted) dispatch("highlight", { highlighted });
   });
 
-  $: if (code) {
-    ({ value: highlighted, language } = hljs.highlightAuto(code));
-  }
+  $: ({ value: highlighted, language } = hljs.highlightAuto(code));
 </script>
 
 <slot {highlighted}>

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -9,7 +9,7 @@
     /**
      * Specify the source code to highlight.
      */
-    code?: any;
+    code: any;
 
     /**
      * Set to `true` for the language name to be
@@ -44,7 +44,7 @@
 
   interface $$Events extends Events {}
 
-  export let code = undefined;
+  export let code;
 
   export let langtag = false;
 

--- a/tests/SvelteHighlight.test.svelte
+++ b/tests/SvelteHighlight.test.svelte
@@ -55,7 +55,17 @@
 
 <HighlightSvelte id="langtag" code={codeSvelte} langtag={true} on:highlight />
 
-<Highlight2 code="123" />
+<Highlight2
+  code="123"
+  language={{
+    name: "custom-lang",
+    register: (hljs) => {
+      return {
+        contains: [],
+      };
+    },
+  }}
+/>
 
 <div id="highlighted">{highlighted}</div>
 


### PR DESCRIPTION
Closes #215

This is technically a breaking change so the major version should be incremented.

This changes the semantics of how `code` and `language` props are typed. Both should be required. To do this in Svelte, the props should not be assigned a default value.