### PR TITLE
fix(types): export `LanguageType` utility type

### DIFF
--- a/README.md
+++ b/README.md
@@ -334,6 +334,22 @@ Refer to the highlight.js [language definition guide](https://highlightjs.readth
 <Highlight {language} code="..." />
 ```
 
+If you're using TypeScript, use the `LanguageType` interface to type the language.
+
+```ts
+import type { LanguageType } from "svelte-highlight";
+
+const language: LanguageType<"custom-language"> = {
+  name: "custom-language",
+  register: (hljs) => {
+    return {
+      /** custom language rules */
+      contains: [],
+    };
+  },
+};
+```
+
 ## Custom Plugin
 
 Additional plugin languages can be installed and used separately.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -2,3 +2,4 @@ export { default as Highlight, default as default } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
+export type { LanguageType } from "./languages";

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -1,4 +1,5 @@
 import * as languages from "../src/languages";
+import type { LanguageType } from "svelte-highlight";
 
 test("Languages", () => {
   const languageNames = Object.keys(languages);
@@ -7,4 +8,22 @@ test("Languages", () => {
   expect(languages.default).toBeUndefined();
   expect(languageNames.length).toEqual(192);
   expect(languageNames).toMatchSnapshot();
+});
+
+test("LanguageType", () => {
+  const language: LanguageType<"custom-language"> = {
+    name: "custom-language",
+    register: () => {
+      return {
+        contains: [],
+        tokenize: () => {
+          return {
+            tokens: [],
+          };
+        },
+      };
+    },
+  };
+
+  expect(language).toBeTruthy();
 });


### PR DESCRIPTION
Fixes #373 

`LanguageType` is a utility for instrumenting custom `language` implementations for `highlight.js`. It's meant to be used by consumers, so this should be exported.

```ts
interface LanguageType<TName extends string> {
  name: TName;
  register: LanguageFn;
}
```

Example usage:

```ts
import type { LanguageType } from "svelte-highlight";

const language: LanguageType<"custom-language"> = {
  name: "custom-language",
  register: () => {
    return {
      contains: [],
      tokenize: () => {
        return {
          tokens: [],
        };
      },
    };
  },
};
```