### PR TITLE
fix(languages): `svelte` supports TypeScript in scripts/markup

### DIFF
--- a/scripts/custom-languages/svelte.js
+++ b/scripts/custom-languages/svelte.js
@@ -5,6 +5,19 @@ const RUNE_NAMES = "state|derived|effect|props|bindable|inspect|host";
 const RUNE_SUFFIXES = "raw|snapshot|by|eager";
 const SVELTE_DIRECTIVES =
   "on|bind|use|transition|in|out|animate|class|style|let";
+const TS_LANG = "(?:ts|typescript)";
+const SCRIPT_TS_BEGIN = new RegExp(
+  String.raw`<script(?=[^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
+  "gm",
+);
+const SCRIPT_JS_MODULE_BEGIN = new RegExp(
+  String.raw`<script(?=[^>]*(?:\scontext=["']module["']|\smodule\b))(?![^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
+  "gm",
+);
+const SCRIPT_JS_BEGIN = new RegExp(
+  String.raw`<script(?![^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
+  "gm",
+);
 
 /** @param {import("highlight.js").HLJSApi} hljs */
 function defineSvelte(hljs) {
@@ -70,26 +83,25 @@ function defineSvelte(hljs) {
       svelteDirective,
       svelteEventAttribute,
       {
-        begin:
-          /<script(?:\s+[^>]*context=["']module["']|\s+module)(?![^>]*lang=["']ts["'])[^>]*>/gm,
-        end: /<\/script>/gm,
-        subLanguage: "javascript",
-        excludeBegin: true,
-        excludeEnd: true,
-        contains: commonPatterns,
-      },
-      {
-        begin: /<script(?!.*lang=["']ts["'])[^>]*>/gm,
-        end: /<\/script>/gm,
-        subLanguage: "javascript",
-        excludeBegin: true,
-        excludeEnd: true,
-        contains: commonPatterns,
-      },
-      {
-        begin: /<script\s+lang=["']ts["'][^>]*>/gm,
+        begin: SCRIPT_TS_BEGIN,
         end: /<\/script>/gm,
         subLanguage: "typescript",
+        excludeBegin: true,
+        excludeEnd: true,
+        contains: commonPatterns,
+      },
+      {
+        begin: SCRIPT_JS_MODULE_BEGIN,
+        end: /<\/script>/gm,
+        subLanguage: "javascript",
+        excludeBegin: true,
+        excludeEnd: true,
+        contains: commonPatterns,
+      },
+      {
+        begin: SCRIPT_JS_BEGIN,
+        end: /<\/script>/gm,
+        subLanguage: "javascript",
         excludeBegin: true,
         excludeEnd: true,
         contains: commonPatterns,
@@ -104,7 +116,7 @@ function defineSvelte(hljs) {
       {
         begin: /\{/,
         end: /\}/,
-        subLanguage: "javascript",
+        subLanguage: "typescript",
         contains: expressionPatterns,
       },
     ],

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -60,7 +60,7 @@ test("SvelteHighlight", async ({ mount, page }) => {
   await mount(SvelteHighlight);
   await expect(page.locator("pre")).toHaveAttribute("data-language", "svelte");
   await expect(page.locator(".hljs-variable").first()).toHaveText("on:");
-  await expect(page.locator(".language-javascript")).toBeVisible();
+  await expect(page.locator(".language-typescript")).toBeVisible();
   await expect(page.locator(".hljs-variable.language_")).toHaveText("console");
 });
 

--- a/tests/svelte-language.test.ts
+++ b/tests/svelte-language.test.ts
@@ -39,6 +39,35 @@ const svelte5Snippet = `<script>
   <p>few</p>
 {/if}`;
 
+const moduleTypescriptSnippet = `<script lang="ts" context="module">
+  export const x: number = 1;
+</script>`;
+
+const langTypescriptSnippet = `<script lang="typescript">
+  let count: number = 0;
+</script>`;
+
+const declarationTagsSnippet = `<script lang="ts">
+  type Box = { width: number; height: number };
+
+  let boxes: Box[] = [
+    { width: 3, height: 4 },
+    { width: 5, height: 7 },
+  ];
+</script>
+
+{#each boxes as box}
+  {const area = box.width * box.height}
+  {let label: number = $state(\`\${area} square pixels\`)}
+  {const doubled: string = area * 2}
+
+  <p>{doubled === 1} {label === "large"}</p>
+  <div>
+    {const area = "nested"}
+    {area}
+  </div>
+{/each}`;
+
 test("svelte highlights embedded JavaScript, CSS, and expressions", () => {
   hljs.registerLanguage(svelte.name, svelte.register);
 
@@ -72,6 +101,43 @@ test("svelte highlights TypeScript script blocks", () => {
 
   expect(result).toContain("language-typescript");
   expect(result).toContain("hljs-keyword");
+});
+
+test("svelte highlights module TypeScript script blocks", () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const result = hljs.highlight(moduleTypescriptSnippet, {
+    language: "svelte",
+  }).value;
+
+  expect(result).toContain("language-typescript");
+  expect(result).toContain('<span class="hljs-built_in">number</span>');
+});
+
+test('svelte highlights script blocks with lang="typescript"', () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const result = hljs.highlight(langTypescriptSnippet, {
+    language: "svelte",
+  }).value;
+
+  expect(result).toContain("language-typescript");
+  expect(result).toContain('<span class="hljs-built_in">number</span>');
+});
+
+test("svelte highlights declaration tags with TypeScript in markup", () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const result = hljs.highlight(declarationTagsSnippet, {
+    language: "svelte",
+  }).value;
+
+  expect(result).toContain("language-typescript");
+  expect(result).toContain('<span class="hljs-keyword">const</span>');
+  expect(result).toContain('<span class="hljs-keyword">let</span>');
+  expect(result).toContain('<span class="hljs-keyword">$state</span>');
+  expect(result).toContain('<span class="hljs-built_in">number</span>');
+  expect(result).toContain('<span class="hljs-built_in">string</span>');
 });
 
 test("svelte highlights runes, event attributes, and block continuations", () => {


### PR DESCRIPTION
Follow-up to #404, which added a custom `svelte` language grammar (more accurate, modern).

However, it's lacking accuracy for TypeScript, both inside script blocks and markup. This improves the grammar further.

---

## Before

<img width="2966" height="32766" alt="before" src="https://github.com/user-attachments/assets/fbd6de44-2a6f-4fdd-9d29-b05609db74f6" />

## After
<img width="2966" height="32766" alt="after" src="https://github.com/user-attachments/assets/c9f59da8-61e6-451a-8adb-814d72016689" />
