### PR TITLE
refactor(highlight): remove unnecessary truthy check

### DIFF
--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -94,7 +94,7 @@
     if (highlighted) dispatch("highlight", { highlighted });
   });
 
-  $: if (language.name && language.register) {
+  $: {
     hljs.registerLanguage(language.name, language.register);
     highlighted = hljs.highlight(code, { language: language.name }).value;
   }


### PR DESCRIPTION
The `language` check can be removed since #218 marked the `language` prop as required.