### PR TITLE
feat(languages): add custom `html` language

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 192 languages exported from highlight.js@11.11.1
+> 193 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -923,6 +923,20 @@
 
   // base import
   import { hsp } from "svelte-highlight/languages";
+</script>
+```
+
+## html (`html`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import html from "svelte-highlight/languages/html";
+
+  // base import
+  import { html } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/biome.json
+++ b/biome.json
@@ -116,7 +116,7 @@
       }
     },
     {
-      "includes": ["scripts/**/*.ts"],
+      "includes": ["scripts/**/*.{ts,js}"],
       "linter": {
         "rules": {
           "performance": {
@@ -127,7 +127,8 @@
             "noForEach": "off"
           },
           "style": {
-            "noParameterAssign": "off"
+            "noParameterAssign": "off",
+            "useNamingConvention": "off"
           }
         }
       }

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -12,7 +12,13 @@ type CustomLanguage = {
   path: string;
 };
 
-const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [];
+const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
+  {
+    name: "html",
+    moduleName: "html",
+    path: `${import.meta.dir}/custom-languages/html.js`,
+  },
+];
 
 type LanguageEntry = {
   name: string;
@@ -45,12 +51,17 @@ export async function buildLanguages() {
     ),
   );
 
+  const customNames = new Set(CUSTOM_LANGUAGES.map(({ name }) => name));
+
   const entries: LanguageEntry[] = [
-    ...hljs.listLanguages().map((name) => ({
-      name,
-      moduleName: getModuleName(name),
-      kind: "hljs" as const,
-    })),
+    ...hljs
+      .listLanguages()
+      .filter((name) => !customNames.has(name))
+      .map((name) => ({
+        name,
+        moduleName: getModuleName(name),
+        kind: "hljs" as const,
+      })),
     ...CUSTOM_LANGUAGES.map(({ name, moduleName, path }) => ({
       name,
       moduleName,

--- a/scripts/custom-languages/html.js
+++ b/scripts/custom-languages/html.js
@@ -1,0 +1,140 @@
+import cssRegister from "highlight.js/lib/languages/css";
+import javascriptRegister from "highlight.js/lib/languages/javascript";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineHtml(hljs) {
+  const regex = hljs.regex;
+  const TagNameRe = regex.concat(
+    /[\p{L}_]/u,
+    regex.optional(/[\p{L}0-9_.-]*:/u),
+    /[\p{L}0-9_.-]*/u,
+  );
+  const HtmlIdentRe = /[\p{L}0-9._:-]+/u;
+  const HtmlEntities = {
+    className: "symbol",
+    begin: /&[a-z]+;|&#[0-9]+;|&#x[a-f0-9]+;/,
+  };
+  const TagInternals = {
+    endsWithParent: true,
+    illegal: /</,
+    relevance: 0,
+    contains: [
+      {
+        className: "attr",
+        begin: HtmlIdentRe,
+        relevance: 0,
+      },
+      {
+        begin: /=\s*/,
+        relevance: 0,
+        contains: [
+          {
+            className: "string",
+            endsParent: true,
+            variants: [
+              {
+                begin: /"/,
+                end: /"/,
+                contains: [HtmlEntities],
+              },
+              {
+                begin: /'/,
+                end: /'/,
+                contains: [HtmlEntities],
+              },
+              { begin: /[^\s"'=<>`]+/ },
+            ],
+          },
+        ],
+      },
+    ],
+  };
+
+  return {
+    name: "HTML",
+    aliases: ["htm"],
+    case_insensitive: true,
+    unicodeRegex: true,
+    contains: [
+      {
+        className: "meta",
+        begin: /<!DOCTYPE/i,
+        end: />/,
+        relevance: 10,
+      },
+      hljs.COMMENT(/<!--/, /-->/, { relevance: 10 }),
+      HtmlEntities,
+      {
+        className: "tag",
+        begin: /<style(?=\s|>)/,
+        end: />/,
+        keywords: { name: "style" },
+        contains: [TagInternals],
+        starts: {
+          end: /<\/style>/,
+          returnEnd: true,
+          subLanguage: ["css"],
+        },
+      },
+      {
+        className: "tag",
+        begin: /<script(?=\s|>)/,
+        end: />/,
+        keywords: { name: "script" },
+        contains: [TagInternals],
+        starts: {
+          end: /<\/script>/,
+          returnEnd: true,
+          subLanguage: ["javascript"],
+        },
+      },
+      {
+        className: "tag",
+        begin: regex.concat(
+          /</,
+          regex.lookahead(
+            regex.concat(TagNameRe, regex.either(/\/>/, />/, /\s/)),
+          ),
+        ),
+        end: /\/?>/,
+        contains: [
+          {
+            className: "name",
+            begin: TagNameRe,
+            relevance: 0,
+            starts: TagInternals,
+          },
+        ],
+      },
+      {
+        className: "tag",
+        begin: regex.concat(
+          /<\//,
+          regex.lookahead(regex.concat(TagNameRe, />/)),
+        ),
+        contains: [
+          {
+            className: "name",
+            begin: TagNameRe,
+            relevance: 0,
+          },
+          {
+            begin: />/,
+            relevance: 0,
+            endsParent: true,
+          },
+        ],
+      },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  hljs.registerLanguage("css", cssRegister);
+  hljs.registerLanguage("javascript", javascriptRegister);
+  return defineHtml(hljs);
+}
+
+export const html = { name: "html", register };
+export default html;

--- a/scripts/utils/postcss-scoped-styles.ts
+++ b/scripts/utils/postcss-scoped-styles.ts
@@ -13,7 +13,6 @@ import { PRE_SELECTOR } from "./regexes.ts";
 export const postcssScopedStyles = (moduleName: string): Plugin => {
   return {
     postcssPlugin: "postcss-scoped-styles",
-    // biome-ignore lint/style/useNamingConvention: PostCSS plugin API requires capitalized method names
     Once(root) {
       root.walkRules((rule) => {
         rule.selectors = rule.selectors.map((selector) => {

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -79,6 +79,7 @@ exports[`Languages 1`] = `
   "haskell",
   "haxe",
   "hsp",
+  "html",
   "http",
   "hy",
   "inform7",

--- a/tests/e2e/Highlight.test.svelte
+++ b/tests/e2e/Highlight.test.svelte
@@ -1,9 +1,11 @@
 <script>
   import Highlight from "svelte-highlight";
+  import html from "svelte-highlight/languages/html";
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
 
   let toggle = true;
+  let showHtml = false;
 
   const code = "const add = (a: number, b: number) => a + b;";
   const code2 =
@@ -11,10 +13,26 @@
     "$" +
     "{name}!" +
     "`;\n}";
+  const htmlCode = `<div id="content">
+  <p>Paragraph one</p>
+</div>
+<style>
+  #content { display: flex; }
+</style>
+<script>
+  const content = document.getElementById("content");
+<\/script>`;
 </script>
 
 <svelte:head> {@html atomOneDark} </svelte:head>
 
 <button type="button" on:click={() => (toggle = !toggle)}>Toggle</button>
+<button type="button" on:click={() => (showHtml = !showHtml)}>
+  Toggle HTML
+</button>
 
-<Highlight langtag language={typescript} code={toggle ? code : code2} />
+{#if showHtml}
+  <Highlight langtag language={html} code={htmlCode} />
+{:else}
+  <Highlight langtag language={typescript} code={toggle ? code : code2} />
+{/if}

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -18,8 +18,20 @@ test("Highlight", async ({ mount, page }) => {
     "typescript",
   );
   await expect(page.locator(".hljs-title")).toHaveText("add");
-  await page.click("button");
+  await page.getByRole("button", { name: "Toggle", exact: true }).click();
   await expect(page.locator(".hljs-title")).toHaveText("hello");
+});
+
+test("Highlight - html language", async ({ mount, page }) => {
+  await mount(Highlight);
+  await page.getByRole("button", { name: "Toggle HTML" }).click();
+  await expect(page.locator("pre")).toHaveAttribute("data-language", "html");
+  await expect(page.locator(".language-css .hljs-selector-id")).toHaveText(
+    "#content",
+  );
+  await expect(page.locator(".language-javascript .hljs-keyword")).toHaveText(
+    "const",
+  );
 });
 
 test("HighlightAuto", async ({ mount, page }) => {

--- a/tests/html-language.test.ts
+++ b/tests/html-language.test.ts
@@ -1,0 +1,46 @@
+import hljs from "highlight.js/lib/core";
+import xml from "svelte-highlight/languages/xml";
+import html from "../src/languages/html";
+
+const styleScriptSnippet = `<style>.content { display: flex; }</style>
+<script>const x = 1;</script>`;
+
+const markupSnippet = `<!DOCTYPE html>
+<!-- comment -->
+<div id="main" class='page'>Hello &amp; world</div>`;
+
+test("html highlights embedded CSS and JavaScript", () => {
+  hljs.registerLanguage(html.name, html.register);
+
+  const result = hljs.highlight(styleScriptSnippet, { language: "html" }).value;
+
+  expect(result).toContain("language-css");
+  expect(result).toContain("hljs-selector-class");
+  expect(result).toContain("language-javascript");
+  expect(result).toContain("hljs-keyword");
+});
+
+test("html highlights basic markup", () => {
+  hljs.registerLanguage(html.name, html.register);
+
+  const result = hljs.highlight(markupSnippet, { language: "html" }).value;
+
+  expect(result).toContain("hljs-meta");
+  expect(result).toContain("hljs-comment");
+  expect(result).toContain("hljs-tag");
+  expect(result).toContain("hljs-attr");
+  expect(result).toContain("hljs-string");
+  expect(result).toContain("hljs-symbol");
+});
+
+test("xml alone does not highlight embedded CSS and JavaScript", () => {
+  const isolated = hljs.newInstance();
+  isolated.registerLanguage(xml.name, xml.register);
+
+  const result = isolated.highlight(styleScriptSnippet, {
+    language: "xml",
+  }).value;
+
+  expect(result).not.toContain("language-css");
+  expect(result).not.toContain("language-javascript");
+});

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(192);
+  expect(languageNames.length).toEqual(193);
   expect(languageNames).toMatchSnapshot();
 });
 


### PR DESCRIPTION
Closes #199

Add a dedicated HTML language plugin so consumers don't have to manually combine xml/css/js.

---

<img width="1222" height="577" alt="Screenshot 2026-06-01 at 12 52 42 PM" src="https://github.com/user-attachments/assets/5f5f916b-f231-4eea-b89a-83e21b537585" />
