### PR TITLE
refactor(build): alphabetically sort generated language exports

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -134,18 +134,6 @@
 </script>
 ```
 
-## xml (`xml`)
-
-```html
-<script>
-  // direct import (recommended)
-  import xml from "svelte-highlight/languages/xml";
-
-  // base import
-  import { xml } from "svelte-highlight/languages";
-</script>
-```
-
 ## asciidoc (`asciidoc`)
 
 ```html
@@ -494,18 +482,6 @@
 </script>
 ```
 
-## markdown (`markdown`)
-
-```html
-<script>
-  // direct import (recommended)
-  import markdown from "svelte-highlight/languages/markdown";
-
-  // base import
-  import { markdown } from "svelte-highlight/languages";
-</script>
-```
-
 ## dart (`dart`)
 
 ```html
@@ -662,18 +638,6 @@
 </script>
 ```
 
-## ruby (`ruby`)
-
-```html
-<script>
-  // direct import (recommended)
-  import ruby from "svelte-highlight/languages/ruby";
-
-  // base import
-  import { ruby } from "svelte-highlight/languages";
-</script>
-```
-
 ## erb (`erb`)
 
 ```html
@@ -686,18 +650,6 @@
 </script>
 ```
 
-## erlang-repl (`erlangRepl`)
-
-```html
-<script>
-  // direct import (recommended)
-  import erlangRepl from "svelte-highlight/languages/erlang-repl";
-
-  // base import
-  import { erlangRepl } from "svelte-highlight/languages";
-</script>
-```
-
 ## erlang (`erlang`)
 
 ```html
@@ -707,6 +659,18 @@
 
   // base import
   import { erlang } from "svelte-highlight/languages";
+</script>
+```
+
+## erlang-repl (`erlangRepl`)
+
+```html
+<script>
+  // direct import (recommended)
+  import erlangRepl from "svelte-highlight/languages/erlang-repl";
+
+  // base import
+  import { erlangRepl } from "svelte-highlight/languages";
 </script>
 ```
 
@@ -1262,6 +1226,18 @@
 </script>
 ```
 
+## markdown (`markdown`)
+
+```html
+<script>
+  // direct import (recommended)
+  import markdown from "svelte-highlight/languages/markdown";
+
+  // base import
+  import { markdown } from "svelte-highlight/languages";
+</script>
+```
+
 ## mathematica (`mathematica`)
 
 ```html
@@ -1343,18 +1319,6 @@
 
   // base import
   import { mizar } from "svelte-highlight/languages";
-</script>
-```
-
-## perl (`perl`)
-
-```html
-<script>
-  // direct import (recommended)
-  import perl from "svelte-highlight/languages/perl";
-
-  // base import
-  import { perl } from "svelte-highlight/languages";
 </script>
 ```
 
@@ -1535,6 +1499,18 @@
 
   // base import
   import { parser3 } from "svelte-highlight/languages";
+</script>
+```
+
+## perl (`perl`)
+
+```html
+<script>
+  // direct import (recommended)
+  import perl from "svelte-highlight/languages/perl";
+
+  // base import
+  import { perl } from "svelte-highlight/languages";
 </script>
 ```
 
@@ -1826,6 +1802,18 @@
 </script>
 ```
 
+## ruby (`ruby`)
+
+```html
+<script>
+  // direct import (recommended)
+  import ruby from "svelte-highlight/languages/ruby";
+
+  // base import
+  import { ruby } from "svelte-highlight/languages";
+</script>
+```
+
 ## ruleslanguage (`ruleslanguage`)
 
 ```html
@@ -2066,18 +2054,6 @@
 </script>
 ```
 
-## yaml (`yaml`)
-
-```html
-<script>
-  // direct import (recommended)
-  import yaml from "svelte-highlight/languages/yaml";
-
-  // base import
-  import { yaml } from "svelte-highlight/languages";
-</script>
-```
-
 ## tap (`tap`)
 
 ```html
@@ -2282,6 +2258,18 @@
 </script>
 ```
 
+## xml (`xml`)
+
+```html
+<script>
+  // direct import (recommended)
+  import xml from "svelte-highlight/languages/xml";
+
+  // base import
+  import { xml } from "svelte-highlight/languages";
+</script>
+```
+
 ## xquery (`xquery`)
 
 ```html
@@ -2291,6 +2279,18 @@
 
   // base import
   import { xquery } from "svelte-highlight/languages";
+</script>
+```
+
+## yaml (`yaml`)
+
+```html
+<script>
+  // direct import (recommended)
+  import yaml from "svelte-highlight/languages/yaml";
+
+  // base import
+  import { yaml } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -6,12 +6,60 @@ import { CONTAINS_DASH, STARTS_WITH_DIGIT } from "./utils/regexes.ts";
 import { toCamelCase } from "./utils/to-camel-case.ts";
 import { writeTo } from "./utils/write-to.ts";
 
+type CustomLanguage = {
+  name: string;
+  moduleName: string;
+  path: string;
+};
+
+const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [];
+
+type LanguageEntry = {
+  name: string;
+  moduleName: string;
+  kind: "custom" | "hljs";
+  customPath?: string;
+};
+
+function getModuleName(name: string) {
+  let moduleName = name;
+
+  if (STARTS_WITH_DIGIT.test(name)) moduleName = `_${name}`;
+  if (CONTAINS_DASH.test(name)) moduleName = toCamelCase(name);
+
+  return moduleName;
+}
+
 export async function buildLanguages() {
   console.time("build languages");
   await $`rm -rf src/languages; mkdir src/languages`;
 
-  const languages = hljs.listLanguages();
-  let markdown = createMarkdown("Languages", languages.length);
+  const customLanguageContents = new Map<
+    CustomLanguage["name"],
+    CustomLanguage["path"]
+  >(
+    await Promise.all(
+      CUSTOM_LANGUAGES.map(
+        async ({ name, path }) => [name, await Bun.file(path).text()] as const,
+      ),
+    ),
+  );
+
+  const entries: LanguageEntry[] = [
+    ...hljs.listLanguages().map((name) => ({
+      name,
+      moduleName: getModuleName(name),
+      kind: "hljs" as const,
+    })),
+    ...CUSTOM_LANGUAGES.map(({ name, moduleName, path }) => ({
+      name,
+      moduleName,
+      kind: "custom" as const,
+      customPath: path,
+    })),
+  ].sort((a, b) => a.name.localeCompare(b.name));
+
+  let markdown = createMarkdown("Languages", entries.length);
   let base = "";
   let baseTs = `
   import type { LanguageFn } from "highlight.js";
@@ -23,20 +71,20 @@ export async function buildLanguages() {
 
   let languageNamesUnion = "";
   const lang: ModuleNames = [];
-
   const files: Array<{ path: string; content: string }> = [];
 
-  for (const name of languages) {
-    let moduleName = name;
-
-    if (STARTS_WITH_DIGIT.test(name)) moduleName = `_${name}`;
-    if (CONTAINS_DASH.test(name)) moduleName = toCamelCase(name);
+  for (const entry of entries) {
+    const { name, moduleName, kind } = entry;
 
     base += `export { default as ${moduleName} } from './${name}';\n`;
     baseTs += `export declare const ${moduleName}: LanguageType<"${name}">;\n`;
     languageNamesUnion += `  | "${name}"\n`;
     lang.push({ name, moduleName });
-    markdown += `## ${name} (\`${moduleName}\`)
+
+    if (kind === "custom") {
+      markdown += `## ${name} (\`${moduleName}\`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
 
 \`\`\`html
 <script>
@@ -48,12 +96,30 @@ export async function buildLanguages() {
 </script>
 \`\`\`\n\n`;
 
-    files.push({
-      path: `src/languages/${name}.js`,
-      content: `import register from "highlight.js/lib/languages/${name}";\n
+      files.push({
+        path: `src/languages/${name}.js`,
+        content: customLanguageContents.get(name) ?? "",
+      });
+    } else {
+      markdown += `## ${name} (\`${moduleName}\`)
+
+\`\`\`html
+<script>
+  // direct import (recommended)
+  import ${moduleName} from "svelte-highlight/languages/${name}";
+
+  // base import
+  import { ${moduleName} } from "svelte-highlight/languages";
+</script>
+\`\`\`\n\n`;
+
+      files.push({
+        path: `src/languages/${name}.js`,
+        content: `import register from "highlight.js/lib/languages/${name}";\n
 export const ${moduleName} = { name: "${name}", register };
 export default ${moduleName};\n`,
-    });
+      });
+    }
 
     files.push({
       path: `src/languages/${name}.d.ts`,

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`Languages 1`] = `
 [

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -1,4 +1,4 @@
-// Bun Snapshot v1, https://goo.gl/fbAQLP
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
 
 exports[`Styles 1`] = `
 [


### PR DESCRIPTION
Merge highlight.js languages into a single sorted entry list so index.js, index.d.ts, and docs stay alpha-ordered when custom languages are added later.