### PR TITLE
chore: remove `@ts-check` comments

### DIFF
--- a/examples/webpack/webpack.config.mjs
+++ b/examples/webpack/webpack.config.mjs
@@ -2,7 +2,7 @@
 import HtmlWebpackPlugin from "html-webpack-plugin";
 import MiniCssExtractPlugin from "mini-css-extract-plugin";
 import path from "node:path";
-import preprocess from "svelte-preprocess";
+import { sveltePreprocess } from "svelte-preprocess";
 
 /** @type {"development" | "production"} */
 const NODE_ENV =
@@ -32,7 +32,7 @@ export default {
           loader: "svelte-loader",
           options: {
             hotReload: !PROD,
-            preprocess: preprocess(),
+            preprocess: sveltePreprocess(),
             compilerOptions: { dev: !PROD },
           },
         },

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   /** @type {import("./languages").LanguageType<string>} */
   export let language;
 

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -1,5 +1,4 @@
 <script>
-  // @ts-check
   import LangTag from "./LangTag.svelte";
 
   /** @type {any} */

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -1,5 +1,4 @@
 <script>
-  // @ts-check
   import LangTag from "./LangTag.svelte";
 
   /** @type {any} */

--- a/src/LangTag.svelte
+++ b/src/LangTag.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   /** @type {any} */
   export let code;
 

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   /** @type {string} */
   export let highlighted;
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -2,6 +2,7 @@
   "extends": "astro/tsconfigs/strictest",
   "compilerOptions": {
     "baseUrl": ".",
+    "checkJs": true,
     "ignoreDeprecations": "5.0",
     "allowSyntheticDefaultImports": true,
     "resolveJsonModule": true,

--- a/www/components/CodeSnippet.svelte
+++ b/www/components/CodeSnippet.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   export let code = "";
 
   import { CodeSnippet } from "carbon-components-svelte";

--- a/www/components/Footer.svelte
+++ b/www/components/Footer.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   import { PKG_HOMEPAGE, PKG_NAME, TS } from "@www/constants";
   import { Grid, Row, Column, Link } from "carbon-components-svelte";
 </script>

--- a/www/components/LineNumbers/Basic.svelte
+++ b/www/components/LineNumbers/Basic.svelte
@@ -1,8 +1,6 @@
 <script>
   import { THEME_NAME, THEME_MODULE_NAME } from "@www/constants";
 
-  // @ts-check
-
   export let snippet = "<LineNumbers {highlighted} />";
 
   import { HighlightSvelte, LineNumbers } from "svelte-highlight";

--- a/www/components/LineNumbers/HideBorder.svelte
+++ b/www/components/LineNumbers/HideBorder.svelte
@@ -1,5 +1,4 @@
 <script>
-  // @ts-check
   import Basic from "./Basic.svelte";
 
   const snippet = "<LineNumbers {highlighted} hideBorder />";

--- a/www/components/LineNumbers/HighlightedLines.svelte
+++ b/www/components/LineNumbers/HighlightedLines.svelte
@@ -1,5 +1,4 @@
 <script>
-  // @ts-check
   import Basic from "./Basic.svelte";
 
   const snippet =

--- a/www/components/LineNumbers/HighlightedLinesCustomColor.svelte
+++ b/www/components/LineNumbers/HighlightedLinesCustomColor.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   import Basic from "./Basic.svelte";
 
   const snippet = `<LineNumbers

--- a/www/components/LineNumbers/StartingLineNumber.svelte
+++ b/www/components/LineNumbers/StartingLineNumber.svelte
@@ -1,5 +1,4 @@
 <script>
-  // @ts-check
   import Basic from "./Basic.svelte";
 
   const snippet = "<LineNumbers {highlighted} startingLineNumber={42} />";

--- a/www/components/LineNumbers/StyleProps.svelte
+++ b/www/components/LineNumbers/StyleProps.svelte
@@ -1,5 +1,4 @@
 <script>
-  // @ts-check
   import Basic from "./Basic.svelte";
 
   const snippet = `<LineNumbers

--- a/www/components/LineNumbers/WrapLines.svelte
+++ b/www/components/LineNumbers/WrapLines.svelte
@@ -1,5 +1,4 @@
 <script>
-  // @ts-check
   import Basic from "./Basic.svelte";
 
   const snippet = "<LineNumbers {highlighted} wrapLines />";

--- a/www/components/ListSearch.svelte
+++ b/www/components/ListSearch.svelte
@@ -1,5 +1,4 @@
 <script>
-  // @ts-check
   import { PKG_HLJS_VERSION } from "@www/constants";
 
   /** @type {{ name: string; moduleName: string; }[]} */

--- a/www/components/ScopedLanguage.svelte
+++ b/www/components/ScopedLanguage.svelte
@@ -1,8 +1,6 @@
 <script>
   import { THEME_MODULE_NAME } from "@www/constants";
 
-  // @ts-check
-
   /** @type {string} */
   export let name;
 

--- a/www/components/ScopedStyle.svelte
+++ b/www/components/ScopedStyle.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   export let name = "";
   export let moduleName = "";
   export let useInjectedStyles = true;

--- a/www/components/ScopedStyleAuto.svelte
+++ b/www/components/ScopedStyleAuto.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   export let name = "";
   export let moduleName = "";
 

--- a/www/components/ScopedStyleSvelte.svelte
+++ b/www/components/ScopedStyleSvelte.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   export let name = "";
   export let moduleName = "";
 

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   /** @type {string} */
   export let title;
 

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   import { THEME_NAME, PKG_NAME, THEME_MODULE_NAME } from "@www/constants";
   import {
     Row,

--- a/www/components/globals/Languages.svelte
+++ b/www/components/globals/Languages.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   import {
     Row,
     Column,

--- a/www/components/globals/Styles.svelte
+++ b/www/components/globals/Styles.svelte
@@ -1,6 +1,4 @@
 <script>
-  // @ts-check
-
   import {
     Row,
     Column,


### PR DESCRIPTION
Instead of including `@ts-check` comments directly in source code, enable `checkJs: true` in `tsconfig.json`.