### PR TITLE
feat(languages): add custom `svelte` language

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 193 languages exported from highlight.js@11.11.1
+> 194 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2041,6 +2041,20 @@
 
   // base import
   import { subunit } from "svelte-highlight/languages";
+</script>
+```
+
+## svelte (`svelte`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import svelte from "svelte-highlight/languages/svelte";
+
+  // base import
+  import { svelte } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -18,6 +18,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "html",
     path: `${import.meta.dir}/custom-languages/html.js`,
   },
+  {
+    name: "svelte",
+    moduleName: "svelte",
+    path: `${import.meta.dir}/custom-languages/svelte.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/custom-languages/svelte.js
+++ b/scripts/custom-languages/svelte.js
@@ -1,0 +1,127 @@
+import typescriptRegister from "highlight.js/lib/languages/typescript";
+import html from "./html.js";
+
+const RUNE_NAMES = "state|derived|effect|props|bindable|inspect|host";
+const RUNE_SUFFIXES = "raw|snapshot|by|eager";
+const SVELTE_DIRECTIVES =
+  "on|bind|use|transition|in|out|animate|class|style|let";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineSvelte(hljs) {
+  const runePattern = {
+    begin: new RegExp(
+      String.raw`\$(?:${RUNE_NAMES})(?:\.(?:${RUNE_SUFFIXES}))?(?=\s|\(|,|;|\)|\}|$)`,
+    ),
+    className: "keyword",
+    relevance: 10,
+  };
+
+  const storeSubscriptionPattern = {
+    begin: new RegExp(String.raw`\$(?!${RUNE_NAMES})[a-zA-Z_][\w-]*\s*\(`),
+    className: "title function_",
+    endsWithParent: true,
+    variants: [
+      {
+        begin: new RegExp(String.raw`\$(?!${RUNE_NAMES})[a-zA-Z_][\w-]*\s*\(`),
+        end: /\(/,
+        returnBegin: true,
+        excludeEnd: true,
+        relevance: 10,
+      },
+    ],
+  };
+
+  const svelteDirective = {
+    begin: new RegExp(String.raw`\b(?:${SVELTE_DIRECTIVES}):`),
+    className: "variable",
+    relevance: 10,
+  };
+
+  const svelteEventAttribute = {
+    begin: /\bon[a-zA-Z][a-zA-Z0-9]*(?==)/,
+    className: "variable",
+    relevance: 5,
+  };
+
+  const expressionPatterns = [
+    hljs.COMMENT(/\/\*/, /\*\//),
+    { begin: /\{/, end: /\}/, skip: true },
+    {
+      begin: /:(else if|else|then|catch)\b/,
+      className: "keyword",
+      relevance: 10,
+    },
+    {
+      begin: /[#@/][a-zA-Z_][\w-]*/,
+      className: "keyword",
+      relevance: 10,
+    },
+    runePattern,
+    storeSubscriptionPattern,
+    svelteDirective,
+  ];
+
+  const commonPatterns = [
+    runePattern,
+    storeSubscriptionPattern,
+    svelteDirective,
+  ];
+
+  return {
+    name: "Svelte",
+    subLanguage: "html",
+    contains: [
+      hljs.COMMENT(/<!--/, /-->/, { relevance: 10 }),
+      svelteDirective,
+      svelteEventAttribute,
+      {
+        begin:
+          /<script(?:\s+[^>]*context=["']module["']|\s+module)(?![^>]*lang=["']ts["'])[^>]*>/gm,
+        end: /<\/script>/gm,
+        subLanguage: "javascript",
+        excludeBegin: true,
+        excludeEnd: true,
+        contains: commonPatterns,
+      },
+      {
+        begin: /<script(?!.*lang=["']ts["'])[^>]*>/gm,
+        end: /<\/script>/gm,
+        subLanguage: "javascript",
+        excludeBegin: true,
+        excludeEnd: true,
+        contains: commonPatterns,
+      },
+      {
+        begin: /<script\s+lang=["']ts["'][^>]*>/gm,
+        end: /<\/script>/gm,
+        subLanguage: "typescript",
+        excludeBegin: true,
+        excludeEnd: true,
+        contains: commonPatterns,
+      },
+      {
+        begin: /^(\s*)(<style[^>]*>)/gm,
+        end: /^(\s*)(<\/style>)/gm,
+        subLanguage: "css",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: /\{/,
+        end: /\}/,
+        subLanguage: "javascript",
+        contains: expressionPatterns,
+      },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  hljs.registerLanguage("html", html.register);
+  hljs.registerLanguage("typescript", typescriptRegister);
+  return defineSvelte(hljs);
+}
+
+export const svelte = { name: "svelte", register };
+export default svelte;

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -8,22 +8,22 @@
   export let langtag = false;
 
   import hljs from "highlight.js/lib/core";
-  import css from "highlight.js/lib/languages/css";
-  import javascript from "highlight.js/lib/languages/javascript";
-  import xml from "highlight.js/lib/languages/xml";
   import { afterUpdate, createEventDispatcher } from "svelte";
+  import svelte from "./languages/svelte";
 
   const dispatch = createEventDispatcher();
 
-  hljs.registerLanguage("xml", xml);
-  hljs.registerLanguage("javascript", javascript);
-  hljs.registerLanguage("css", css);
+  /** @type {string} */
+  let highlighted = "";
 
   afterUpdate(() => {
     if (highlighted) dispatch("highlight", { highlighted });
   });
 
-  $: highlighted = hljs.highlightAuto(code).value;
+  $: {
+    hljs.registerLanguage(svelte.name, svelte.register);
+    highlighted = hljs.highlight(code, { language: svelte.name }).value;
+  }
 </script>
 
 <slot {highlighted} {langtag} languageName="svelte">

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -172,6 +172,7 @@ exports[`Languages 1`] = `
   "step21",
   "stylus",
   "subunit",
+  "svelte",
   "swift",
   "taggerscript",
   "tap",

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -48,7 +48,10 @@ test("HighlightAuto", async ({ mount, page }) => {
 
 test("SvelteHighlight", async ({ mount, page }) => {
   await mount(SvelteHighlight);
-  await expect(page.locator(".hljs-attr")).toHaveText("on:click");
+  await expect(page.locator("pre")).toHaveAttribute("data-language", "svelte");
+  await expect(page.locator(".hljs-variable").first()).toHaveText("on:");
+  await expect(page.locator(".language-javascript")).toBeVisible();
+  await expect(page.locator(".hljs-variable.language_")).toHaveText("console");
 });
 
 test("LineNumbers - basic functionality", async ({ mount, page }) => {

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(193);
+  expect(languageNames.length).toEqual(194);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/svelte-language.test.ts
+++ b/tests/svelte-language.test.ts
@@ -1,0 +1,97 @@
+import hljs from "highlight.js/lib/core";
+import html from "svelte-highlight/languages/html";
+import svelte from "../src/languages/svelte";
+
+const embeddedBlocksSnippet = `<script>
+  let count = 0;
+</script>
+
+<style>
+  button { color: red; }
+</style>
+
+<button>{count}</button>`;
+
+const markupSnippet = `<svelte:head>
+  <title>App</title>
+</svelte:head>
+
+{#if visible}
+  <button on:click={toggle}>Click</button>
+{/if}`;
+
+const typescriptSnippet = `<script lang="ts">
+  let count: number = 0;
+</script>`;
+
+const svelte5Snippet = `<script>
+  let count = $state(0);
+  let doubled = $derived(count * 2);
+</script>
+
+<button onclick={() => count++}>{doubled}</button>
+
+{#if count}
+  {@render children()}
+{:else if count > 10}
+  <p>many</p>
+{:else}
+  <p>few</p>
+{/if}`;
+
+test("svelte highlights embedded JavaScript, CSS, and expressions", () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const result = hljs.highlight(embeddedBlocksSnippet, {
+    language: "svelte",
+  }).value;
+
+  expect(result).toContain("language-javascript");
+  expect(result).toContain("hljs-keyword");
+  expect(result).toContain("language-css");
+  expect(result).toContain("hljs-selector-tag");
+  expect(result).toContain("language-html");
+});
+
+test("svelte highlights markup, directives, and block syntax", () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const result = hljs.highlight(markupSnippet, { language: "svelte" }).value;
+
+  expect(result).toContain("hljs-tag");
+  expect(result).toContain("hljs-variable");
+  expect(result).toContain("hljs-keyword");
+});
+
+test("svelte highlights TypeScript script blocks", () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const result = hljs.highlight(typescriptSnippet, {
+    language: "svelte",
+  }).value;
+
+  expect(result).toContain("language-typescript");
+  expect(result).toContain("hljs-keyword");
+});
+
+test("svelte highlights runes, event attributes, and block continuations", () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const result = hljs.highlight(svelte5Snippet, { language: "svelte" }).value;
+
+  expect(result).toContain('<span class="hljs-keyword">$state</span>');
+  expect(result).toContain('<span class="hljs-keyword">$derived</span>');
+  expect(result).toContain('<span class="hljs-variable">onclick</span>');
+  expect(result).toContain('<span class="hljs-keyword">@render</span>');
+  expect(result).toContain('<span class="hljs-keyword">:else if</span>');
+  expect(result).toContain('<span class="hljs-keyword">:else</span>');
+});
+
+test("html alone does not highlight Svelte block syntax", () => {
+  const isolated = hljs.newInstance();
+  isolated.registerLanguage(html.name, html.register);
+
+  const result = isolated.highlight(markupSnippet, { language: "html" }).value;
+
+  expect(result).not.toContain("hljs-keyword");
+});


### PR DESCRIPTION
Adds a custom Svelte language plugin, with Runes syntax support.

This then applies the plugin to `HighlightSvelte` for more accurate syntax highlighting.

---


<img width="1140" height="410" alt="Screenshot 2026-06-01 at 6 55 46 PM" src="https://github.com/user-attachments/assets/73d5e7d1-3fa0-4cee-b933-312fb525bd7c" />
<img width="1152" height="145" alt="Screenshot 2026-06-01 at 6 55 39 PM" src="https://github.com/user-attachments/assets/f23c81ca-9a1a-4ac0-9b8b-56b4e3cf5c9c" />
<img width="1446" height="354" alt="Screenshot 2026-06-01 at 6 55 34 PM" src="https://github.com/user-attachments/assets/46ee55db-d115-42e6-8e86-8a40ab722deb" />
