### PR TITLE
ci: parallelize jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,28 @@ on:
   push:
     branches: [master]
 
+permissions:
+  contents: read
+
 jobs:
-  test:
+  unit-tests:
+    runs-on: macos-14
+    steps:
+      - uses: actions/checkout@v4
+      - uses: oven-sh/setup-bun@v2
+      - name: Install dependencies
+        run: bun install
+
+      - name: Build library
+        run: bun build:lib
+
+      - name: Run unit tests
+        run: bun test:unit
+
+      - name: Run typecheck
+        run: bun test:types
+
+  e2e-tests:
     runs-on: macos-14
     steps:
       - uses: actions/checkout@v4
@@ -29,11 +49,5 @@ jobs:
       - name: Build library
         run: bun build:lib
 
-      - name: Run unit tests
-        run: bun test:unit
-
       - name: Run e2e tests
         run: bun test:e2e
-
-      - name: Run typecheck
-        run: bun test:types


### PR DESCRIPTION
Parallelize the unit/integration/typecheck and e2e Playwright tests.

This should generally be faster.

## Before

<img width="450" height="321" alt="Screenshot 2025-08-31 at 11 50 39 AM" src="https://github.com/user-attachments/assets/2a88d5ad-e05b-48f8-9d1b-a452228f51f9" />

## After

<img width="450" height="374" alt="Screenshot 2025-08-31 at 11 50 28 AM" src="https://github.com/user-attachments/assets/870623f1-aa47-44fd-aefe-464d1bfbc5b4" />
