### PR TITLE
feat(line-numbers): support highlighted lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,16 +208,43 @@ Set `wrapLines` to `true` to hide the border of the line numbers column.
 </Highlight>
 ```
 
+### Custom Starting Line Number
+
+The line number starts at `1`. Customize this via the `startingLineNumber` prop.
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers {highlighted} startingLineNumber={42} />
+</Highlight>
+```
+
+### Highlighted Lines
+
+Specify the lines to highlight using the `highlightedLines` prop. Indices start at zero.
+
+Use `--highlighted-background` to customize the background color of highlighted lines.
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers
+    {highlighted}
+    highlightedLines={[0, 2, 3, 14]}
+    --highlighted-background="#000"
+  />
+</Highlight>
+```
+
 ### Custom Styles
 
 Use `--style-props` to customize styles.
 
-| Style prop          | Description                                | Default value  |
-| :------------------ | :----------------------------------------- | :------------- |
-| --line-number-color | Text color of the line numbers             | `currentColor` |
-| --border-color      | Border color of the column of line numbers | `currentColor` |
-| --padding-left      | Left padding for `td` elements             | `1em`          |
-| --padding-right     | Rightt padding for `td` elements           | `1em`          |
+| Style prop               | Description                                | Default value             |
+| :----------------------- | :----------------------------------------- | :------------------------ |
+| --line-number-color      | Text color of the line numbers             | `currentColor`            |
+| --border-color           | Border color of the column of line numbers | `currentColor`            |
+| --padding-left           | Left padding for `td` elements             | `1em`                     |
+| --padding-right          | Right padding for `td` elements            | `1em`                     |
+| --highlighted-background | Background color of highlighted lines      | `rgba(254, 241, 96, 0.2)` |
 
 ```svelte
 <Highlight language={typescript} {code} let:highlighted>
@@ -227,17 +254,8 @@ Use `--style-props` to customize styles.
     --border-color="rgba(255, 255, 255, 0.2)"
     --padding-left={0}
     --padding-right="3em"
+    --highlighted-background="#000"
   />
-</Highlight>
-```
-
-### Custom Starting Line Number
-
-The line number starts at `1`. Customize this via the `startingLineNumber` prop.
-
-```svelte
-<Highlight language={typescript} {code} let:highlighted>
-  <LineNumbers {highlighted} startingLineNumber={42} />
 </Highlight>
 ```
 
@@ -378,12 +396,13 @@ In the example below, the `HighlightAuto` component and injected styles are dyna
 
 #### Props
 
-| Name               | Type      | Default value  |
-| :----------------- | :-------- | :------------- |
-| highlighted        | `string`  | N/A (required) |
-| hideBorder         | `boolean` | `false`        |
-| wrapLines          | `boolean` | `false`        |
-| startingLineNumber | `number`  | `1`            |
+| Name               | Type       | Default value  |
+| :----------------- | :--------- | :------------- |
+| highlighted        | `string`   | N/A (required) |
+| hideBorder         | `boolean`  | `false`        |
+| wrapLines          | `boolean`  | `false`        |
+| startingLineNumber | `number`   | `1`            |
+| highlightedLines   | `number[]` | `[]`           |
 
 `$$restProps` are forwarded to the top-level `div` element.
 

--- a/demo/lib/LineNumbers/HighlightedLines.svelte
+++ b/demo/lib/LineNumbers/HighlightedLines.svelte
@@ -1,0 +1,8 @@
+<script>
+  // @ts-check
+  import Basic from "./Basic.svelte";
+
+  const snippet = "<LineNumbers {highlighted} highlightedLines={[0, 2, 3, 14]} />";
+</script>
+
+<Basic {snippet} highlightedLines={[0, 2, 3, 14]} />

--- a/demo/lib/LineNumbers/HighlightedLinesCustomColor.svelte
+++ b/demo/lib/LineNumbers/HighlightedLinesCustomColor.svelte
@@ -1,0 +1,9 @@
+<script>
+  // @ts-check
+  import Basic from "./Basic.svelte";
+
+  const snippet =
+    '<LineNumbers {highlighted} highlightedLines={[1, 2]} --highlighted-background="#000" />';
+</script>
+
+<Basic {snippet} highlightedLines={[1, 2]} --highlighted-background="#000" />

--- a/demo/routes/+page.svelte
+++ b/demo/routes/+page.svelte
@@ -24,6 +24,8 @@
   import WrapLines from "lib/LineNumbers/WrapLines.svelte";
   import StyleProps from "lib/LineNumbers/StyleProps.svelte";
   import StartingLineNumber from "lib/LineNumbers/StartingLineNumber.svelte";
+  import HighlightedLines from "lib/LineNumbers/HighlightedLines.svelte";
+  import HighlightedLinesCustomColor from "lib/LineNumbers/HighlightedLinesCustomColor.svelte";
 
   const NAME = process.env.NAME;
 
@@ -237,6 +239,24 @@
   </Column>
   <Column xlg={12}>
     <StartingLineNumber />
+  </Column>
+  <Column xlg={9} lg={12}>
+    <p class="mb-5">
+      Use <code class="code">highlightedLines</code> to highlight specific lines.
+      Indices start at zero.
+    </p>
+  </Column>
+  <Column xlg={12}>
+    <HighlightedLines />
+  </Column>
+  <Column xlg={9} lg={12}>
+    <p class="mb-5">
+      Use <code class="code">--highlighted-background</code> to customize the background
+      color of highlighted lines.
+    </p>
+  </Column>
+  <Column xlg={12}>
+    <HighlightedLinesCustomColor />
   </Column>
 </Row>
 

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -86,6 +86,7 @@
 
   const DIGIT_WIDTH = 12;
   const MIN_DIGITS = 2;
+  const HIGHLIGHTED_BACKGROUND = "rgba(254, 241, 96, 0.2)";
 
   $: lines = highlighted.split("\n");
   $: len_digits = lines.length.toString().length;
@@ -114,8 +115,7 @@
             {#if highlightedLines.includes(i)}
               <div
                 class:line-background={true}
-                style:background="var(--highlighted-background, rgba(254, 241,
-                96, 0.2))"
+                style:background="var(--highlighted-background, {HIGHLIGHTED_BACKGROUND})"
               />
             {/if}
           </td>
@@ -124,8 +124,7 @@
             {#if highlightedLines.includes(i)}
               <div
                 class:line-background={true}
-                style:background="var(--highlighted-background, rgba(254, 241,
-                96, 0.2))"
+                style:background="var(--highlighted-background, {HIGHLIGHTED_BACKGROUND})"
               />
             {/if}
           </td>

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -30,6 +30,13 @@
     wrapLines?: boolean;
 
     /**
+     * Specify the line indices to highlight.
+     * @default []
+     * @example [0, 1, 9]
+     */
+    highlightedLines?: number[];
+
+    /**
      * Specify the text color for line numbers.
      * Defaults to the current theme color applied to `.hljs code`.
      * @default currentColor
@@ -58,6 +65,13 @@
      * @example 0
      */
     "--padding-right"?: number | string;
+
+    /**
+     * Specify the background color of highlighted lines.
+     * @default "rgba(254, 241, 96, 0.2)"
+     * @example "#fff"
+     */
+    "--highlighted-background"?: string;
   }
 
   export let highlighted: $$Props["highlighted"];
@@ -67,6 +81,8 @@
   export let wrapLines = false;
 
   export let startingLineNumber = 1;
+
+  export let highlightedLines = [];
 
   const DIGIT_WIDTH = 12;
   const MIN_DIGITS = 2;
@@ -95,9 +111,23 @@
             <code style:color="var(--line-number-color, currentColor)">
               {lineNumber}
             </code>
+            {#if highlightedLines.includes(i)}
+              <div
+                class:line-background={true}
+                style:background="var(--highlighted-background, rgba(254, 241,
+                96, 0.2))"
+              />
+            {/if}
           </td>
           <td>
             <pre class:wrapLines><code>{@html line || "\n"}</code></pre>
+            {#if highlightedLines.includes(i)}
+              <div
+                class:line-background={true}
+                style:background="var(--highlighted-background, rgba(254, 241,
+                96, 0.2))"
+              />
+            {/if}
           </td>
         </tr>
       {/each}
@@ -150,5 +180,36 @@
 
   .wrapLines {
     white-space: pre-wrap;
+  }
+
+  td,
+  pre {
+    position: relative;
+  }
+
+  pre {
+    z-index: 1;
+  }
+
+  .line-background {
+    position: absolute;
+    z-index: 0;
+    top: 0;
+    left: 0;
+    width: 100%;
+    height: 100%;
+  }
+
+  tr:first-of-type td .line-background,
+  tr:last-of-type td .line-background {
+    height: calc(100% - 1em);
+  }
+
+  tr:first-of-type td .line-background {
+    top: 1em;
+  }
+
+  tr:last-of-type td .line-background {
+    bottom: 1em;
   }
 </style>

--- a/tests/SvelteHighlight.test.ts
+++ b/tests/SvelteHighlight.test.ts
@@ -61,8 +61,8 @@ describe("SvelteHighlight", () => {
 
     expect(target.querySelector("#line-numbers")?.innerHTML)
       .toMatchInlineSnapshot(`
-        "<div style=\\"overflow-x: auto;\\" class=\\"svelte-1kmlnkb\\"><table class=\\"svelte-1kmlnkb\\"><tbody class=\\"hljs\\"><tr class=\\"svelte-1kmlnkb\\"><td class=\\"svelte-1kmlnkb hljs\\" style=\\"position: sticky; left: 0px; text-align: right; user-select: none; width: 24px;\\"><code>1</code></td> <td class=\\"svelte-1kmlnkb\\"><pre class=\\"svelte-1kmlnkb\\"><code>
-        </code></pre></td> </tr></tbody></table></div>"
+        "<div style=\\"overflow-x: auto;\\" class=\\"svelte-tjkhvl\\"><table class=\\"svelte-tjkhvl\\"><tbody class=\\"hljs\\"><tr class=\\"svelte-tjkhvl\\"><td class=\\"svelte-tjkhvl hljs\\" style=\\"position: sticky; left: 0px; text-align: right; user-select: none; width: 24px;\\"><code>1</code> </td> <td class=\\"svelte-tjkhvl\\"><pre class=\\"svelte-tjkhvl\\"><code>
+        </code></pre> </td> </tr></tbody></table></div>"
       `);
   });
 });


### PR DESCRIPTION
Closes #256

Supports highlighting specific lines through the `highlightedLines` prop. Customize the background color using `--highlighted-background` style prop.

```svelte
<Highlight language={typescript} {code} let:highlighted>
  <LineNumbers {highlighted} highlightedLines={[1, 2]} --highlighted-background="#000" />
</Highlight>
```

---

<img width="838" alt="Example" src="https://user-images.githubusercontent.com/10718366/218340592-2e9707ed-6da3-4d60-829d-33fe9a82a262.png">
