### PR TITLE
docs: improve docs, use path aliases

### DIFF
--- a/README.md
+++ b/README.md
@@ -147,9 +147,8 @@ Use the `HighlightSvelte` component for Svelte syntax highlighting.
 
 The `HighlightAuto` component uses [highlightAuto](https://highlightjs.readthedocs.io/en/latest/api.html#highlightauto) API.
 
-**Note:** auto-highlighting will result in a larger bundle size in order to infer a language.
-
-Prefer to specify a language if possible.
+> **Warning**
+> Auto-highlighting will result in a larger bundle size. Specify a language if possible.
 
 ```svelte
 <script>

--- a/README.md
+++ b/README.md
@@ -247,7 +247,7 @@ See the [Languages page](SUPPORTED_LANGUAGES.md) for a list of supported languag
 
 All `Highlight` components allow for a tag to be added at the top-right of the codeblock displaying the language name.
 
-The language tag can be given a custom `background` , `color` , and `border-radius` through CSS custom properties.
+Customize the language tag `background`, `color`, and `border-radius` using style props.
 
 It is recommended that you set values for `--hljs-background` and `--hljs-foreground` to ensure the langtags are readable with your theme.
 

--- a/demo/lib/LineNumbers/Basic.svelte
+++ b/demo/lib/LineNumbers/Basic.svelte
@@ -2,9 +2,8 @@
   // @ts-check
   export let snippet = "<LineNumbers {highlighted} />";
 
-  import { HighlightSvelte } from "../../../src";
-  import LineNumbers from "../../../src/LineNumbers.svelte";
-  import atomOneDark from "../../../src/styles/atom-one-dark";
+  import { HighlightSvelte, LineNumbers } from "svelte-highlight";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
 
   const code = `<script>
   import Hightlight, { LineNumbers } from "svelte-highlight";

--- a/demo/lib/ScopedStyle.svelte
+++ b/demo/lib/ScopedStyle.svelte
@@ -5,8 +5,8 @@
   export let useInjectedStyles = true;
   export let useCdnImport = false;
 
-  import HighlightSvelte from "../../src/HighlightSvelte.svelte";
-  import * as styles from "../../src/styles";
+  import HighlightSvelte from "svelte-highlight/HighlightSvelte.svelte";
+  import * as styles from "svelte-highlight/styles";
 
   $: importStyles = useInjectedStyles
     ? `import ${moduleName} from "svelte-highlight/styles/${name}";`

--- a/demo/lib/ScopedStyleAuto.svelte
+++ b/demo/lib/ScopedStyleAuto.svelte
@@ -3,8 +3,8 @@
   export let name = "";
   export let moduleName = "";
 
-  import HighlightAuto from "../../src/HighlightAuto.svelte";
-  import * as styles from "../../src/styles";
+  import HighlightAuto from "svelte-highlight/HighlightAuto.svelte";
+  import * as styles from "svelte-highlight/styles";
 
   $: code = `<script>
   import { HighlightAuto } from "svelte-highlight";

--- a/demo/lib/ScopedStyleSvelte.svelte
+++ b/demo/lib/ScopedStyleSvelte.svelte
@@ -3,8 +3,8 @@
   export let name = "";
   export let moduleName = "";
 
-  import HighlightSvelte from "../../src/HighlightSvelte.svelte";
-  import * as styles from "../../src/styles";
+  import HighlightSvelte from "svelte-highlight/HighlightSvelte.svelte";
+  import * as styles from "svelte-highlight/styles";
 
   $: code = `<script>
   import { HighlightSvelte } from "svelte-highlight";

--- a/demo/routes/+layout.svelte
+++ b/demo/routes/+layout.svelte
@@ -17,7 +17,7 @@
   import { LogoGithub } from "carbon-icons-svelte";
   import { page } from "$app/stores";
   import { base } from "$app/paths";
-  import Footer from "../lib/Footer.svelte";
+  import Footer from "lib/Footer.svelte";
 
   const routes = {
     "/": "Svelte Highlight",

--- a/demo/routes/+page.svelte
+++ b/demo/routes/+page.svelte
@@ -2,6 +2,7 @@
   /** @type {import('./$types').PageData} */
   export const data = null;
 
+  import { base } from "$app/paths";
   import {
     Tabs,
     Tab,
@@ -12,17 +13,15 @@
     UnorderedList,
     ListItem,
   } from "carbon-components-svelte";
-  import ScopedStyle from "../lib/ScopedStyle.svelte";
-  import CodeSnippet from "../lib/CodeSnippet.svelte";
-  import { base } from "$app/paths";
-  import ScopedStyleSvelte from "../lib/ScopedStyleSvelte.svelte";
-  import ScopedStyleAuto from "../lib/ScopedStyleAuto.svelte";
-  import HighlightSvelte from "../../src/HighlightSvelte.svelte";
-  import HighlightAuto from "../../src/HighlightAuto.svelte";
-  import Basic from "../lib/LineNumbers/Basic.svelte";
-  import HideBorder from "../lib/LineNumbers/HideBorder.svelte";
-  import WrapLines from "../lib/LineNumbers/WrapLines.svelte";
-  import StyleProps from "../lib/LineNumbers/StyleProps.svelte";
+  import { HighlightSvelte, HighlightAuto } from "svelte-highlight";
+  import ScopedStyle from "lib/ScopedStyle.svelte";
+  import CodeSnippet from "lib/CodeSnippet.svelte";
+  import ScopedStyleSvelte from "lib/ScopedStyleSvelte.svelte";
+  import ScopedStyleAuto from "lib/ScopedStyleAuto.svelte";
+  import Basic from "lib/LineNumbers/Basic.svelte";
+  import HideBorder from "lib/LineNumbers/HideBorder.svelte";
+  import WrapLines from "lib/LineNumbers/WrapLines.svelte";
+  import StyleProps from "lib/LineNumbers/StyleProps.svelte";
 
   const NAME = process.env.NAME;
 

--- a/demo/routes/+page.svelte
+++ b/demo/routes/+page.svelte
@@ -12,6 +12,7 @@
     Link,
     UnorderedList,
     ListItem,
+    InlineNotification,
   } from "carbon-components-svelte";
   import { HighlightSvelte, HighlightAuto } from "svelte-highlight";
   import ScopedStyle from "lib/ScopedStyle.svelte";
@@ -211,10 +212,13 @@
       <code class="code">highlightAuto</code>
       API from <code class="code">highlight.js</code>.
     </p>
-    <p>
-      Note that auto-highlighting will result in a larger bundle size in order
-      to infer a language. Prefer to specify a language if possible.
-    </p>
+    <InlineNotification
+      lowContrast
+      hideCloseButton
+      kind="warning"
+      title="Note:"
+      subtitle="Auto-highlighting will result in a larger bundle size. Specify a language if possible."
+    />
   </Column>
   <Column xlg={12}>
     <ScopedStyleAuto name="atom-one-dark" moduleName="atomOneDark" />

--- a/demo/routes/+page.svelte
+++ b/demo/routes/+page.svelte
@@ -135,7 +135,7 @@
       </ListItem>
     </UnorderedList>
     <p class="mb-5">
-      Languages can be found in <code class="code"
+      Import languages from <code class="code"
         >"svelte-highlight/src/languages"</code
       >.
     </p>
@@ -149,8 +149,7 @@
   </Column>
   <Column xlg={9} lg={12}>
     <p class="mb-5">
-      Styles can be imported from <code class="code"
-        >"svelte-highlight/src/styles"</code
+      Import styles from <code class="code">"svelte-highlight/src/styles"</code
       >.
     </p>
     <p class="mb-5">There are two ways to add styles:</p>
@@ -310,9 +309,9 @@
       at the top-right of the codeblock displaying the language name.
     </p>
     <p class="mb-5">
-      The language tag can be given a custom <code class="code">background</code
-      >, <code class="code">color</code>, and
-      <code class="code">border-radius</code> through the custom properties shown.
+      Customize the language tag <code class="code">background</code>,
+      <code class="code">color</code>, and
+      <code class="code">border-radius</code> using style props.
     </p>
     <p class="mb-5">This is also compatible with custom languages.</p>
     <p class="mb-5">

--- a/demo/routes/languages/+page.svelte
+++ b/demo/routes/languages/+page.svelte
@@ -9,11 +9,11 @@
     StructuredListCell,
     StructuredListBody,
   } from "carbon-components-svelte";
-  import HighlightSvelte from "../../../src/HighlightSvelte.svelte";
-  import atomOneDark from "../../../src/styles/atom-one-dark";
-  import ListSearch from "../../lib/ListSearch.svelte";
-  import CodeSnippet from "../../lib/CodeSnippet.svelte";
-  import languages from "../../lib/languages.json";
+  import HighlightSvelte from "svelte-highlight/HighlightSvelte.svelte";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+  import ListSearch from "lib/ListSearch.svelte";
+  import CodeSnippet from "lib/CodeSnippet.svelte";
+  import languages from "lib/languages.json";
 
   function formatCode(name, moduleName, useDirectImport) {
     return `<script>

--- a/demo/routes/styles/+page.svelte
+++ b/demo/routes/styles/+page.svelte
@@ -10,10 +10,10 @@
     StructuredListBody,
     Toggle,
   } from "carbon-components-svelte";
-  import ScopedStyle from "../../lib/ScopedStyle.svelte";
-  import CodeSnippet from "../../lib/CodeSnippet.svelte";
-  import ListSearch from "../../lib/ListSearch.svelte";
-  import styles from "../../lib/styles.json";
+  import ScopedStyle from "lib/ScopedStyle.svelte";
+  import CodeSnippet from "lib/CodeSnippet.svelte";
+  import ListSearch from "lib/ListSearch.svelte";
+  import styles from "lib/styles.json";
 
   let useCdnImport = false;
 </script>

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -85,11 +85,12 @@
 </script>
 
 <slot {highlighted}>
-  <!-- prettier-ignore -->
   <pre
     class:langtag
     data-language={language.name || "plaintext"}
-    {...$$restProps}><code class="hljs">{#if highlighted !== undefined}{@html highlighted}{:else}{code}{/if}</code></pre>
+    {...$$restProps}><code class="hljs"
+      >{#if highlighted !== undefined}{@html highlighted}{:else}{code}{/if}</code
+    ></pre>
 </slot>
 
 <style>

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -49,11 +49,12 @@
 </script>
 
 <slot {highlighted}>
-  <!-- prettier-ignore -->
   <pre
     class:langtag
     data-language={language || "plaintext"}
-    {...$$restProps}><code class="hljs">{#if highlighted !== undefined}{@html highlighted}{:else}{code}{/if}</code></pre>
+    {...$$restProps}><code class="hljs"
+      >{#if highlighted !== undefined}{@html highlighted}{:else}{code}{/if}</code
+    ></pre>
 </slot>
 
 <style>

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -51,8 +51,9 @@
 </script>
 
 <slot {highlighted}>
-  <!-- prettier-ignore -->
-  <pre class:langtag data-language="svelte" {...$$restProps}><code class="hljs">{@html highlighted}</code></pre>
+  <pre class:langtag data-language="svelte" {...$$restProps}><code class="hljs"
+      >{@html highlighted}</code
+    ></pre>
 </slot>
 
 <style>

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,4 +2,3 @@ export { default as default, default as Highlight } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
-

--- a/tests/SvelteHighlight.test.ts
+++ b/tests/SvelteHighlight.test.ts
@@ -56,9 +56,8 @@ describe("SvelteHighlight", () => {
       '"<code class=\\"hljs\\">&lt;<span class=\\"hljs-keyword\\">button</span> <span class=\\"hljs-keyword\\">on</span>:click&gt;Click me&lt;/<span class=\\"hljs-keyword\\">button</span>&gt;</code>"'
     );
 
-    expect(
-      target.querySelector("#line-numbers")?.innerHTML
-    ).toMatchInlineSnapshot(`
+    expect(target.querySelector("#line-numbers")?.innerHTML)
+      .toMatchInlineSnapshot(`
       "<div style=\\"overflow-x: auto;\\" class=\\"svelte-1gt16c9\\"><table style=\\"width: 100%;\\"><tbody class=\\"hljs\\"><tr><td class=\\"svelte-1gt16c9 hljs\\" style=\\"position: sticky; left: 0px; text-align: right; user-select: none; padding-top: 1em; padding-bottom: 1em; width: 54px; min-width: 54px;\\"><code>1</code></td> <td class=\\"svelte-1gt16c9\\"><pre class=\\"svelte-1gt16c9\\"><code>
       </code></pre></td> </tr></tbody></table></div>"
     `);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,7 +2,15 @@
   "extends": "./.svelte-kit/tsconfig.json",
   "compilerOptions": {
     "allowSyntheticDefaultImports": true,
-    "resolveJsonModule": true
+    "resolveJsonModule": true,
+    "paths": {
+      "$lib": ["src"],
+      "$lib/*": ["src/*"],
+      "lib": ["demo/lib"],
+      "lib/*": ["demo/lib/*"],
+      "svelte-highlight": ["src"],
+      "svelte-highlight/*": ["src/*"]
+    }
   },
   "include": ["src/**/*", "demo/**/*", "tests/**/*"]
 }

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,5 +1,6 @@
 import { sveltekit } from "@sveltejs/kit/vite";
 import { svelte } from "@sveltejs/vite-plugin-svelte";
+import path from "path";
 
 const TEST = process.env.VITEST;
 
@@ -8,6 +9,12 @@ export default {
   plugins: [TEST ? svelte({ hot: false }) : sveltekit()],
   optimizeDeps: {
     exclude: ["carbon-components-svelte", "carbon-icons-svelte"],
+  },
+  resolve: {
+    alias: {
+      lib: path.resolve("demo/lib"),
+      "svelte-highlight": path.resolve("src"),
+    },
   },
   server: {
     fs: {


### PR DESCRIPTION
**Refactoring**

- remove `prettier-ignore` comment since `prettier-plugin-svelte` correctly formats `pre` tags

**Docs**

- use path aliases
- use the active voice where possible
- use warn notification for auto-highlighting note