### PR TITLE
chore(svelte): avoid directive highlighting in script block

### DIFF
--- a/scripts/custom-languages/svelte.js
+++ b/scripts/custom-languages/svelte.js
@@ -58,14 +58,9 @@ function defineSvelte(hljs) {
     },
     runePattern,
     storeSubscriptionPattern,
-    svelteDirective,
   ];
 
-  const commonPatterns = [
-    runePattern,
-    storeSubscriptionPattern,
-    svelteDirective,
-  ];
+  const commonPatterns = [runePattern, storeSubscriptionPattern];
 
   return {
     name: "Svelte",

--- a/tests/svelte-language.test.ts
+++ b/tests/svelte-language.test.ts
@@ -87,6 +87,23 @@ test("svelte highlights runes, event attributes, and block continuations", () =>
   expect(result).toContain('<span class="hljs-keyword">:else</span>');
 });
 
+test("svelte does not highlight directives inside script strings", () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const snippet = `<script>
+  const code = \`<button on:click={() => { console.log(0); }}>Click me</button>\`;
+</script>`;
+
+  const result = hljs.highlight(snippet, { language: "svelte" }).value;
+
+  expect(result).not.toMatch(
+    /<span class="hljs-string">[^<]*<\/span><span class="hljs-variable">on:<\/span>/,
+  );
+  expect(result).toContain(
+    '<span class="hljs-string">`&lt;button on:click={() =&gt; { console.log(0); }}&gt;Click me&lt;/button&gt;`</span>',
+  );
+});
+
 test("html alone does not highlight Svelte block syntax", () => {
   const isolated = hljs.newInstance();
   isolated.registerLanguage(html.name, html.register);


### PR DESCRIPTION
Follow-up fix for [#404](https://github.com/metonym/svelte-highlight/issues/404).

Not a "fix" since #404 isn't released yet.

Directives inside strings/template literals in the script block should not be highlighted. See below:

<img width="795" height="365" alt="Screenshot 2026-06-01 at 7 44 31 PM" src="https://github.com/user-attachments/assets/b7c7bec2-fef1-46d1-b427-f2f046886328" />
