### PR TITLE
fix(line-numbers): avoid self-closing tag to address Svelte 5 warning

### DIFF
--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -48,7 +48,7 @@
               <div
                 class:line-background={true}
                 style:background="var(--highlighted-background, {HIGHLIGHTED_BACKGROUND})"
-              />
+              ></div>
             {/if}
           </td>
           <td>
@@ -57,7 +57,7 @@
               <div
                 class:line-background={true}
                 style:background="var(--highlighted-background, {HIGHLIGHTED_BACKGROUND})"
-              />
+              ></div>
             {/if}
           </td>
         </tr>


### PR DESCRIPTION
Fixes #341 