### PR TITLE
fix(line-numbers): support `langtag` with custom slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,31 @@ Use `--style-props` to customize styles.
 </Highlight>
 ```
 
+### Language Tag
+
+When using a custom slot, forward `langtag` and `languageName` from `Highlight` to `LineNumbers`.
+
+```svelte
+<Highlight
+  language={typescript}
+  {code}
+  langtag
+  let:highlighted
+  let:langtag
+  let:languageName
+>
+  <LineNumbers {highlighted} {langtag} {languageName} />
+</Highlight>
+```
+
+With `HighlightAuto`:
+
+```svelte
+<HighlightAuto {code} langtag let:highlighted let:langtag let:languageName>
+  <LineNumbers {highlighted} {langtag} {languageName} />
+</HighlightAuto>
+```
+
 ## Language Targeting
 
 All `Highlight` components apply a `data-language` attribute on the codeblock containing the language name.
@@ -473,6 +498,8 @@ In the example below, the `HighlightAuto` component and injected styles are dyna
 | wrapLines          | `boolean`  | `false`        |
 | startingLineNumber | `number`   | `1`            |
 | highlightedLines   | `number[]` | `[]`           |
+| langtag            | `boolean`  | `false`        |
+| languageName       | `string`   | `"plaintext"`  |
 
 `$$restProps` are forwarded to the top-level `div` element.
 

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -59,7 +59,7 @@ pkgJson.types = "./index.d.ts";
 
 // Most modern bundlers know if standalone StyleSheets are used.
 // We specify it here to be sure so that it will not be mistakenly tree-shaken.
-pkgJson.sideEffects = ["src/styles/*.css"];
+pkgJson.sideEffects = ["src/styles/*.css", "src/langtag.css"];
 
 await Bun.write("./package/package.json", JSON.stringify(pkgJson, null, 2));
 console.timeEnd("package");

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -27,7 +27,7 @@
   }
 </script>
 
-<slot {highlighted}>
+<slot {highlighted} {langtag} languageName={language.name}>
   <LangTag
     {...$$restProps}
     languageName={language.name}

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -35,7 +35,7 @@
   ));
 </script>
 
-<slot {highlighted}>
+<slot {highlighted} {langtag} languageName={language}>
   <LangTag
     {...$$restProps}
     languageName={language}

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -26,7 +26,7 @@
   $: highlighted = hljs.highlightAuto(code).value;
 </script>
 
-<slot {highlighted}>
+<slot {highlighted} {langtag} languageName="svelte">
   <LangTag
     {...$$restProps}
     languageName="svelte"

--- a/src/LangTag.svelte
+++ b/src/LangTag.svelte
@@ -12,27 +12,11 @@
   export let langtag = false;
 </script>
 
-<pre class:langtag data-language={languageName} {...$$restProps}><code
+<pre class:langtag={langtag} data-language={languageName} {...$$restProps}><code
     class:hljs={true}
     >{#if highlighted}{@html highlighted}{:else}{code}{/if}</code
   ></pre>
 
 <style>
-  .langtag {
-    position: relative;
-  }
-
-  .langtag::after {
-    content: attr(data-language);
-    position: absolute;
-    top: var(--langtag-top, 0);
-    right: var(--langtag-right, 0);
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    background: var(--langtag-background, inherit);
-    color: var(--langtag-color, inherit);
-    border-radius: var(--langtag-border-radius, 0);
-    padding: var(--langtag-padding, 1em);
-  }
+  @import "./langtag.css";
 </style>

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -14,6 +14,12 @@
   /** @type {number[]} */
   export let highlightedLines = [];
 
+  /** @type {import('./languages').LanguageName | (string & {})} */
+  export let languageName = "plaintext";
+
+  /** @type {boolean} */
+  export let langtag = false;
+
   const DIGIT_WIDTH = 12;
   const MIN_DIGITS = 2;
   const HIGHLIGHTED_BACKGROUND = "rgba(254, 241, 96, 0.2)";
@@ -24,7 +30,12 @@
   $: width = len * DIGIT_WIDTH;
 </script>
 
-<div style:overflow-x="auto" {...$$restProps}>
+<div
+  class:langtag={langtag}
+  data-language={languageName}
+  style:overflow-x="auto"
+  {...$$restProps}
+>
   <table>
     <tbody class:hljs={true}>
       {#each lines as line, i}
@@ -65,6 +76,8 @@
 </div>
 
 <style>
+  @import "./langtag.css";
+
   pre {
     margin: 0;
   }

--- a/src/LineNumbers.svelte.d.ts
+++ b/src/LineNumbers.svelte.d.ts
@@ -1,78 +1,87 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
+import type { LangtagProps } from "./Highlight.svelte";
+import type { LanguageName } from "./languages";
 
-export type LineNumbersProps = HTMLAttributes<HTMLPreElement> & {
-  /**
-   * Pass the highlighted `code` to `LineNumbers`.
-   * @example
-   * <Highlight language={typescript} {code} let:highlighted>
-   *  <LineNumbers {highlighted} />
-   * </Highlight>
-   */
-  highlighted: string;
+export type LineNumbersProps = HTMLAttributes<HTMLDivElement> &
+  LangtagProps & {
+    /**
+     * Pass the highlighted `code` to `LineNumbers`.
+     * @example
+     * <Highlight language={typescript} {code} langtag let:highlighted let:langtag let:languageName>
+     *  <LineNumbers {highlighted} {langtag} {languageName} />
+     * </Highlight>
+     */
+    highlighted: string;
 
-  /**
-   * Set to `true` to hide the border of the line numbers column.
-   * @default false
-   */
-  hideBorder?: boolean;
+    /**
+     * Provide the language name.
+     * @default "plaintext"
+     */
+    languageName?: LanguageName | (string & {});
 
-  /**
-   * Specify which starting line number should be displayed.
-   * @default 1
-   */
-  startingLineNumber?: number;
+    /**
+     * Set to `true` to hide the border of the line numbers column.
+     * @default false
+     */
+    hideBorder?: boolean;
 
-  /**
-   * Set to `true` for lines to wrap.
-   * @default false
-   */
-  wrapLines?: boolean;
+    /**
+     * Specify which starting line number should be displayed.
+     * @default 1
+     */
+    startingLineNumber?: number;
 
-  /**
-   * Specify the line indices to highlight.
-   * @default []
-   * @example [0, 1, 9]
-   */
-  highlightedLines?: number[];
+    /**
+     * Set to `true` for lines to wrap.
+     * @default false
+     */
+    wrapLines?: boolean;
 
-  /**
-   * Specify the text color for line numbers.
-   * Defaults to the current theme color applied to `.hljs code`.
-   * @default currentColor
-   * @example "pink"
-   */
-  "--line-number-color"?: string;
+    /**
+     * Specify the line indices to highlight.
+     * @default []
+     * @example [0, 1, 9]
+     */
+    highlightedLines?: number[];
 
-  /**
-   * Specify the border color.
-   * Defaults to the current background color applied to `.hljs`.
-   * @default currentColor
-   * @example "#fff"
-   */
-  "--border-color"?: string;
+    /**
+     * Specify the text color for line numbers.
+     * Defaults to the current theme color applied to `.hljs code`.
+     * @default currentColor
+     * @example "pink"
+     */
+    "--line-number-color"?: string;
 
-  /**
-   * Specify the left padding for `td` elements.
-   * @default 1em
-   * @example 0
-   */
-  "--padding-left"?: number | string;
+    /**
+     * Specify the border color.
+     * Defaults to the current background color applied to `.hljs`.
+     * @default currentColor
+     * @example "#fff"
+     */
+    "--border-color"?: string;
 
-  /**
-   * Specify the right padding for `td` elements.
-   * @default 1em
-   * @example 0
-   */
-  "--padding-right"?: number | string;
+    /**
+     * Specify the left padding for `td` elements.
+     * @default 1em
+     * @example 0
+     */
+    "--padding-left"?: number | string;
 
-  /**
-   * Specify the background color of highlighted lines.
-   * @default "rgba(254, 241, 96, 0.2)"
-   * @example "#fff"
-   */
-  "--highlighted-background"?: string;
-};
+    /**
+     * Specify the right padding for `td` elements.
+     * @default 1em
+     * @example 0
+     */
+    "--padding-right"?: number | string;
+
+    /**
+     * Specify the background color of highlighted lines.
+     * @default "rgba(254, 241, 96, 0.2)"
+     * @example "#fff"
+     */
+    "--highlighted-background"?: string;
+  };
 
 export type LineNumbersEvents = {};
 

--- a/src/langtag.css
+++ b/src/langtag.css
@@ -1,0 +1,17 @@
+.langtag {
+  position: relative;
+}
+
+.langtag::after {
+  content: attr(data-language);
+  position: absolute;
+  top: var(--langtag-top, 0);
+  right: var(--langtag-right, 0);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: var(--langtag-background, inherit);
+  color: var(--langtag-color, inherit);
+  border-radius: var(--langtag-border-radius, 0);
+  padding: var(--langtag-padding, 1em);
+}

--- a/tests/e2e/LineNumbers.langtag.test.svelte
+++ b/tests/e2e/LineNumbers.langtag.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import Highlight, { LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const add = (a: number, b: number) => a + b";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<Highlight
+  language={typescript}
+  {code}
+  langtag
+  let:highlighted
+  let:langtag
+  let:languageName
+>
+  <LineNumbers {highlighted} {langtag} {languageName} />
+</Highlight>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -5,6 +5,7 @@ import HighlightAuto from "./HighlightAuto.test.svelte";
 import LangTag from "./LangTag.test.svelte";
 import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test.svelte";
 import LineNumbersHideBorder from "./LineNumbers.hideBorder.test.svelte";
+import LineNumbersLangtag from "./LineNumbers.langtag.test.svelte";
 import LineNumbers from "./LineNumbers.test.svelte";
 import LineNumbersWrapLines from "./LineNumbers.wrapLines.test.svelte";
 import SvelteHighlight from "./SvelteHighlight.test.svelte";
@@ -80,6 +81,18 @@ test("LineNumbers - custom starting number", async ({ mount, page }) => {
   await mount(LineNumbersCustomStartingLine);
 
   await expect(page.getByText("100")).toBeVisible();
+});
+
+test("LineNumbers - langtag", async ({ mount, page }) => {
+  await mount(LineNumbersLangtag);
+
+  await expect(page.locator("div.langtag")).toBeVisible();
+  await expect(page.locator("div.langtag")).toHaveAttribute(
+    "data-language",
+    "typescript",
+  );
+  await expect(page.locator("div.langtag")).toHaveCSS("position", "relative");
+  await expect(page.locator(".hljs-keyword")).toHaveText("const");
 });
 
 test("Language tag styling", async ({ mount, page }) => {

--- a/www/components/LineNumbers/Langtag.svelte
+++ b/www/components/LineNumbers/Langtag.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+
+  import { HighlightSvelte, LineNumbers } from "svelte-highlight";
+
+  const code = `<script>
+      import { HighlightSvelte, LineNumbers } from "svelte-highlight";
+      import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+      const code = "const add = (a: number, b: number) => a + b";
+    <\/script>
+
+    <svelte:head>
+      {@html ${THEME_MODULE_NAME}}
+    </svelte:head>
+
+    <HighlightSvelte {code} langtag let:highlighted let:langtag let:languageName>
+      <LineNumbers {highlighted} {langtag} {languageName} />
+    </HighlightSvelte>`;
+</script>
+
+<HighlightSvelte {code} langtag let:highlighted let:langtag let:languageName>
+  <LineNumbers
+    class={THEME_MODULE_NAME}
+    {highlighted}
+    {langtag}
+    {languageName}
+  />
+</HighlightSvelte>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -4,6 +4,7 @@
   import HideBorder from "@components/LineNumbers/HideBorder.svelte";
   import HighlightedLines from "@components/LineNumbers/HighlightedLines.svelte";
   import HighlightedLinesCustomColor from "@components/LineNumbers/HighlightedLinesCustomColor.svelte";
+  import Langtag from "@components/LineNumbers/Langtag.svelte";
   import StartingLineNumber from "@components/LineNumbers/StartingLineNumber.svelte";
   import StyleProps from "@components/LineNumbers/StyleProps.svelte";
   import WrapLines from "@components/LineNumbers/WrapLines.svelte";
@@ -23,9 +24,9 @@
   import css from "svelte-highlight/languages/css";
 
   const svelteHeadCdn = `<link
-    rel="stylesheet"
-    href="https://unpkg.com/svelte-highlight/styles/github.css"
-  />\n`;
+      rel="stylesheet"
+      href="https://unpkg.com/svelte-highlight/styles/github.css"
+    />\n`;
 </script>
 
 <Row>
@@ -232,6 +233,17 @@
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <HighlightedLinesCustomColor /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      When using a custom slot, forward <code class="code">langtag</code> and
+      <code class="code">languageName</code>
+      from
+      <code class="code">Highlight</code>
+      to
+      <code class="code">LineNumbers</code>.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <Langtag /> </Column>
 </Row>
 
 <Row class="mb-9">
@@ -263,7 +275,12 @@
     <p class="mb-5">
       All <code class="code">Highlight</code> components allow for a tag to be
       added at the top-right of the codeblock displaying the language name.
-      Customize the language tag using style props.
+      Customize the language tag using style props. With
+      <code class="code">LineNumbers</code>, forward
+      <code class="code">langtag</code>
+      and
+      <code class="code">languageName</code>
+      from the parent slot (see Line Numbers above).
     </p>
     <p class="mb-5">Defaults:</p>
     <UnorderedList class="mb-5">


### PR DESCRIPTION
Fixes #278

Add support for `langtag` usage with `LineNumbers`.

---

<img width="835" height="389" alt="Screenshot 2026-06-01 at 2 17 42 PM" src="https://github.com/user-attachments/assets/0b8a3cfd-0539-4d3e-aa10-a45e6a2761ac" />
