### PR TITLE
fix(exports): include additional `exports` in package.json

### DIFF
--- a/scripts/npm-package.js
+++ b/scripts/npm-package.js
@@ -17,7 +17,7 @@ async function npmPackage() {
   fs.rmSync("./package/src", { recursive: true, force: true });
 
   const pkgJson = JSON.parse(
-    fs.readFileSync("./package/package.json", "utf-8"),
+    fs.readFileSync("./package/package.json", "utf-8")
   );
 
   delete pkgJson.scripts;
@@ -35,11 +35,27 @@ async function npmPackage() {
     "./styles/*.css": {
       import: "./styles/*.css",
     },
+    "./styles": {
+      types: "./styles/index.d.ts",
+      import: "./styles/index.js",
+    },
     "./styles/*": {
       types: "./styles/*.d.ts",
       import: "./styles/*.js",
     },
+    "./styles/*.js": {
+      types: "./styles/*.d.ts",
+      import: "./styles/*.js",
+    },
+    "./languages": {
+      types: "./languages/index.d.ts",
+      import: "./languages/index.js",
+    },
     "./languages/*": {
+      types: "./languages/*.d.ts",
+      import: "./languages/*.js",
+    },
+    "./languages/*.js": {
       types: "./languages/*.d.ts",
       import: "./languages/*.js",
     },


### PR DESCRIPTION
Fixes #315

`package.json#exports` needs additional entries to the library code.

This fixes resolution of the following import methods:

```ts
// Base import for styles/languages
import { _default } from "svelte-highlight/styles";
import { _1c } from "svelte-highlight/languages";

// Explicit index
import { _default } from "svelte-highlight/styles/index";
import { typescript } from "svelte-highlight/languages/index";

// Explicit extension
import lang from "svelte-highlight/languages/1c.js"
import style from "svelte-highlight/styles/3024.js";
```