### PR TITLE
fix: inline theme background images in generated `highlight.js` styles

### DIFF
--- a/scripts/build-styles.ts
+++ b/scripts/build-styles.ts
@@ -1,11 +1,11 @@
 import path from "node:path";
 import { $, Glob } from "bun";
 import { createMarkdown } from "./utils/create-markdown.ts";
+import { inlineCssUrls } from "./utils/inline-css-urls.ts";
 import { postcssScopedStyles } from "./utils/postcss-scoped-styles.ts";
 import { preprocessStyles } from "./utils/preprocess-styles.ts";
 import {
   BACKTICK,
-  CSS_FILE,
   DEFAULT_STRING,
   NON_MINIFIED_CSS,
   STARTS_WITH_DIGIT,
@@ -24,7 +24,6 @@ export async function buildStyles() {
   let styles: ModuleNames = [];
 
   const glob = new Glob("**/*");
-  const copyCommands: string[] = [];
 
   const cssFiles: Array<{
     file: string;
@@ -55,22 +54,13 @@ export async function buildStyles() {
       seenNames.add(name);
       styles.push({ name, moduleName });
       cssFiles.push({ file, absPath, name, dir, moduleName });
-    } else {
-      if (!CSS_FILE.test(file)) {
-        copyCommands.push(absPath);
-      }
     }
-  }
-
-  if (copyCommands.length > 0) {
-    await Promise.all(
-      copyCommands.map((absPath) => $`cp ${absPath} src/styles/`),
-    );
   }
 
   const fileWrites = await Promise.all(
     cssFiles.map(async ({ absPath, name, moduleName }) => {
-      const content = await Bun.file(absPath).text();
+      const raw = await Bun.file(absPath).text();
+      const content = await inlineCssUrls(raw, path.dirname(absPath));
 
       const cssMinified = preprocessStyles(content, {
         discardComments: "preserve-license",

--- a/scripts/utils/inline-css-urls.ts
+++ b/scripts/utils/inline-css-urls.ts
@@ -2,21 +2,27 @@ import path from "node:path";
 
 const RELATIVE_URL = /url\(\.\/([^)]+)\)/g;
 
-const MIME_TYPES: Record<string, string> = {
+const MIME_TYPES = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
   ".png": "image/png",
   ".gif": "image/gif",
   ".svg": "image/svg+xml",
   ".webp": "image/webp",
-};
+} as const;
+
+type ImageExtension = keyof typeof MIME_TYPES;
+
+function isImageExtension(ext: string): ext is ImageExtension {
+  return ext.toLowerCase() in MIME_TYPES;
+}
 
 export function mimeFromExt(ext: string): string {
-  const mime = MIME_TYPES[ext.toLowerCase()];
-  if (!mime) {
+  const normalized = ext.toLowerCase();
+  if (!isImageExtension(normalized)) {
     throw new Error(`Unsupported image extension: ${ext}`);
   }
-  return mime;
+  return MIME_TYPES[normalized];
 }
 
 /**
@@ -30,7 +36,13 @@ export async function inlineCssUrls(
   const matches = [...css.matchAll(RELATIVE_URL)];
   if (matches.length === 0) return css;
 
-  const uniqueFilenames = [...new Set(matches.map((match) => match[1]))];
+  const uniqueFilenames = [
+    ...new Set(
+      matches
+        .map((match) => match[1])
+        .filter((filename): filename is string => filename !== undefined),
+    ),
+  ];
   const dataUrls = await Promise.all(
     uniqueFilenames.map(async (filename) => {
       const filePath = path.join(baseDir, filename);

--- a/scripts/utils/inline-css-urls.ts
+++ b/scripts/utils/inline-css-urls.ts
@@ -1,0 +1,59 @@
+import path from "node:path";
+
+const RELATIVE_URL = /url\(\.\/([^)]+)\)/g;
+
+const MIME_TYPES: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".svg": "image/svg+xml",
+  ".webp": "image/webp",
+};
+
+export function mimeFromExt(ext: string): string {
+  const mime = MIME_TYPES[ext.toLowerCase()];
+  if (!mime) {
+    throw new Error(`Unsupported image extension: ${ext}`);
+  }
+  return mime;
+}
+
+/**
+ * Replaces relative `url(./filename)` references with base64 data URLs.
+ * Reads assets from `baseDir` (the highlight.js styles directory for each theme).
+ */
+export async function inlineCssUrls(
+  css: string,
+  baseDir: string,
+): Promise<string> {
+  const matches = [...css.matchAll(RELATIVE_URL)];
+  if (matches.length === 0) return css;
+
+  const uniqueFilenames = [...new Set(matches.map((match) => match[1]))];
+  const dataUrls = await Promise.all(
+    uniqueFilenames.map(async (filename) => {
+      const filePath = path.join(baseDir, filename);
+      const file = Bun.file(filePath);
+
+      if (!(await file.exists())) {
+        throw new Error(`CSS references missing asset: ${filePath}`);
+      }
+
+      const buffer = await file.arrayBuffer();
+      const base64 = Buffer.from(buffer).toString("base64");
+      const mime = mimeFromExt(path.extname(filename));
+      return {
+        filename,
+        dataUrl: `url(data:${mime};base64,${base64})`,
+      };
+    }),
+  );
+
+  let result = css;
+  for (const { filename, dataUrl } of dataUrls) {
+    result = result.replaceAll(`url(./${filename})`, dataUrl);
+  }
+
+  return result;
+}

--- a/tests/inline-css-urls.test.ts
+++ b/tests/inline-css-urls.test.ts
@@ -1,0 +1,55 @@
+import { mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import path from "node:path";
+import { inlineCssUrls, mimeFromExt } from "../scripts/utils/inline-css-urls";
+
+describe("mimeFromExt", () => {
+  it("returns mime type for known extensions", () => {
+    expect(mimeFromExt(".png")).toBe("image/png");
+    expect(mimeFromExt(".jpg")).toBe("image/jpeg");
+    expect(mimeFromExt(".JPEG")).toBe("image/jpeg");
+  });
+
+  it("throws for unknown extensions", () => {
+    expect(() => mimeFromExt(".bmp")).toThrow("Unsupported image extension");
+  });
+});
+
+describe("inlineCssUrls", () => {
+  let fixtureDir: string;
+
+  beforeEach(async () => {
+    fixtureDir = await mkdtemp(path.join(tmpdir(), "inline-css-urls-"));
+  });
+
+  afterEach(async () => {
+    await rm(fixtureDir, { recursive: true, force: true });
+  });
+
+  it("passes through CSS without relative URLs", async () => {
+    const css = ".hljs { color: red; }";
+    expect(await inlineCssUrls(css, fixtureDir)).toBe(css);
+  });
+
+  it("inlines relative url(./...) references as data URLs", async () => {
+    const pngBytes = Buffer.from(
+      "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8BQDwAEhQGAhKmMIQAAAABJRU5ErkJggg==",
+      "base64",
+    );
+    await writeFile(path.join(fixtureDir, "fixture.png"), pngBytes);
+
+    const css = ".hljs { background: url(./fixture.png); }";
+    const result = await inlineCssUrls(css, fixtureDir);
+
+    expect(result).not.toContain("url(./fixture.png)");
+    expect(result).toContain("url(data:image/png;base64,");
+    expect(result).toContain(pngBytes.toString("base64"));
+  });
+
+  it("throws when a referenced asset is missing", async () => {
+    const css = ".hljs { background: url(./missing.png); }";
+    await expect(inlineCssUrls(css, fixtureDir)).rejects.toThrow(
+      "CSS references missing asset",
+    );
+  });
+});


### PR DESCRIPTION
`pojoaque` and `brown-paper` reference `url(./...)` assets that break when CSS is bundled into `www/data/scoped-styles.css` or injected via `{@html}`. Inline them as base64 during `build:lib` so all outputs are self-contained and Vite no longer warns at Astro build time.