### PR TITLE
feat: add more custom languages (Vue, Marko, MDX)

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 196 languages exported from highlight.js@11.11.1
+> 197 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1299,6 +1299,20 @@
 
   // base import
   import { maxima } from "svelte-highlight/languages";
+</script>
+```
+
+## mdx (`mdx`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import mdx from "svelte-highlight/languages/mdx";
+
+  // base import
+  import { mdx } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 197 languages exported from highlight.js@11.11.1
+> 198 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1263,6 +1263,20 @@
 
   // base import
   import { markdown } from "svelte-highlight/languages";
+</script>
+```
+
+## marko (`marko`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import marko from "svelte-highlight/languages/marko";
+
+  // base import
+  import { marko } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 195 languages exported from highlight.js@11.11.1
+> 196 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2249,6 +2249,20 @@
 
   // base import
   import { vim } from "svelte-highlight/languages";
+</script>
+```
+
+## vue (`vue`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import vue from "svelte-highlight/languages/vue";
+
+  // base import
+  import { vue } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -38,6 +38,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "mdx",
     path: `${import.meta.dir}/custom-languages/mdx.js`,
   },
+  {
+    name: "marko",
+    moduleName: "marko",
+    path: `${import.meta.dir}/custom-languages/marko.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -28,6 +28,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "svelte",
     path: `${import.meta.dir}/custom-languages/svelte.js`,
   },
+  {
+    name: "vue",
+    moduleName: "vue",
+    path: `${import.meta.dir}/custom-languages/vue.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -33,6 +33,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "vue",
     path: `${import.meta.dir}/custom-languages/vue.js`,
   },
+  {
+    name: "mdx",
+    moduleName: "mdx",
+    path: `${import.meta.dir}/custom-languages/mdx.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/custom-languages/marko.js
+++ b/scripts/custom-languages/marko.js
@@ -1,0 +1,86 @@
+import cssRegister from "highlight.js/lib/languages/css";
+import javascriptRegister from "highlight.js/lib/languages/javascript";
+import typescriptRegister from "highlight.js/lib/languages/typescript";
+import html from "./html.js";
+
+const TS_LANG = "(?:ts|typescript)";
+const SCRIPT_TS_BEGIN = new RegExp(
+  String.raw`<script(?=[^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
+  "gm",
+);
+const SCRIPT_JS_BEGIN = new RegExp(
+  String.raw`<script(?![^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
+  "gm",
+);
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineMarko(hljs) {
+  const markoControlFlow = {
+    begin: /^\s*(?:if|else if|else|for|while)\b/m,
+    className: "keyword",
+    relevance: 10,
+  };
+
+  const markoEventAttribute = {
+    begin: /\bon-(?:[\w.-]+|\[[\w.-]+\])(?=[=(\s/>])/,
+    className: "variable",
+    relevance: 5,
+  };
+
+  return {
+    name: "Marko",
+    subLanguage: "html",
+    contains: [
+      hljs.COMMENT(/<!--/, /-->/, { relevance: 10 }),
+      markoControlFlow,
+      markoEventAttribute,
+      {
+        begin: SCRIPT_TS_BEGIN,
+        end: /<\/script>/gm,
+        subLanguage: "typescript",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: SCRIPT_JS_BEGIN,
+        end: /<\/script>/gm,
+        subLanguage: "javascript",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: /^(\s*)(<style[^>]*>)/gm,
+        end: /^(\s*)(<\/style>)/gm,
+        subLanguage: "css",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: /\$\{/,
+        end: /\}/,
+        subLanguage: "javascript",
+        relevance: 10,
+      },
+      {
+        begin: /^class\s*\{/m,
+        end: /^\}/m,
+        subLanguage: "javascript",
+        excludeBegin: true,
+        excludeEnd: true,
+        relevance: 100,
+      },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  hljs.registerLanguage("html", html.register);
+  hljs.registerLanguage("typescript", typescriptRegister);
+  hljs.registerLanguage("javascript", javascriptRegister);
+  hljs.registerLanguage("css", cssRegister);
+  return defineMarko(hljs);
+}
+
+export const marko = { name: "marko", register };
+export default marko;

--- a/scripts/custom-languages/mdx.js
+++ b/scripts/custom-languages/mdx.js
@@ -1,0 +1,92 @@
+import cssRegister from "highlight.js/lib/languages/css";
+import javascriptRegister from "highlight.js/lib/languages/javascript";
+import html from "./html.js";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineMdx(hljs) {
+  return {
+    name: "MDX",
+    aliases: ["mdx"],
+    contains: [
+      hljs.COMMENT(/<!--/, /-->/, { relevance: 10 }),
+      {
+        begin: /^(?:import|export)\b/m,
+        end: /;?\s*$/m,
+        subLanguage: "javascript",
+        relevance: 100,
+      },
+      {
+        begin: /^(\s*)(```)([\s\S]*?)(```)/m,
+        beginScope: { 2: "string", 3: "code" },
+        relevance: 10,
+      },
+      {
+        begin: /^(\s*)(<style[^>]*>)/gm,
+        end: /^(\s*)(<\/style>)/gm,
+        subLanguage: "css",
+        excludeBegin: true,
+        excludeEnd: true,
+        relevance: 100,
+      },
+      {
+        begin: /^(\s*)(<script[^>]*>)/gm,
+        end: /^(\s*)(<\/script>)/gm,
+        subLanguage: "javascript",
+        excludeBegin: true,
+        excludeEnd: true,
+        relevance: 100,
+      },
+      {
+        begin: /<(?=[A-Za-z/!])/,
+        end: />|\/>/,
+        subLanguage: "html",
+        relevance: 10,
+      },
+      {
+        begin: /\{/,
+        end: /\}/,
+        subLanguage: "javascript",
+        contains: /** @type {(import("highlight.js").Mode | "self")[]} */ ([
+          "self",
+        ]),
+        relevance: 10,
+      },
+      {
+        begin: /^#{1,6}\s+/m,
+        className: "section",
+        relevance: 10,
+      },
+      {
+        begin: /^\s*[-*+]\s+/m,
+        className: "bullet",
+        relevance: 5,
+      },
+      {
+        begin: /^\s*\d+\.\s+/m,
+        className: "number",
+        relevance: 5,
+      },
+      {
+        begin: /`[^`\n]+`/,
+        className: "string",
+        relevance: 5,
+      },
+      {
+        begin: /\*\*[^*\n]+\*\*/,
+        className: "strong",
+        relevance: 5,
+      },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  hljs.registerLanguage("html", html.register);
+  hljs.registerLanguage("javascript", javascriptRegister);
+  hljs.registerLanguage("css", cssRegister);
+  return defineMdx(hljs);
+}
+
+export const mdx = { name: "mdx", register };
+export default mdx;

--- a/scripts/custom-languages/vue.js
+++ b/scripts/custom-languages/vue.js
@@ -1,0 +1,126 @@
+import cssRegister from "highlight.js/lib/languages/css";
+import javascriptRegister from "highlight.js/lib/languages/javascript";
+import lessRegister from "highlight.js/lib/languages/less";
+import scssRegister from "highlight.js/lib/languages/scss";
+import stylusRegister from "highlight.js/lib/languages/stylus";
+import typescriptRegister from "highlight.js/lib/languages/typescript";
+import html from "./html.js";
+
+const TS_LANG = "(?:ts|typescript)";
+const SCRIPT_TS_BEGIN = new RegExp(
+  String.raw`<script(?=[^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
+  "gm",
+);
+const SCRIPT_JS_BEGIN = new RegExp(
+  String.raw`<script(?![^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
+  "gm",
+);
+const STYLE_SCSS_BEGIN = /<style(?=[^>]*\slang=["'](?:scss|sass)["'])[^>]*>/gm;
+const STYLE_LESS_BEGIN = /<style(?=[^>]*\slang=["']less["'])[^>]*>/gm;
+const STYLE_STYLUS_BEGIN = /<style(?=[^>]*\slang=["']stylus["'])[^>]*>/gm;
+const STYLE_CSS_BEGIN =
+  /<style(?![^>]*\slang=["'](?:scss|sass|less|stylus)["'])[^>]*>/gm;
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineVue(hljs) {
+  const vueDirective = {
+    begin:
+      /\bv-(?:if|else-if|else|for|show|model|bind|on|slot|pre|once|memo|html|text|cloak)(?:\.[\w-]+)*(?==|\s|>)/,
+    className: "keyword",
+    relevance: 10,
+  };
+
+  const vueEventAttribute = {
+    begin: /@(?:[\w.$-]+|\[[\w.$-]+\])(?==)/,
+    className: "variable",
+    relevance: 5,
+  };
+
+  const vueBindShorthand = {
+    begin: /:(?:[\w.$-]+|\[[\w.$-]+\])(?==)/,
+    className: "variable",
+    relevance: 5,
+  };
+
+  const vueSlotShorthand = {
+    begin: /#(?:[\w.$-]+|\[[\w.$-]+\])(?==)/,
+    className: "variable",
+    relevance: 5,
+  };
+
+  return {
+    name: "Vue",
+    aliases: ["vue-sfc"],
+    subLanguage: "html",
+    contains: [
+      hljs.COMMENT(/<!--/, /-->/, { relevance: 10 }),
+      vueDirective,
+      vueEventAttribute,
+      vueBindShorthand,
+      vueSlotShorthand,
+      {
+        begin: SCRIPT_TS_BEGIN,
+        end: /<\/script>/gm,
+        subLanguage: "typescript",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: SCRIPT_JS_BEGIN,
+        end: /<\/script>/gm,
+        subLanguage: "javascript",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: STYLE_SCSS_BEGIN,
+        end: /^(\s*)(<\/style>)/gm,
+        subLanguage: "scss",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: STYLE_LESS_BEGIN,
+        end: /^(\s*)(<\/style>)/gm,
+        subLanguage: "less",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: STYLE_STYLUS_BEGIN,
+        end: /^(\s*)(<\/style>)/gm,
+        subLanguage: "stylus",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: STYLE_CSS_BEGIN,
+        end: /^(\s*)(<\/style>)/gm,
+        subLanguage: "css",
+        excludeBegin: true,
+        excludeEnd: true,
+      },
+      {
+        begin: /\{\{/,
+        end: /\}\}/,
+        subLanguage: "javascript",
+        relevance: 10,
+      },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  hljs.registerLanguage("html", html.register);
+  hljs.registerLanguage("typescript", typescriptRegister);
+  hljs.registerLanguage("javascript", javascriptRegister);
+  hljs.registerLanguage("css", cssRegister);
+  hljs.registerLanguage("scss", scssRegister);
+  hljs.registerLanguage("less", lessRegister);
+  hljs.registerLanguage("stylus", stylusRegister);
+  return defineVue(hljs);
+}
+
+export const vue = { name: "vue", register };
+export default vue;

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -107,6 +107,7 @@ exports[`Languages 1`] = `
   "lua",
   "makefile",
   "markdown",
+  "marko",
   "mathematica",
   "matlab",
   "maxima",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -110,6 +110,7 @@ exports[`Languages 1`] = `
   "mathematica",
   "matlab",
   "maxima",
+  "mdx",
   "mel",
   "mercury",
   "mipsasm",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -189,6 +189,7 @@ exports[`Languages 1`] = `
   "verilog",
   "vhdl",
   "vim",
+  "vue",
   "wasm",
   "wren",
   "x86asm",

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(195);
+  expect(languageNames.length).toEqual(196);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(196);
+  expect(languageNames.length).toEqual(197);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(197);
+  expect(languageNames.length).toEqual(198);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/marko-language.test.ts
+++ b/tests/marko-language.test.ts
@@ -1,0 +1,105 @@
+import hljs from "highlight.js/lib/core";
+import html from "svelte-highlight/languages/html";
+import marko from "../src/languages/marko";
+
+const expressionSnippet = `<div class=input.className>
+  Hello \${input.name}!
+</div>`;
+
+const scriptSnippet = `<script>
+module.exports = {
+  onCreate() {
+    this.state = { count: 0 };
+  },
+};
+</script>
+
+<button>\${state.count}</button>`;
+
+const styleSnippet = `<style>
+  .card { color: red; }
+</style>
+
+<div>Hi</div>`;
+
+const controlFlowSnippet = `<div>
+  if (condition)
+    p -- Yes
+  else
+    p -- No
+</div>`;
+
+const classComponentSnippet = `class {
+  onCreate() {
+    this.state = { count: 0 };
+  }
+}
+<button on-click('increment')>
+  \${state.count}
+</button>`;
+
+test("marko highlights dollar-brace expressions as JavaScript", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(expressionSnippet, {
+    language: "marko",
+  }).value;
+
+  expect(result).toContain("language-javascript");
+  expect(result).toContain("language-html");
+  expect(result).toContain("hljs-tag");
+});
+
+test("marko highlights script blocks as JavaScript", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(scriptSnippet, { language: "marko" }).value;
+
+  expect(result).toContain("language-javascript");
+  expect(result).toContain("hljs-title function_");
+});
+
+test("marko highlights style blocks as CSS", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(styleSnippet, { language: "marko" }).value;
+
+  expect(result).toContain("language-css");
+  expect(result).toContain("hljs-selector-class");
+  expect(result).toContain("language-html");
+});
+
+test("marko highlights control flow keywords", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(controlFlowSnippet, {
+    language: "marko",
+  }).value;
+
+  expect(result).toContain('<span class="hljs-keyword">');
+  expect(result).toContain("if</span>");
+  expect(result).toContain("else</span>");
+});
+
+test("marko highlights class components and event attributes", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(classComponentSnippet, {
+    language: "marko",
+  }).value;
+
+  expect(result).toContain("language-javascript");
+  expect(result).toContain('<span class="hljs-variable">on-click</span>');
+  expect(result).toContain("language-javascript");
+});
+
+test("html alone does not highlight marko expressions", () => {
+  const isolated = hljs.newInstance();
+  isolated.registerLanguage(html.name, html.register);
+
+  const result = isolated.highlight(expressionSnippet, {
+    language: "html",
+  }).value;
+
+  expect(result).not.toContain("language-javascript");
+});

--- a/tests/mdx-language.test.ts
+++ b/tests/mdx-language.test.ts
@@ -1,0 +1,78 @@
+import hljs from "highlight.js/lib/core";
+import markdown from "svelte-highlight/languages/markdown";
+import mdx from "../src/languages/mdx";
+
+const importSnippet = `import { Chart } from "./chart";
+
+# Hello MDX
+
+<Chart data={points} />`;
+
+const headingSnippet = `# Title
+
+Some **bold** text and \`inline code\`.`;
+
+const jsxSnippet = `<div className="card">
+  {items.map((item) => (
+    <p key={item.id}>{item.name}</p>
+  ))}
+</div>`;
+
+const listSnippet = `- first item
+- second item
+
+1. ordered
+2. list`;
+
+test("mdx highlights import statements as JavaScript", () => {
+  hljs.registerLanguage(mdx.name, mdx.register);
+
+  const result = hljs.highlight(importSnippet, { language: "mdx" }).value;
+
+  expect(result).toContain("language-javascript");
+  expect(result).toContain("hljs-keyword");
+  expect(result).toContain('<span class="hljs-section"># </span>');
+  expect(result).toContain("Hello MDX");
+});
+
+test("mdx highlights markdown headings and inline formatting", () => {
+  hljs.registerLanguage(mdx.name, mdx.register);
+
+  const result = hljs.highlight(headingSnippet, { language: "mdx" }).value;
+
+  expect(result).toContain('<span class="hljs-section"># </span>');
+  expect(result).toContain("Title");
+  expect(result).toContain('<span class="hljs-strong">');
+  expect(result).toContain('<span class="hljs-string">');
+});
+
+test("mdx highlights JSX and embedded JavaScript expressions", () => {
+  hljs.registerLanguage(mdx.name, mdx.register);
+
+  const result = hljs.highlight(jsxSnippet, { language: "mdx" }).value;
+
+  expect(result).toContain("language-html");
+  expect(result).toContain("hljs-tag");
+  expect(result).toContain("language-javascript");
+});
+
+test("mdx highlights markdown lists", () => {
+  hljs.registerLanguage(mdx.name, mdx.register);
+
+  const result = hljs.highlight(listSnippet, { language: "mdx" }).value;
+
+  expect(result).toContain('<span class="hljs-bullet">');
+  expect(result).toContain('<span class="hljs-number">');
+});
+
+test("markdown alone does not highlight JSX tags", () => {
+  const isolated = hljs.newInstance();
+  isolated.registerLanguage(markdown.name, markdown.register);
+
+  const result = isolated.highlight(jsxSnippet, {
+    language: "markdown",
+  }).value;
+
+  expect(result).not.toContain("language-html");
+  expect(result).not.toContain("hljs-tag");
+});

--- a/tests/vue-language.test.ts
+++ b/tests/vue-language.test.ts
@@ -1,0 +1,98 @@
+import hljs from "highlight.js/lib/core";
+import html from "svelte-highlight/languages/html";
+import vue from "../src/languages/vue";
+
+const scriptSetupSnippet = `<script setup lang="ts">
+const count = ref(0);
+</script>
+
+<template>
+  <button @click="count++">{{ count }}</button>
+</template>`;
+
+const templateSnippet = `<template>
+  <div v-if="visible" :class="{ active: isActive }">
+    <slot name="header" />
+  </div>
+</template>`;
+
+const styleSnippet = `<style scoped lang="scss">
+.card {
+  color: red;
+}
+</style>
+
+<p>Hi</p>`;
+
+const javascriptSnippet = `<script>
+export default {
+  data() {
+    return { count: 0 };
+  },
+};
+</script>`;
+
+test("vue highlights script setup as TypeScript", () => {
+  hljs.registerLanguage(vue.name, vue.register);
+
+  const result = hljs.highlight(scriptSetupSnippet, {
+    language: "vue",
+  }).value;
+
+  expect(result).toContain("language-typescript");
+  expect(result).toContain("hljs-keyword");
+  expect(result).toContain("language-html");
+});
+
+test("vue highlights template directives and mustache expressions", () => {
+  hljs.registerLanguage(vue.name, vue.register);
+
+  const result = hljs.highlight(templateSnippet, { language: "vue" }).value;
+
+  expect(result).toContain("language-html");
+  expect(result).toContain("hljs-tag");
+  expect(result).toContain('<span class="hljs-keyword">v-if</span>');
+  expect(result).toContain('<span class="hljs-variable">:class</span>');
+});
+
+test("vue highlights mustache expressions in templates", () => {
+  hljs.registerLanguage(vue.name, vue.register);
+
+  const result = hljs.highlight("<template><p>{{ message }}</p></template>", {
+    language: "vue",
+  }).value;
+
+  expect(result).toContain("language-javascript");
+  expect(result).toContain("{{ message }}");
+});
+
+test("vue highlights scss style blocks", () => {
+  hljs.registerLanguage(vue.name, vue.register);
+
+  const result = hljs.highlight(styleSnippet, { language: "vue" }).value;
+
+  expect(result).toContain("language-scss");
+  expect(result).toContain("hljs-selector-class");
+  expect(result).toContain("language-html");
+});
+
+test("vue highlights plain JavaScript script blocks", () => {
+  hljs.registerLanguage(vue.name, vue.register);
+
+  const result = hljs.highlight(javascriptSnippet, { language: "vue" }).value;
+
+  expect(result).toContain("language-javascript");
+  expect(result).toContain("hljs-keyword");
+});
+
+test("html alone does not highlight vue directives or mustache expressions", () => {
+  const isolated = hljs.newInstance();
+  isolated.registerLanguage(html.name, html.register);
+
+  const result = isolated.highlight(templateSnippet, {
+    language: "html",
+  }).value;
+
+  expect(result).not.toContain('<span class="hljs-keyword">v-if</span>');
+  expect(result).not.toContain("language-javascript");
+});

--- a/www/components/MarkoLanguagePreview.svelte
+++ b/www/components/MarkoLanguagePreview.svelte
@@ -1,0 +1,66 @@
+<script>
+  import { markoKitchenSink } from "@www/preview/marko-kitchen-sink";
+  import { markoPreviewSnippets } from "@www/preview/marko-preview-snippets";
+  import { previewThemes } from "@www/preview/preview-themes";
+  import { Column, Row } from "carbon-components-svelte";
+  import { Highlight } from "svelte-highlight";
+  import marko from "svelte-highlight/languages/marko";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+  import dracula from "svelte-highlight/styles/dracula";
+  import github from "svelte-highlight/styles/github";
+  import githubDark from "svelte-highlight/styles/github-dark";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+  import nord from "svelte-highlight/styles/nord";
+
+  /** @type {Record<string, string>} */
+  const themeCss = {
+    horizonDark,
+    atomOneDark,
+    githubDark,
+    dracula,
+    nord,
+    github,
+  };
+</script>
+
+<svelte:head>
+  {#each Object.values(themeCss) as css}
+    {@html css}
+  {/each}
+</svelte:head>
+
+{#each markoPreviewSnippets as snippet, index}
+  <Row class="mb-9">
+    <Column xlg={12}>
+      <h3>{index + 1}. {snippet.title}</h3>
+    </Column>
+    {#each previewThemes as theme}
+      <Column xlg={10} lg={10} md={12} class="mb-5">
+        <div class="label-01 mb-3">{theme.name}</div>
+        <Highlight
+          class={theme.moduleName}
+          language={marko}
+          code={snippet.code}
+          langtag
+        />
+      </Column>
+    {/each}
+  </Row>
+{/each}
+
+<Row class="mb-9">
+  <Column xlg={12}>
+    <h3>Kitchen sink</h3>
+  </Column>
+  {#each previewThemes as theme}
+    <Column xlg={10} lg={10} md={12} class="mb-5">
+      <div class="label-01 mb-3">{theme.name}</div>
+      <Highlight
+        class={theme.moduleName}
+        language={marko}
+        code={markoKitchenSink}
+        langtag
+      />
+    </Column>
+  {/each}
+</Row>

--- a/www/components/MdxLanguagePreview.svelte
+++ b/www/components/MdxLanguagePreview.svelte
@@ -1,0 +1,66 @@
+<script>
+  import { mdxKitchenSink } from "@www/preview/mdx-kitchen-sink";
+  import { mdxPreviewSnippets } from "@www/preview/mdx-preview-snippets";
+  import { previewThemes } from "@www/preview/preview-themes";
+  import { Column, Row } from "carbon-components-svelte";
+  import { Highlight } from "svelte-highlight";
+  import mdx from "svelte-highlight/languages/mdx";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+  import dracula from "svelte-highlight/styles/dracula";
+  import github from "svelte-highlight/styles/github";
+  import githubDark from "svelte-highlight/styles/github-dark";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+  import nord from "svelte-highlight/styles/nord";
+
+  /** @type {Record<string, string>} */
+  const themeCss = {
+    horizonDark,
+    atomOneDark,
+    githubDark,
+    dracula,
+    nord,
+    github,
+  };
+</script>
+
+<svelte:head>
+  {#each Object.values(themeCss) as css}
+    {@html css}
+  {/each}
+</svelte:head>
+
+{#each mdxPreviewSnippets as snippet, index}
+  <Row class="mb-9">
+    <Column xlg={12}>
+      <h3>{index + 1}. {snippet.title}</h3>
+    </Column>
+    {#each previewThemes as theme}
+      <Column xlg={10} lg={10} md={12} class="mb-5">
+        <div class="label-01 mb-3">{theme.name}</div>
+        <Highlight
+          class={theme.moduleName}
+          language={mdx}
+          code={snippet.code}
+          langtag
+        />
+      </Column>
+    {/each}
+  </Row>
+{/each}
+
+<Row class="mb-9">
+  <Column xlg={12}>
+    <h3>Kitchen sink</h3>
+  </Column>
+  {#each previewThemes as theme}
+    <Column xlg={10} lg={10} md={12} class="mb-5">
+      <div class="label-01 mb-3">{theme.name}</div>
+      <Highlight
+        class={theme.moduleName}
+        language={mdx}
+        code={mdxKitchenSink}
+        langtag
+      />
+    </Column>
+  {/each}
+</Row>

--- a/www/components/VueLanguagePreview.svelte
+++ b/www/components/VueLanguagePreview.svelte
@@ -1,0 +1,66 @@
+<script>
+  import { previewThemes } from "@www/preview/preview-themes";
+  import { vueKitchenSink } from "@www/preview/vue-kitchen-sink";
+  import { vuePreviewSnippets } from "@www/preview/vue-preview-snippets";
+  import { Column, Row } from "carbon-components-svelte";
+  import { Highlight } from "svelte-highlight";
+  import vue from "svelte-highlight/languages/vue";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+  import dracula from "svelte-highlight/styles/dracula";
+  import github from "svelte-highlight/styles/github";
+  import githubDark from "svelte-highlight/styles/github-dark";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+  import nord from "svelte-highlight/styles/nord";
+
+  /** @type {Record<string, string>} */
+  const themeCss = {
+    horizonDark,
+    atomOneDark,
+    githubDark,
+    dracula,
+    nord,
+    github,
+  };
+</script>
+
+<svelte:head>
+  {#each Object.values(themeCss) as css}
+    {@html css}
+  {/each}
+</svelte:head>
+
+{#each vuePreviewSnippets as snippet, index}
+  <Row class="mb-9">
+    <Column xlg={12}>
+      <h3>{index + 1}. {snippet.title}</h3>
+    </Column>
+    {#each previewThemes as theme}
+      <Column xlg={10} lg={10} md={12} class="mb-5">
+        <div class="label-01 mb-3">{theme.name}</div>
+        <Highlight
+          class={theme.moduleName}
+          language={vue}
+          code={snippet.code}
+          langtag
+        />
+      </Column>
+    {/each}
+  </Row>
+{/each}
+
+<Row class="mb-9">
+  <Column xlg={12}>
+    <h3>Kitchen sink</h3>
+  </Column>
+  {#each previewThemes as theme}
+    <Column xlg={10} lg={10} md={12} class="mb-5">
+      <div class="label-01 mb-3">{theme.name}</div>
+      <Highlight
+        class={theme.moduleName}
+        language={vue}
+        code={vueKitchenSink}
+        langtag
+      />
+    </Column>
+  {/each}
+</Row>

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -32,6 +32,7 @@
   const hiddenRoutes = {
     "/preview-svelte": "Svelte language preview",
     "/preview-vue": "Vue language preview",
+    "/preview-mdx": "MDX language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -33,6 +33,7 @@
     "/preview-svelte": "Svelte language preview",
     "/preview-vue": "Vue language preview",
     "/preview-mdx": "MDX language preview",
+    "/preview-marko": "Marko language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -31,6 +31,7 @@
   /** @type {Record<string, string>} */
   const hiddenRoutes = {
     "/preview-svelte": "Svelte language preview",
+    "/preview-vue": "Vue language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/pages/preview-marko.astro
+++ b/www/pages/preview-marko.astro
@@ -1,0 +1,8 @@
+---
+import MarkoLanguagePreview from "@components/MarkoLanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Marko language preview">
+  <MarkoLanguagePreview client:idle />
+</Layout>

--- a/www/pages/preview-mdx.astro
+++ b/www/pages/preview-mdx.astro
@@ -1,0 +1,8 @@
+---
+import MdxLanguagePreview from "@components/MdxLanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="MDX language preview">
+  <MdxLanguagePreview client:idle />
+</Layout>

--- a/www/pages/preview-vue.astro
+++ b/www/pages/preview-vue.astro
@@ -1,0 +1,8 @@
+---
+import VueLanguagePreview from "@components/VueLanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Vue language preview">
+  <VueLanguagePreview client:idle />
+</Layout>

--- a/www/preview/marko-kitchen-sink.ts
+++ b/www/preview/marko-kitchen-sink.ts
@@ -1,0 +1,58 @@
+export const markoKitchenSink = `class {
+  onCreate() {
+    this.state = {
+      count: 0,
+      name: "",
+      visible: true,
+    };
+  }
+
+  increment() {
+    this.state.count += 1;
+  }
+
+  submit() {
+    console.log(this.state.name);
+  }
+}
+
+<script lang="ts">
+type Item = { id: number; label: string };
+
+export function formatItem(item: Item): string {
+  return \`\${item.id}: \${item.label}\`;
+}
+</script>
+
+<style>
+  .card {
+    padding: 1rem;
+    border: 1px solid #ccc;
+  }
+
+  .active {
+    font-weight: bold;
+  }
+</style>
+
+<!-- Marko template with expressions and control flow -->
+<div class=["card", state.visible && "active"]>
+  if (state.visible)
+    h1 -- \${input.title || "Untitled"}
+
+  input type="text" value=state.name on-input("updateName") /
+  button on-click("increment") -- Count: \${state.count}
+  button on-click("submit") -- Submit
+
+  if (state.count === 0)
+    p -- Start counting
+  else if (state.count < 5)
+    p -- Getting started
+  else
+    p -- \${state.count} clicks
+
+  for (const item of input.items)
+    li -- \${formatItem(item)}
+
+  span -- Hello \${state.name || "Anonymous"}!
+</div>`;

--- a/www/preview/marko-preview-snippets.ts
+++ b/www/preview/marko-preview-snippets.ts
@@ -1,0 +1,76 @@
+export type MarkoPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const markoPreviewSnippets: MarkoPreviewSnippet[] = [
+  {
+    title: "Dollar-brace expressions",
+    description: "Dollar-brace expressions in markup",
+    code: `<div class=input.className>
+  Hello \${input.name}!
+</div>`,
+  },
+  {
+    title: "Script block",
+    description: "<script> with CommonJS or ES module code",
+    code: `<script>
+module.exports = {
+  onCreate() {
+    this.state = { count: 0 };
+  },
+  increment() {
+    this.state.count += 1;
+  },
+};
+</script>
+
+<button on-click('increment')>
+  \${state.count}
+</button>`,
+  },
+  {
+    title: "TypeScript script block",
+    description: '<script lang="ts">',
+    code: `<script lang="ts">
+type Item = { id: number; label: string };
+
+export function formatItem(item: Item): string {
+  return \`\${item.id}: \${item.label}\`;
+}
+</script>`,
+  },
+  {
+    title: "Control flow",
+    description: "if / else blocks in Marko templates",
+    code: `<div>
+  if (condition)
+    p -- Yes
+  else
+    p -- No
+</div>`,
+  },
+  {
+    title: "Class component and styles",
+    description: "class { } syntax with CSS block",
+    code: `class {
+  onCreate() {
+    this.state = { count: 0 };
+  }
+  increment() {
+    this.state.count += 1;
+  }
+}
+
+<style>
+  .card {
+    color: red;
+  }
+</style>
+
+<div class="card">
+  \${state.count}
+</div>`,
+  },
+];

--- a/www/preview/mdx-kitchen-sink.ts
+++ b/www/preview/mdx-kitchen-sink.ts
@@ -1,0 +1,60 @@
+export const mdxKitchenSink = `import { Tabs, TabItem } from "@components/Tabs";
+import { Chart } from "./chart";
+import type { Point } from "./types";
+
+export const meta = {
+  title: "Kitchen sink",
+  description: "MDX grammar preview",
+};
+
+# {meta.title}
+
+Welcome to the **MDX** preview. This page mixes \`markdown\`, JSX, and JavaScript.
+
+## Features
+
+- import / export statements
+- **bold** and \`inline code\`
+- JSX components
+- {expressions} in prose
+
+## Counter
+
+export const initialCount = 0;
+
+The current count is **{count}**.
+
+<button onClick={() => setCount((c) => c + 1)}>Increment</button>
+
+## Chart
+
+<Chart
+  data={[
+    { x: 0, y: 1 },
+    { x: 1, y: 3 },
+    { x: 2, y: 2 },
+  ]}
+  title={meta.title}
+/>
+
+## Code sample
+
+\`\`\`javascript
+const total = items.reduce((sum, item) => sum + item.value, 0);
+console.log(\`Total: \${total}\`);
+\`\`\`
+
+## List rendering
+
+<ul>
+  {["alpha", "beta", "gamma"].map((label) => (
+    <li key={label}>{label.toUpperCase()}</li>
+  ))}
+</ul>
+
+<Tabs>
+  <TabItem label="One">First tab</TabItem>
+  <TabItem label="Two">Second tab</TabItem>
+</Tabs>
+
+<!-- HTML comments are preserved -->`;

--- a/www/preview/mdx-preview-snippets.ts
+++ b/www/preview/mdx-preview-snippets.ts
@@ -1,0 +1,68 @@
+export type MdxPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const mdxPreviewSnippets: MdxPreviewSnippet[] = [
+  {
+    title: "Import and export statements",
+    description: "ESM frontmatter at the top of MDX files",
+    code: `import { Chart } from "./chart";
+import type { Point } from "./types";
+
+export const title = "Dashboard";
+
+# {title}`,
+  },
+  {
+    title: "Markdown headings and formatting",
+    description: "Headings, bold, inline code, and lists",
+    code: `# Getting started
+
+Some **bold** text and \`inline code\`.
+
+- first item
+- second item
+
+1. ordered
+2. list`,
+  },
+  {
+    title: "JSX components",
+    description: "Embedded HTML/JSX with props",
+    code: `<Card title="Hello">
+  <p>Welcome to the docs.</p>
+</Card>
+
+<Alert variant="warning">
+  Remember to save your work.
+</Alert>`,
+  },
+  {
+    title: "JavaScript expressions",
+    description: "Inline {expressions} in prose and JSX",
+    code: `# Stats
+
+The total is {items.length} items.
+
+<ul>
+  {items.map((item) => (
+    <li key={item.id}>{item.name}</li>
+  ))}
+</ul>`,
+  },
+  {
+    title: "Fenced code block",
+    description: "Triple-backtick code fences in MDX",
+    code: `# Example
+
+\`\`\`typescript
+type User = { id: string; name: string };
+
+export function greet(user: User): string {
+  return \`Hello, \${user.name}\`;
+}
+\`\`\``,
+  },
+];

--- a/www/preview/preview-themes.ts
+++ b/www/preview/preview-themes.ts
@@ -1,0 +1,13 @@
+export type PreviewTheme = {
+  name: string;
+  moduleName: string;
+};
+
+export const previewThemes: PreviewTheme[] = [
+  { name: "horizon-dark", moduleName: "horizonDark" },
+  { name: "atom-one-dark", moduleName: "atomOneDark" },
+  { name: "github-dark", moduleName: "githubDark" },
+  { name: "dracula", moduleName: "dracula" },
+  { name: "nord", moduleName: "nord" },
+  { name: "github", moduleName: "github" },
+];

--- a/www/preview/svelte-preview-themes.ts
+++ b/www/preview/svelte-preview-themes.ts
@@ -1,13 +1,3 @@
-export type SveltePreviewTheme = {
-  name: string;
-  moduleName: string;
-};
+export type SveltePreviewTheme = import("./preview-themes").PreviewTheme;
 
-export const sveltePreviewThemes: SveltePreviewTheme[] = [
-  { name: "horizon-dark", moduleName: "horizonDark" },
-  { name: "atom-one-dark", moduleName: "atomOneDark" },
-  { name: "github-dark", moduleName: "githubDark" },
-  { name: "dracula", moduleName: "dracula" },
-  { name: "nord", moduleName: "nord" },
-  { name: "github", moduleName: "github" },
-];
+export { previewThemes as sveltePreviewThemes } from "./preview-themes.ts";

--- a/www/preview/vue-kitchen-sink.ts
+++ b/www/preview/vue-kitchen-sink.ts
@@ -1,0 +1,101 @@
+export const vueKitchenSink = `<script setup lang="ts">
+import { computed, onMounted, ref, watch } from "vue";
+
+type Item = { id: number; label: string };
+
+interface Props {
+  title: string;
+  items?: Item[];
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  items: () => [],
+});
+
+const emit = defineEmits<{
+  submit: [value: string];
+  update: [count: number];
+}>();
+
+const count = ref(0);
+const name = ref("");
+const visible = ref(true);
+const isActive = ref(false);
+
+const doubled = computed(() => count.value * 2);
+const greeting = computed(() => \`Hello, \${name.value || "Anonymous"}!\`);
+
+watch(count, (value) => {
+  emit("update", value);
+});
+
+function increment() {
+  count.value += 1;
+}
+
+function submit() {
+  emit("submit", name.value);
+}
+
+onMounted(() => {
+  console.log("mounted", props.title);
+});
+</script>
+
+<template>
+  <!-- Template directives and mustache expressions -->
+  <header v-if="visible">
+    <h1>{{ title }}</h1>
+    <p>{{ greeting }} · {{ doubled }} clicks</p>
+  </header>
+
+  <div
+    v-show="visible"
+    :class="{ active: isActive, card: true }"
+    :style="{ opacity: count / 10 }"
+  >
+    <input v-model="name" placeholder="Name" @keyup.enter="submit" />
+    <button @click="increment" @keydown.enter="increment">+1</button>
+    <button v-on:click="isActive = !isActive">Toggle</button>
+  </div>
+
+  <ul v-if="items.length">
+    <li v-for="item in items" :key="item.id" v-memo="[item.id]">
+      {{ item.label }}
+    </li>
+  </ul>
+  <p v-else>No items</p>
+
+  <Child v-slot="{ message }">
+    <span>{{ message }}</span>
+  </Child>
+
+  <template #footer>
+    <small>Built with Vue</small>
+  </template>
+</template>
+
+<style scoped lang="scss">
+$brand: #42b883;
+
+.card {
+  padding: 1rem;
+  border: 1px solid #ccc;
+
+  &.active {
+    border-color: $brand;
+  }
+}
+
+:deep(.nested) {
+  margin: 0;
+}
+</style>
+
+<style scoped lang="less">
+@muted: #666;
+
+small {
+  color: @muted;
+}
+</style>`;

--- a/www/preview/vue-preview-snippets.ts
+++ b/www/preview/vue-preview-snippets.ts
@@ -1,0 +1,88 @@
+export type VuePreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const vuePreviewSnippets: VuePreviewSnippet[] = [
+  {
+    title: "Script setup with TypeScript",
+    description: '<script setup lang="ts"> with Composition API',
+    code: `<script setup lang="ts">
+import { ref, computed } from "vue";
+
+const count = ref(0);
+const doubled = computed(() => count.value * 2);
+
+function increment() {
+  count.value += 1;
+}
+</script>
+
+<template>
+  <button @click="increment">{{ doubled }}</button>
+</template>`,
+  },
+  {
+    title: "Options API script block",
+    description: "Classic export default with data and methods",
+    code: `<script>
+export default {
+  data() {
+    return { count: 0, name: "" };
+  },
+  methods: {
+    increment() {
+      this.count += 1;
+    },
+  },
+};
+</script>`,
+  },
+  {
+    title: "Template directives",
+    description: "v-if, v-for, v-model, @click, :class, and #slot",
+    code: `<template>
+  <div v-if="visible" :class="{ active: isActive }">
+    <input v-model="name" @keyup.enter="submit" />
+    <ul>
+      <li v-for="item in items" :key="item.id">{{ item.label }}</li>
+    </ul>
+    <template #header="{ title }">
+      <h1>{{ title }}</h1>
+    </template>
+  </div>
+</template>`,
+  },
+  {
+    title: "Scoped SCSS styles",
+    description: '<style scoped lang="scss">',
+    code: `<style scoped lang="scss">
+$primary: #42b883;
+
+.card {
+  color: $primary;
+
+  &:hover {
+    opacity: 0.9;
+  }
+}
+</style>`,
+  },
+  {
+    title: "Less and Stylus style blocks",
+    description: "Alternate style lang attributes",
+    code: `<style scoped lang="less">
+@brand: #35495e;
+
+.title {
+  color: @brand;
+}
+</style>
+
+<style lang="stylus">
+.card
+  padding 1rem
+</style>`,
+  },
+];


### PR DESCRIPTION
Adds three custom highlight.js grammars for composite file formats that are not covered by the core library: Vue SFC, MDX, and Marko. Each language ships with unit tests and an unlisted docs preview page.

svelte-highlight already ships custom grammars for Svelte, Astro, and enhanced HTML. Several other widely used formats share the same problem: they embed HTML, JavaScript, TypeScript, and CSS in a single file, but highlight.js has no first-class support.

### Vue (`.vue`)

Vue Single File Components are the main gap. A `.vue` file combines `<template>`, `<script>` / `<script setup>`, and `<style>` blocks in one document. Stock highlight.js treats this as plain HTML or XML, which misses:

- TypeScript in `<script setup lang="ts">`
- Template directives (`v-if`, `v-for`, `v-model`)
- Shorthand bindings (`@click`, `:class`, `#default`)
- Mustache expressions (`{{ count }}`)
- Preprocessor styles (`lang="scss"`, `less`, `stylus`)

<img width="990" height="794" alt="Screenshot 2026-06-07 at 1 54 03 PM" src="https://github.com/user-attachments/assets/2b8b10b2-d3e5-4fef-928a-939e966748c4" />
<img width="936" height="395" alt="Screenshot 2026-06-07 at 1 53 50 PM" src="https://github.com/user-attachments/assets/4ac58b8d-a6f3-43f8-8cd2-dabec1b64fde" />


### MDX (`.mdx`)

MDX mixes Markdown, JSX, and ESM imports in one file. Docs sites (Next.js, Nuxt Content, etc.) commonly paste full `.mdx` sources into code blocks. Without a dedicated grammar, imports, headings, JSX tags, and `{expressions}` are not highlighted together.

<img width="1004" height="849" alt="Screenshot 2026-06-07 at 1 54 58 PM" src="https://github.com/user-attachments/assets/a768aa57-5062-4e33-b46a-3eb9c6e5d0d3" />


### Marko (`.marko`)

Marko components use HTML-like markup with `<script>`, `<style>`, `${expressions}`, and control-flow keywords. Same composite pattern as Astro; useful for parity across meta-framework docs.

<img width="1011" height="752" alt="Screenshot 2026-06-07 at 1 54 34 PM" src="https://github.com/user-attachments/assets/f4a85f40-527c-42df-bb4c-b3701fd3faf5" />
<img width="919" height="384" alt="Screenshot 2026-06-07 at 1 54 17 PM" src="https://github.com/user-attachments/assets/130bd8a5-b20e-459f-a7ae-e6a908a70786" />
