### PR TITLE
fix: preserve license comments in processed CSS

### DIFF
--- a/scripts/utils/minify-css.ts
+++ b/scripts/utils/minify-css.ts
@@ -1,16 +1,36 @@
 import cssnano from "cssnano";
-import litePreset, { type LiteOptions } from "cssnano-preset-lite";
+import litePreset from "cssnano-preset-lite";
 import postcss from "postcss";
 import discardDuplicates from "postcss-discard-duplicates";
 import mergeRules from "postcss-merge-rules";
 
 export const minifyCss = (
   css: string,
-  discardComments?: LiteOptions["discardComments"],
+  options?: {
+    discardComments?: "preserve-license" | "remove-all";
+  },
 ) => {
   return postcss([
     discardDuplicates(),
     mergeRules(),
-    cssnano({ preset: litePreset({ discardComments }) }),
+    cssnano({
+      preset: litePreset({
+        discardComments:
+          options?.discardComments === "preserve-license"
+            ? {
+                remove: (comment) => {
+                  if (/(License|Author)/i.test(comment)) {
+                    // Preserve license comments.
+                    return false;
+                  }
+
+                  return true;
+                },
+              }
+            : options?.discardComments === "remove-all"
+              ? { removeAll: true }
+              : undefined,
+      }),
+    }),
   ]).process(css).css;
 };

--- a/tests/minify-css.test.ts
+++ b/tests/minify-css.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from "bun:test";
+import { minifyCss } from "../scripts/utils/minify-css";
+
+describe("minifyCss", () => {
+  it("should minify basic CSS", () => {
+    const input = `
+      .test {
+        color: red;
+        background: blue;
+      }
+    `;
+    const output = minifyCss(input);
+    expect(output).toBe(".test{color:red;background:blue}");
+  });
+
+  it("should remove duplicate rules", () => {
+    const input = `
+      .test {
+        color: red;
+      }
+      .test {
+        color: red;
+      }
+    `;
+    const output = minifyCss(input);
+    expect(output).toBe(".test{color:red}");
+  });
+
+  it("should merge rules with same selectors", () => {
+    const input = `
+      .test {
+        color: red;
+      }
+      .test {
+        background: blue;
+      }
+    `;
+    const output = minifyCss(input);
+    expect(output).toBe(".test{color:red;background:blue}");
+  });
+
+  describe("comments handling", () => {
+    const cssWithComments = `
+      /* Regular comment */
+      .test {
+        color: red;
+      }
+      /* @license
+         My License text
+      */
+      .other {
+        color: blue;
+      }
+      /* @Author: John Doe */
+      .another {
+        color: green;
+      }
+    `;
+
+    it("should preserve license comments when option is set", () => {
+      const output = minifyCss(cssWithComments, {
+        discardComments: "preserve-license",
+      });
+      expect(output).toContain("@license");
+      expect(output).toContain("@Author");
+      expect(output).not.toContain("Regular comment");
+    });
+
+    it("should remove all comments when remove-all option is set", () => {
+      const output = minifyCss(cssWithComments, {
+        discardComments: "remove-all",
+      });
+      expect(output).not.toContain("@license");
+      expect(output).not.toContain("@Author");
+      expect(output).not.toContain("Regular comment");
+    });
+  });
+});


### PR DESCRIPTION
The processed JS styles (e.g., `arta.js`) preserve license-related comments while optimizing output. However, the same effect is not applied to processed CSS files (`arta.css`).