### PR TITLE
feat(languages): add custom `astro` language

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 194 languages exported from highlight.js@11.11.1
+> 195 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -155,6 +155,20 @@
 
   // base import
   import { aspectj } from "svelte-highlight/languages";
+</script>
+```
+
+## astro (`astro`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import astro from "svelte-highlight/languages/astro";
+
+  // base import
+  import { astro } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -19,6 +19,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     path: `${import.meta.dir}/custom-languages/html.js`,
   },
   {
+    name: "astro",
+    moduleName: "astro",
+    path: `${import.meta.dir}/custom-languages/astro.js`,
+  },
+  {
     name: "svelte",
     moduleName: "svelte",
     path: `${import.meta.dir}/custom-languages/svelte.js`,

--- a/scripts/custom-languages/astro.js
+++ b/scripts/custom-languages/astro.js
@@ -1,0 +1,57 @@
+import cssRegister from "highlight.js/lib/languages/css";
+import javascriptRegister from "highlight.js/lib/languages/javascript";
+import typescriptRegister from "highlight.js/lib/languages/typescript";
+import html from "./html.js";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineAstro(hljs) {
+  return {
+    name: "Astro",
+    subLanguage: "html",
+    contains: [
+      {
+        begin: /^---\s*\n/,
+        end: /^---\s*$|^\.\.\.\s*$/m,
+        subLanguage: "typescript",
+        excludeBegin: true,
+        excludeEnd: true,
+        relevance: 100,
+      },
+      {
+        begin: /^---\s*$/m,
+        className: "meta",
+        relevance: 50,
+      },
+      hljs.COMMENT(/<!--/, /-->/, { relevance: 10 }),
+      {
+        begin: /^(\s*)(<style[^>]*>)/gm,
+        end: /^(\s*)(<\/style>)/gm,
+        subLanguage: "css",
+        excludeBegin: true,
+        excludeEnd: true,
+        relevance: 100,
+      },
+      {
+        begin: /\{/,
+        end: /\}/,
+        contains: /** @type {(import("highlight.js").Mode | "self")[]} */ ([
+          "self",
+        ]),
+        subLanguage: "javascript",
+        relevance: 10,
+      },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  hljs.registerLanguage("html", html.register);
+  hljs.registerLanguage("typescript", typescriptRegister);
+  hljs.registerLanguage("css", cssRegister);
+  hljs.registerLanguage("javascript", javascriptRegister);
+  return defineAstro(hljs);
+}
+
+export const astro = { name: "astro", register };
+export default astro;

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -15,6 +15,7 @@ exports[`Languages 1`] = `
   "armasm",
   "asciidoc",
   "aspectj",
+  "astro",
   "autohotkey",
   "autoit",
   "avrasm",

--- a/tests/astro-language.test.ts
+++ b/tests/astro-language.test.ts
@@ -1,0 +1,109 @@
+import hljs from "highlight.js/lib/core";
+import html from "svelte-highlight/languages/html";
+import astro from "../src/languages/astro";
+
+const frontmatterSnippet = `---
+export const title = "Hello";
+---
+
+<div>{title}</div>`;
+
+const templateSnippet = `<div class="card">
+  <h1>{title}</h1>
+  <Counter client:load />
+</div>`;
+
+const styleSnippet = `<style is:global>
+  .card { color: red; }
+</style>
+
+<p>Hi</p>`;
+
+const globalWildcardSnippet = `<style is:global>
+  * {
+    margin: 0;
+  }
+</style>`;
+
+const directiveAttrsSnippet = `<div set:html={html} />
+<span class:list={["badge", { active }]}>Status</span>`;
+
+test("astro highlights frontmatter as TypeScript", () => {
+  hljs.registerLanguage(astro.name, astro.register);
+
+  const result = hljs.highlight(frontmatterSnippet, {
+    language: "astro",
+  }).value;
+
+  expect(result).toContain("language-typescript");
+  expect(result).toContain("hljs-keyword");
+  expect(result).not.toContain(
+    'hljs-comment"><span class="language-typescript"',
+  );
+  expect(result).toContain("language-html");
+  expect(result).toContain("hljs-tag");
+});
+
+test("astro highlights template markup and expressions", () => {
+  hljs.registerLanguage(astro.name, astro.register);
+
+  const result = hljs.highlight(templateSnippet, { language: "astro" }).value;
+
+  expect(result).toContain("language-html");
+  expect(result).toContain("hljs-tag");
+  expect(result).toContain("language-javascript");
+  expect(result).toContain('<span class="hljs-attr">client:load</span>');
+  expect(result).not.toContain(
+    '<span class="hljs-variable">client:load</span>',
+  );
+});
+
+test("astro highlights style blocks as CSS", () => {
+  hljs.registerLanguage(astro.name, astro.register);
+
+  const result = hljs.highlight(styleSnippet, { language: "astro" }).value;
+
+  expect(result).toContain("language-css");
+  expect(result).toContain("hljs-selector-class");
+  expect(result).toContain("language-html");
+});
+
+test("astro highlights is:global and CSS universal selector", () => {
+  hljs.registerLanguage(astro.name, astro.register);
+
+  const result = hljs.highlight(globalWildcardSnippet, {
+    language: "astro",
+  }).value;
+
+  expect(result).toContain('<span class="hljs-attr">is:global</span>');
+  expect(result).toContain("hljs-attribute");
+  expect(result).toContain("language-css");
+  expect(result).toContain(
+    '<span class="hljs-tag">&lt;/<span class="hljs-name">style</span>&gt;</span>',
+  );
+});
+
+test("astro highlights colon attributes inside tags", () => {
+  hljs.registerLanguage(astro.name, astro.register);
+
+  const result = hljs.highlight(directiveAttrsSnippet, {
+    language: "astro",
+  }).value;
+
+  expect(result).toContain('<span class="hljs-attr">set:html</span>');
+  expect(result).toContain('<span class="hljs-attr">class:list</span>');
+  expect(result).not.toContain('<span class="hljs-variable">set:html</span>');
+  expect(result).not.toContain('hljs-tag">]}&gt;');
+  expect(result).toContain('language-javascript">{[<span class="hljs-string">');
+});
+
+test("html alone does not highlight Astro frontmatter or client directives", () => {
+  const isolated = hljs.newInstance();
+  isolated.registerLanguage(html.name, html.register);
+
+  const result = isolated.highlight(frontmatterSnippet, {
+    language: "html",
+  }).value;
+
+  expect(result).not.toContain("language-typescript");
+});

--- a/tests/e2e/Highlight.test.svelte
+++ b/tests/e2e/Highlight.test.svelte
@@ -1,11 +1,13 @@
 <script>
   import Highlight from "svelte-highlight";
+  import astro from "svelte-highlight/languages/astro";
   import html from "svelte-highlight/languages/html";
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
 
   let toggle = true;
   let showHtml = false;
+  let showAstro = false;
 
   const code = "const add = (a: number, b: number) => a + b;";
   const code2 =
@@ -13,6 +15,11 @@
     "$" +
     "{name}!" +
     "`;\n}";
+  const astroCode = `---
+export const title = "Page";
+---
+<h1>{title}</h1>
+<Counter client:load />`;
   const htmlCode = `<div id="content">
     <p>Paragraph one</p>
   </div>
@@ -30,8 +37,13 @@
 <button type="button" on:click={() => (showHtml = !showHtml)}>
   Toggle HTML
 </button>
+<button type="button" on:click={() => (showAstro = !showAstro)}>
+  Toggle Astro
+</button>
 
-{#if showHtml}
+{#if showAstro}
+  <Highlight langtag language={astro} code={astroCode} />
+{:else if showHtml}
   <Highlight langtag language={html} code={htmlCode} />
 {:else}
   <Highlight langtag language={typescript} code={toggle ? code : code2} />

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -35,6 +35,16 @@ test("Highlight - html language", async ({ mount, page }) => {
   );
 });
 
+test("Highlight - astro language", async ({ mount, page }) => {
+  await mount(Highlight);
+  await page.getByRole("button", { name: "Toggle Astro" }).click();
+  await expect(page.locator("pre")).toHaveAttribute("data-language", "astro");
+  await expect(
+    page.locator(".language-typescript .hljs-keyword").first(),
+  ).toHaveText("export");
+  await expect(page.locator(".hljs-attr")).toHaveText("client:load");
+});
+
 test("HighlightAuto", async ({ mount, page }) => {
   await mount(HighlightAuto);
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(194);
+  expect(languageNames.length).toEqual(195);
   expect(languageNames).toMatchSnapshot();
 });
 


### PR DESCRIPTION
Add custom language support for Astro, which is a mix of html/css/js/ts, with custom support for frontmatter.

---

<img width="934" height="383" alt="Screenshot 2026-06-01 at 3 29 55 PM" src="https://github.com/user-attachments/assets/6dc0d399-cee7-4320-aa02-d7c8dc72ab47" />
<img width="940" height="340" alt="Screenshot 2026-06-01 at 3 29 50 PM" src="https://github.com/user-attachments/assets/0290a79f-f271-43f9-a2dd-4eb3d95c0e38" />
<img width="948" height="233" alt="Screenshot 2026-06-01 at 3 22 09 PM" src="https://github.com/user-attachments/assets/c30b5c54-e355-4aae-8487-f149f442370c" />
<img width="976" height="240" alt="Screenshot 2026-06-01 at 3 22 01 PM" src="https://github.com/user-attachments/assets/2fc86436-fced-45cc-8f4f-ddd9f7d26a40" />
