### PR TITLE
feat(deps): upgrade highlight.js 11.6.0 -> 11.7.0

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 192 languages exported from highlight.js@11.6.0
+> 192 languages exported from highlight.js@11.7.0
 
 ## 1c (`_1c`)
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 248 styles exported from highlight.js@11.6.0
+> 248 styles exported from highlight.js@11.7.0
 
 ## 3024 (`_3024`)
 

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "format": "prettier --ignore-path .gitignore --write ."
   },
   "dependencies": {
-    "highlight.js": "11.6.0"
+    "highlight.js": "11.7.0"
   },
   "devDependencies": {
     "@sveltejs/adapter-static": "1.0.0-next.48",

--- a/yarn.lock
+++ b/yarn.lock
@@ -826,10 +826,10 @@ has@^1.0.3:
   dependencies:
     function-bind "^1.1.1"
 
-highlight.js@11.6.0:
-  version "11.6.0"
-  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.6.0.tgz#a50e9da05763f1bb0c1322c8f4f755242cff3f5a"
-  integrity sha512-ig1eqDzJaB0pqEvlPVIpSSyMaO92bH1N2rJpLMN/nX396wTpDA4Eq0uK+7I/2XG17pFaaKE0kjV/XPeGt7Evjw==
+highlight.js@11.7.0:
+  version "11.7.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-11.7.0.tgz#3ff0165bc843f8c9bce1fd89e2fda9143d24b11e"
+  integrity sha512-1rRqesRFhMO/PRF+G86evnyJkCgaZFOI+Z6kdj15TA18funfoqJXvgPCLSf0SWq3SRfg1j3HlDs8o4s3EGq1oQ==
 
 html-encoding-sniffer@^3.0.0:
   version "3.0.0"


### PR DESCRIPTION
- upgrade `highlight.js` to version [11.7.0](https://github.com/highlightjs/highlight.js/releases/tag/11.7.0)