### PR TITLE
refactor: extract lang tag into an internal component

### DIFF
--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -1,90 +1,23 @@
 <script context="module" lang="ts">
-  import type { LanguageFn } from "highlight.js";
-
-  export interface Language {
-    name?: string;
-    register: LanguageFn;
-  }
-
-  export interface Slots {
-    default: {
-      /**
-       * The highlighted HTML as a string.
-       * @example "<span>...</span>"
-       */
-      highlighted: string;
-    };
-  }
-
-  export interface Events {
-    highlight: CustomEvent<{
-      /**
-       * The highlighted HTML as a string.
-       * @example "<span>...</span>"
-       */
-      highlighted: string;
-    }>;
-  }
+  import type { Props, Slots, Events } from "./shared";
 </script>
 
 <script lang="ts">
-  import type { HTMLAttributes } from "svelte/elements";
-
-  interface $$Props extends HTMLAttributes<HTMLPreElement> {
-    /**
-     * Specify the source code to highlight.
-     */
-    code: any;
-
-    /**
-     * Provide the language grammar used to highlight the code.
-     * Import languages from `svelte-highlight/languages/*`.
-     * @example
-     * import typescript from "svelte-highlight/languages/typescript";
-     */
-    language: Language;
-
-    /**
-     * Set to `true` for the language name to be
-     * displayed at the top right of the code block.
-     *
-     * Use style props to customize styles:
-     * - `--langtag-background`
-     * - `--langtag-color`
-     * - `--langtag-border-radius`
-     *
-     * @default false
-     */
-    langtag?: boolean;
-
-    /**
-     * Customize the background color of the langtag.
-     */
-    "--langtag-background"?: string;
-
-    /**
-     * Customize the text color of the langtag.
-     */
-    "--langtag-color"?: string;
-
-    /**
-     * Customize the border radius of the langtag.
-     */
-    "--langtag-border-radius"?: string;
-  }
+  interface $$Props extends Props {}
 
   interface $$Slots extends Slots {}
 
   interface $$Events extends Events {}
 
-  export let language: Language;
+  export let language: $$Props["language"];
 
-  export let code: any;
+  export let code: $$Props["code"];
 
   export let langtag = false;
 
   import hljs from "highlight.js/lib/core";
   import { createEventDispatcher, afterUpdate } from "svelte";
+  import LangTag from "./LangTag.svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -101,32 +34,11 @@
 </script>
 
 <slot {highlighted}>
-  <pre
-    class:langtag
-    data-language={language.name || "plaintext"}
-    {...$$restProps}><code class="hljs"
-      >{#if highlighted !== undefined}{@html highlighted}{:else}{code}{/if}</code
-    ></pre>
+  <LangTag
+    {...$$restProps}
+    languageName={language.name}
+    {langtag}
+    {highlighted}
+    {code}
+  />
 </slot>
-
-<style>
-  .langtag {
-    position: relative;
-  }
-
-  .langtag::after {
-    content: attr(data-language);
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding: 1em;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: inherit;
-    color: inherit;
-    background: var(--langtag-background);
-    color: var(--langtag-color);
-    border-radius: var(--langtag-border-radius);
-  }
-</style>

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -1,64 +1,26 @@
 <script context="module" lang="ts">
-  import type { Slots } from "./Highlight.svelte";
+  import type { Props, Slots, Events, HighlightedCode } from "./shared";
 </script>
 
 <script lang="ts">
-  import type { HTMLAttributes } from "svelte/elements";
+  import LangTag from "./LangTag.svelte";
 
-  interface $$Props extends HTMLAttributes<HTMLPreElement> {
-    /**
-     * Specify the source code to highlight.
-     */
-    code: any;
-
-    /**
-     * Set to `true` for the language name to be
-     * displayed at the top right of the code block.
-     *
-     * Use style props to customize styles:
-     * - `--langtag-background`
-     * - `--langtag-color`
-     * - `--langtag-border-radius`
-     *
-     * @default false
-     */
-    langtag?: boolean;
-
-    /**
-     * Customize the background color of the langtag.
-     */
-    "--langtag-background"?: string;
-
-    /**
-     * Customize the text color of the langtag.
-     */
-    "--langtag-color"?: string;
-
-    /**
-     * Customize the border radius of the langtag.
-     */
-    "--langtag-border-radius"?: string;
-  }
+  interface $$Props extends Omit<Props, "language"> {}
 
   interface $$Slots extends Slots {}
 
-  interface $$Events {
-    highlight: CustomEvent<{
-      /**
-       * The highlighted HTML as a string.
-       * @example "<span>...</span>"
-       */
-      highlighted: string;
+  interface $$Events
+    extends Events<
+      HighlightedCode & {
+        /**
+         * The inferred language name.
+         * @example "css"
+         */
+        language?: string;
+      }
+    > {}
 
-      /**
-       * The inferred language name.
-       * @example "css"
-       */
-      language?: string;
-    }>;
-  }
-
-  export let code;
+  export let code: $$Props["code"];
 
   export let langtag = false;
 
@@ -78,32 +40,11 @@
 </script>
 
 <slot {highlighted}>
-  <pre
-    class:langtag
-    data-language={language || "plaintext"}
-    {...$$restProps}><code class="hljs"
-      >{#if highlighted !== undefined}{@html highlighted}{:else}{code}{/if}</code
-    ></pre>
+  <LangTag
+    {...$$restProps}
+    languageName={language}
+    {langtag}
+    {highlighted}
+    {code}
+  />
 </slot>
-
-<style>
-  .langtag {
-    position: relative;
-  }
-
-  .langtag::after {
-    content: attr(data-language);
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding: 1em;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: inherit;
-    color: inherit;
-    background: var(--langtag-background);
-    color: var(--langtag-color);
-    border-radius: var(--langtag-border-radius);
-  }
-</style>

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -1,50 +1,17 @@
 <script context="module" lang="ts">
-  import type { Slots, Events } from "./Highlight.svelte";
+  import type { Props, Slots, Events } from "./shared";
 </script>
 
 <script lang="ts">
-  import type { HTMLAttributes } from "svelte/elements";
+  import LangTag from "./LangTag.svelte";
 
-  interface $$Props extends HTMLAttributes<HTMLPreElement> {
-    /**
-     * Specify the source code to highlight.
-     */
-    code: any;
-
-    /**
-     * Set to `true` for the language name to be
-     * displayed at the top right of the code block.
-     *
-     * Use style props to customize styles:
-     * - `--langtag-background`
-     * - `--langtag-color`
-     * - `--langtag-border-radius`
-     *
-     * @default false
-     */
-    langtag?: boolean;
-
-    /**
-     * Customize the background color of the langtag.
-     */
-    "--langtag-background"?: string;
-
-    /**
-     * Customize the text color of the langtag.
-     */
-    "--langtag-color"?: string;
-
-    /**
-     * Customize the border radius of the langtag.
-     */
-    "--langtag-border-radius"?: string;
-  }
+  interface $$Props extends Omit<Props, "language"> {}
 
   interface $$Slots extends Slots {}
 
   interface $$Events extends Events {}
 
-  export let code;
+  export let code: $$Props["code"];
 
   export let langtag = false;
 
@@ -68,29 +35,11 @@
 </script>
 
 <slot {highlighted}>
-  <pre class:langtag data-language="svelte" {...$$restProps}><code class="hljs"
-      >{@html highlighted}</code
-    ></pre>
+  <LangTag
+    {...$$restProps}
+    languageName="svelte"
+    {langtag}
+    {highlighted}
+    {code}
+  />
 </slot>
-
-<style>
-  .langtag {
-    position: relative;
-  }
-
-  .langtag::after {
-    content: attr(data-language);
-    position: absolute;
-    top: 0;
-    right: 0;
-    padding: 1em;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: inherit;
-    color: inherit;
-    background: var(--langtag-background);
-    color: var(--langtag-color);
-    border-radius: var(--langtag-border-radius);
-  }
-</style>

--- a/src/LangTag.svelte
+++ b/src/LangTag.svelte
@@ -1,0 +1,51 @@
+<script context="module" lang="ts">
+  import type { Props } from "./shared";
+</script>
+
+<script lang="ts">
+  interface $$Props extends Omit<Props, "language"> {
+    /**
+     * Specify the highlighted code.
+     */
+    highlighted: string | undefined;
+
+    /**
+     * Specifiy the language name.
+     * @default "plaintext"
+     */
+    languageName?: string;
+  }
+
+  export let langtag = false;
+
+  export let highlighted: $$Props["highlighted"];
+
+  export let code: $$Props["code"];
+
+  export let languageName = "plaintext";
+</script>
+
+<pre class:langtag data-language={languageName} {...$$restProps}><code
+    class:hljs={true}
+    >{#if highlighted}{@html highlighted}{:else}{code}{/if}</code
+  ></pre>
+
+<style>
+  .langtag {
+    position: relative;
+  }
+
+  .langtag::after {
+    content: attr(data-language);
+    position: absolute;
+    top: 0;
+    right: 0;
+    padding: 1em;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: var(--langtag-background, inherit);
+    color: var(--langtag-color, inherit);
+    border-radius: var(--langtag-border-radius);
+  }
+</style>

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -60,7 +60,7 @@
     "--padding-right"?: number | string;
   }
 
-  export let highlighted: string;
+  export let highlighted: $$Props["highlighted"];
 
   export let hideBorder = false;
 

--- a/src/shared.d.ts
+++ b/src/shared.d.ts
@@ -1,0 +1,61 @@
+import type { HTMLAttributes } from "svelte/elements";
+import type { LanguageType } from "./languages";
+
+export interface Props extends HTMLAttributes<HTMLPreElement> {
+  /**
+   * Specify the text to highlight.
+   */
+  code: any;
+
+  /**
+   * Provide the language grammar used to highlight the code.
+   * Import languages from `svelte-highlight/languages/*`.
+   * @example
+   * import typescript from "svelte-highlight/languages/typescript";
+   */
+  language: LanguageType<string>;
+
+  /**
+   * Set to `true` for the language name to be
+   * displayed at the top right of the code block.
+   *
+   * Use style props to customize styles:
+   * - `--langtag-background`
+   * - `--langtag-color`
+   * - `--langtag-border-radius`
+   *
+   * @default false
+   */
+  langtag?: boolean;
+
+  /**
+   * Customize the background color of the langtag.
+   */
+  "--langtag-background"?: string;
+
+  /**
+   * Customize the text color of the langtag.
+   */
+  "--langtag-color"?: string;
+
+  /**
+   * Customize the border radius of the langtag.
+   */
+  "--langtag-border-radius"?: string;
+}
+
+export interface HighlightedCode {
+  /**
+   * The highlighted HTML as a string.
+   * @example "<span>...</span>"
+   */
+  highlighted: string;
+}
+
+export interface Slots {
+  default: HighlightedCode;
+}
+
+export interface Events<THighlight = HighlightedCode> {
+  highlight: CustomEvent<THighlight>;
+}

--- a/tests/SvelteHighlight.test.ts
+++ b/tests/SvelteHighlight.test.ts
@@ -42,7 +42,7 @@ describe("SvelteHighlight", () => {
 
     expect(target.querySelector("#highlight-auto-css")?.outerHTML)
       .toMatchInlineSnapshot(`
-        "<pre data-language=\\"css\\" id=\\"highlight-auto-css\\" class=\\"langtag svelte-d72vtw\\"><code class=\\"hljs\\"><span class=\\"hljs-selector-tag\\">body</span> {
+        "<pre data-language=\\"css\\" id=\\"highlight-auto-css\\" class=\\"langtag svelte-11sh29b\\"><code class=\\"hljs\\"><span class=\\"hljs-selector-tag\\">body</span> {
           <span class=\\"hljs-attribute\\">padding</span>: <span class=\\"hljs-number\\">0</span>;
           <span class=\\"hljs-attribute\\">color</span>: red;
         }</code></pre>"

--- a/tests/SvelteHighlightPackage.test.svelte
+++ b/tests/SvelteHighlightPackage.test.svelte
@@ -1,7 +1,7 @@
 <script lang="ts">
   import Highlight from "../package";
   import Highlight2 from "../package/Highlight.svelte";
-  import { LineNumbers } from "../package";
+  import { HighlightAuto, LineNumbers } from "../package";
   import { typescript } from "../package/languages";
   import typescriptDefault from "../package/languages/typescript";
   import { typescript as ts } from "../package/languages/typescript";
@@ -40,3 +40,10 @@
     --padding-right="1em"
   />
 </Highlight>
+
+<HighlightAuto
+  code=""
+  on:highlight={(e) => {
+    console.log(e.detail.language);
+  }}
+/>


### PR DESCRIPTION
Closes #261

Currently, lang tag logic is duplicated in three different files. This extracts them into an internal component to reduce duplication.

It also:

- sets "initial" as the default value for CSS variables in the `langtag::after` rule (hence the updated snapshot test)
- adds a type check for `HighlightAuto`
- reuses `Props/Slots/Events` as much as possible