### PR TITLE
feat(styles): support scoped styles

### DIFF
--- a/examples/rollup/src/App.svelte
+++ b/examples/rollup/src/App.svelte
@@ -3,6 +3,7 @@
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import DynamicImport from "./DynamicImport.svelte";
+  import ScopedStyles from "./ScopedStyles.svelte";
 
   const code = "const add = (a: number, b: number) => a + b;";
 </script>
@@ -14,3 +15,5 @@
 <Highlight language={typescript} {code} />
 
 <DynamicImport />
+
+<ScopedStyles />

--- a/examples/rollup/src/ScopedStyles.svelte
+++ b/examples/rollup/src/ScopedStyles.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark.scoped";
+  import github from "svelte-highlight/styles/github.scoped";
+  import blackMetalDarkFuneral from "svelte-highlight/styles/black-metal-dark-funeral.scoped";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+  {@html atomOneDark}
+  {@html blackMetalDarkFuneral}
+</svelte:head>
+
+<Highlight class="github" language={typescript} {code} />
+
+<Highlight class="atomOneDark" language={typescript} {code} />
+
+<Highlight class="blackMetalDarkFuneral" language={typescript} {code} />

--- a/examples/routify/src/components/ScopedStyles.svelte
+++ b/examples/routify/src/components/ScopedStyles.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark.scoped";
+  import github from "svelte-highlight/styles/github.scoped";
+  import blackMetalDarkFuneral from "svelte-highlight/styles/black-metal-dark-funeral.scoped";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+  {@html atomOneDark}
+  {@html blackMetalDarkFuneral}
+</svelte:head>
+
+<Highlight class="github" language={typescript} {code} />
+
+<Highlight class="atomOneDark" language={typescript} {code} />
+
+<Highlight class="blackMetalDarkFuneral" language={typescript} {code} />

--- a/examples/routify/src/routes/index.svelte
+++ b/examples/routify/src/routes/index.svelte
@@ -3,6 +3,7 @@
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import DynamicImport from "../components/DynamicImport.svelte";
+  import ScopedStyles from "../components/ScopedStyles.svelte";
 
   const code = "const add = (a: number, b: number) => a + b;";
 </script>
@@ -14,3 +15,5 @@
 <Highlight language={typescript} {code} />
 
 <DynamicImport />
+
+<ScopedStyles />

--- a/examples/sveltekit/src/lib/ScopedStyles.svelte
+++ b/examples/sveltekit/src/lib/ScopedStyles.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark.scoped";
+  import github from "svelte-highlight/styles/github.scoped";
+  import blackMetalDarkFuneral from "svelte-highlight/styles/black-metal-dark-funeral.scoped";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+  {@html atomOneDark}
+  {@html blackMetalDarkFuneral}
+</svelte:head>
+
+<Highlight class="github" language={typescript} {code} />
+
+<Highlight class="atomOneDark" language={typescript} {code} />
+
+<Highlight class="blackMetalDarkFuneral" language={typescript} {code} />

--- a/examples/sveltekit/src/routes/+page.svelte
+++ b/examples/sveltekit/src/routes/+page.svelte
@@ -3,6 +3,7 @@
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import DynamicImport from "$lib/DynamicImport.svelte";
+  import ScopedStyles from "$lib/ScopedStyles.svelte";
 
   const code = "const add = (a: number, b: number) => a + b;";
 </script>
@@ -14,3 +15,5 @@
 <Highlight language={typescript} {code} />
 
 <DynamicImport />
+
+<ScopedStyles />

--- a/examples/vite/src/App.svelte
+++ b/examples/vite/src/App.svelte
@@ -3,6 +3,7 @@
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import DynamicImport from "./DynamicImport.svelte";
+  import ScopedStyles from "./ScopedStyles.svelte";
 
   const code = "const add = (a: number, b: number) => a + b;";
 </script>
@@ -14,3 +15,5 @@
 <Highlight language={typescript} {code} />
 
 <DynamicImport />
+
+<ScopedStyles />

--- a/examples/vite/src/ScopedStyles.svelte
+++ b/examples/vite/src/ScopedStyles.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark.scoped";
+  import github from "svelte-highlight/styles/github.scoped";
+  import blackMetalDarkFuneral from "svelte-highlight/styles/black-metal-dark-funeral.scoped";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+  {@html atomOneDark}
+  {@html blackMetalDarkFuneral}
+</svelte:head>
+
+<Highlight class="github" language={typescript} {code} />
+
+<Highlight class="atomOneDark" language={typescript} {code} />
+
+<Highlight class="blackMetalDarkFuneral" language={typescript} {code} />

--- a/examples/vite@svelte-5/src/App.svelte
+++ b/examples/vite@svelte-5/src/App.svelte
@@ -3,6 +3,7 @@
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import DynamicImport from "./DynamicImport.svelte";
+  import ScopedStyles from "./ScopedStyles.svelte";
 
   const code = "const add = (a: number, b: number) => a + b;";
 </script>
@@ -14,3 +15,5 @@
 <Highlight language={typescript} {code} />
 
 <DynamicImport />
+
+<ScopedStyles />

--- a/examples/vite@svelte-5/src/ScopedStyles.svelte
+++ b/examples/vite@svelte-5/src/ScopedStyles.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark.scoped";
+  import github from "svelte-highlight/styles/github.scoped";
+  import blackMetalDarkFuneral from "svelte-highlight/styles/black-metal-dark-funeral.scoped";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+  {@html atomOneDark}
+  {@html blackMetalDarkFuneral}
+</svelte:head>
+
+<Highlight class="github" language={typescript} {code} />
+
+<Highlight class="atomOneDark" language={typescript} {code} />
+
+<Highlight class="blackMetalDarkFuneral" language={typescript} {code} />

--- a/examples/webpack/src/App.svelte
+++ b/examples/webpack/src/App.svelte
@@ -3,6 +3,7 @@
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import DynamicImport from "./DynamicImport.svelte";
+  import ScopedStyles from "./ScopedStyles.svelte";
 
   const code = "const add = (a: number, b: number) => a + b;";
 </script>
@@ -14,3 +15,5 @@
 <Highlight language={typescript} {code} />
 
 <DynamicImport />
+
+<ScopedStyles />

--- a/examples/webpack/src/ScopedStyles.svelte
+++ b/examples/webpack/src/ScopedStyles.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { Highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark.scoped";
+  import github from "svelte-highlight/styles/github.scoped";
+  import blackMetalDarkFuneral from "svelte-highlight/styles/black-metal-dark-funeral.scoped";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+  {@html atomOneDark}
+  {@html blackMetalDarkFuneral}
+</svelte:head>
+
+<Highlight class="github" language={typescript} {code} />
+
+<Highlight class="atomOneDark" language={typescript} {code} />
+
+<Highlight class="blackMetalDarkFuneral" language={typescript} {code} />

--- a/scripts/utils/minify-css.ts
+++ b/scripts/utils/minify-css.ts
@@ -2,11 +2,13 @@ import cssnano from "cssnano";
 import litePreset, { type LiteOptions } from "cssnano-preset-lite";
 import postcss from "postcss";
 
+export const minifyPreset = (
+  discardComments?: LiteOptions["discardComments"],
+) => [cssnano({ preset: litePreset({ discardComments }) })];
+
 export const minifyCss = (
   css: string,
   discardComments?: LiteOptions["discardComments"],
 ) => {
-  return postcss([
-    cssnano({ preset: litePreset({ discardComments }) }),
-  ]).process(css).css;
+  return postcss(minifyPreset(discardComments)).process(css).css;
 };

--- a/scripts/utils/plugin-scoped-styles.ts
+++ b/scripts/utils/plugin-scoped-styles.ts
@@ -1,0 +1,26 @@
+import type { Plugin } from "postcss";
+
+const RE_PRE = /^pre /;
+
+export function pluginScopedStyles({
+  moduleName,
+}: {
+  moduleName: string;
+}): Plugin {
+  return {
+    postcssPlugin: "postcss-plugin:scoped-styles",
+    Once(root) {
+      root.walkRules((rule) => {
+        rule.selectors = rule.selectors.map((selector) => {
+          if (RE_PRE.test(selector)) {
+            selector = `pre.${moduleName}${selector.replace(RE_PRE, " ")}`;
+          } else {
+            selector = `.${moduleName} ${selector}`;
+          }
+
+          return selector;
+        });
+      });
+    },
+  };
+};


### PR DESCRIPTION
Closes #233 

**TODO**

- [ ] Update docs (README)
- [ ] Update demo docs
- [ ] Update demo option

```svelte
<script>
  import { Highlight } from "svelte-highlight";
  import typescript from "svelte-highlight/languages/typescript";
  import atomOneDark from "svelte-highlight/styles/atom-one-dark.scoped";
  import github from "svelte-highlight/styles/github.scoped";
  import blackMetalDarkFuneral from "svelte-highlight/styles/black-metal-dark-funeral.scoped";

  const code = "const add = (a: number, b: number) => a + b;";
</script>

<svelte:head>
  {@html github}
  {@html atomOneDark}
  {@html blackMetalDarkFuneral}
</svelte:head>

<Highlight class="github" language={typescript} {code} />

<Highlight class="atomOneDark" language={typescript} {code} />

<Highlight class="blackMetalDarkFuneral" language={typescript} {code} />

```