### PR TITLE
fix(types): style/lang types should use declare const

### DIFF
--- a/scripts/build-languages.js
+++ b/scripts/build-languages.js
@@ -30,7 +30,7 @@ export async function buildLanguages() {
     if (/-/.test(name)) moduleName = toCamelCase(name);
 
     base += `export { default as ${moduleName} } from './${name}';\n`;
-    baseTs += `export const ${moduleName}: LanguageType<"${name}">;\n`;
+    baseTs += `export declare const ${moduleName}: LanguageType<"${name}">;\n`;
     lang.push({ name, moduleName });
     markdown += `## ${name} (\`${moduleName}\`)
 

--- a/scripts/build-styles.js
+++ b/scripts/build-styles.js
@@ -120,7 +120,7 @@ export async function buildStyles() {
       .join("");
 
   const types = styles
-    .map((style) => `export const ${style.moduleName}: string;\n`)
+    .map((style) => `export declare const ${style.moduleName}: string;\n`)
     .join("");
   const base = styles
     .map(


### PR DESCRIPTION
There's a subtle but important difference between `export const` and `export declare const` when used in a type definition file.

- `export const` both declares and exports a constant.
- `export declare const` signifies types for a variable that is created elsewhere.

`declare` should be used in this case, since it's a type definition file; the variable is exported elsewhere.