### PR TITLE
feat(highlight-auto): include `language` in "on:highlight" event detail

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,11 @@ In the example below, the `HighlightAuto` component and injected styles are dyna
   language={typescript}
   {code}
   on:highlight={(e) => {
-    console.log(e.detail.highlighted); // "<span>...</span>"
+    /**
+     * The highlighted HTML as a string.
+     * @example "<span>...</span>"
+     */
+    console.log(e.detail.highlighted);
   }}
 />
 ```
@@ -391,7 +395,11 @@ In the example below, the `HighlightAuto` component and injected styles are dyna
 <HighlightSvelte
   {code}
   on:highlight={(e) => {
-    console.log(e.detail.highlighted); // "<span>...</span>"
+    /**
+     * The highlighted HTML as a string.
+     * @example "<span>...</span>"
+     */
+    console.log(e.detail.highlighted);
   }}
 />
 ```
@@ -415,7 +423,17 @@ In the example below, the `HighlightAuto` component and injected styles are dyna
 <HighlightAuto
   {code}
   on:highlight={(e) => {
-    console.log(e.detail.highlighted); // "<span>...</span>"
+    /**
+     * The highlighted HTML as a string.
+     * @example "<span>...</span>"
+     */
+    console.log(e.detail.highlighted);
+
+    /**
+     * The inferred language name
+     * @example "css"
+     */
+    console.log(e.detail.language);
   }}
 />
 ```

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -1,8 +1,6 @@
 <script context="module" lang="ts">
   import type { LanguageFn } from "highlight.js";
 
-  export type HighlightedCode = undefined | string;
-
   export interface Language {
     name?: string;
     register: LanguageFn;
@@ -11,18 +9,20 @@
   export interface Slots {
     default: {
       /**
-       * The highlighted code.
+       * The highlighted HTML as a string.
+       * @example "<span>...</span>"
        */
-      highlighted: HighlightedCode;
+      highlighted: string;
     };
   }
 
   export interface Events {
     highlight: CustomEvent<{
       /**
-       * The highlighted code.
+       * The highlighted HTML as a string.
+       * @example "<span>...</span>"
        */
-      highlighted?: HighlightedCode;
+      highlighted: string;
     }>;
   }
 </script>
@@ -88,7 +88,7 @@
 
   const dispatch = createEventDispatcher();
 
-  let highlighted: HighlightedCode = undefined;
+  let highlighted = "";
 
   afterUpdate(() => {
     if (highlighted) dispatch("highlight", { highlighted });

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-  import type { HighlightedCode, Slots } from "./Highlight.svelte";
+  import type { Slots } from "./Highlight.svelte";
 </script>
 
 <script lang="ts">
@@ -45,13 +45,14 @@
   interface $$Events {
     highlight: CustomEvent<{
       /**
-       * The highlighted code.
+       * The highlighted HTML as a string.
+       * @example "<span>...</span>"
        */
-      highlighted?: HighlightedCode;
+      highlighted: string;
 
       /**
        * The inferred language name.
-       * @example "xml"
+       * @example "css"
        */
       language?: string;
     }>;
@@ -66,7 +67,7 @@
 
   const dispatch = createEventDispatcher();
 
-  let highlighted: HighlightedCode = undefined;
+  let highlighted = "";
   let language = undefined;
 
   afterUpdate(() => {

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -1,5 +1,5 @@
 <script context="module" lang="ts">
-  import type { HighlightedCode, Slots, Events } from "./Highlight.svelte";
+  import type { HighlightedCode, Slots } from "./Highlight.svelte";
 </script>
 
 <script lang="ts">
@@ -42,7 +42,20 @@
 
   interface $$Slots extends Slots {}
 
-  interface $$Events extends Events {}
+  interface $$Events {
+    highlight: CustomEvent<{
+      /**
+       * The highlighted code.
+       */
+      highlighted?: HighlightedCode;
+
+      /**
+       * The inferred language name.
+       * @example "xml"
+       */
+      language?: string;
+    }>;
+  }
 
   export let code;
 
@@ -57,7 +70,7 @@
   let language = undefined;
 
   afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted });
+    if (highlighted) dispatch("highlight", { highlighted, language });
   });
 
   $: ({ value: highlighted, language } = hljs.highlightAuto(code));

--- a/tests/SvelteHighlight.test.svelte
+++ b/tests/SvelteHighlight.test.svelte
@@ -12,6 +12,7 @@
 
   let toggled = true;
   let highlighted = "";
+  let language = "";
 
   $: code = "const add = (a: number, b: number) => a + b;";
   $: codeSvelte = "<button on:click>Click me</button>";
@@ -39,7 +40,12 @@
   id="highlight-auto-css"
   code={`body {\n  padding: 0;\n  color: red;\n}`}
   langtag={true}
+  on:highlight={(e) => {
+    language = e.detail.language;
+  }}
 />
+
+<div id="inferred-language">{language}</div>
 
 <Highlight
   language={toggled ? javascript : typescript}

--- a/tests/SvelteHighlight.test.ts
+++ b/tests/SvelteHighlight.test.ts
@@ -47,6 +47,9 @@ describe("SvelteHighlight", () => {
           <span class=\\"hljs-attribute\\">color</span>: red;
         }</code></pre>"
       `);
+    expect(target.querySelector("#inferred-language")?.innerHTML).toEqual(
+      "css"
+    );
 
     await userEvent.click(target.querySelector("button")!);
 


### PR DESCRIPTION
**Features**

- include the inferred `language` name in `on:highlight` event detail

**Fixes**

- `e.detail.highlighted` is a string

```svelte
<HighlightAuto
  code={`body {\n  padding: 0;\n  color: red;\n}`}
  on:highlight={(e) => {
    console.log(e.detail.language); // "css"
  }}
/>
```