### PR TITLE
feat: expose and document container CSS variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,58 @@ CSS StyleSheets can also be externally linked from a Content Delivery Network (C
 </svelte:head>
 ```
 
+## Styling with CSS variables
+
+Every `Highlight` variant forwards `$$restProps` to its top-level element, so you can style the component using CSS variables without resorting to `:global` overrides or `!important`.
+
+```svelte
+<Highlight
+  language={typescript}
+  {code}
+  --border-radius="8px"
+  --max-width="40rem"
+/>
+```
+
+### Container variables
+
+These apply to the outer container of every component (the `pre` element for `Highlight`, `HighlightAuto`, `HighlightSvelte`, and `LangTag`; the `div` element for `LineNumbers`).
+
+| Variable        | Description                                | Default value |
+| :-------------- | :----------------------------------------- | :------------ |
+| --border-radius | Border radius of the container             | `0`           |
+| --width         | Width of the container                     | `auto`        |
+| --max-width     | Maximum width of the container             | `none`        |
+| --overflow-x    | Horizontal overflow behavior               | `auto`        |
+| --overflow-y    | Vertical overflow behavior                 | `auto`        |
+
+> [!NOTE]
+> Because the container clips its content (`overflow` is not `visible` by default), setting `--border-radius` rounds the visible corners without any extra CSS.
+
+### `LineNumbers` variables
+
+| Variable                 | Description                                       | Default value             |
+| :----------------------- | :------------------------------------------------ | :------------------------ |
+| --line-number-color      | Text color of the line numbers                    | `currentColor`            |
+| --border-color           | Border color of the column of line numbers        | `currentColor`            |
+| --highlighted-background | Background color of highlighted lines             | `rgba(254, 241, 96, 0.2)` |
+| --padding                | Fallback padding for `--padding-left` / `--padding-right` | `1em`              |
+| --padding-left           | Left padding for `td` elements                    | `var(--padding, 1em)`     |
+| --padding-right          | Right padding for `td` elements                   | `var(--padding, 1em)`     |
+
+### Language tag variables
+
+These apply when `langtag` is set to `true`.
+
+| Variable                | Description                     | Default value |
+| :---------------------- | :------------------------------ | :------------ |
+| --langtag-top           | Top position of the langtag     | `0`           |
+| --langtag-right         | Right position of the langtag   | `0`           |
+| --langtag-background    | Background color of the langtag | `inherit`     |
+| --langtag-color         | Text color of the langtag       | `inherit`     |
+| --langtag-border-radius | Border radius of the langtag    | `0`           |
+| --langtag-padding       | Padding of the langtag          | `1em`         |
+
 ## Svelte Syntax Highlighting
 
 Use the `HighlightSvelte` component for Svelte syntax highlighting.
@@ -257,13 +309,16 @@ Use `--highlighted-background` to customize the background color of highlighted 
 
 Use `--style-props` to customize styles.
 
-| Style prop               | Description                                | Default value             |
-| :----------------------- | :----------------------------------------- | :------------------------ |
-| --line-number-color      | Text color of the line numbers             | `currentColor`            |
-| --border-color           | Border color of the column of line numbers | `currentColor`            |
-| --padding-left           | Left padding for `td` elements             | `1em`                     |
-| --padding-right          | Right padding for `td` elements            | `1em`                     |
-| --highlighted-background | Background color of highlighted lines      | `rgba(254, 241, 96, 0.2)` |
+| Style prop               | Description                                              | Default value             |
+| :----------------------- | :------------------------------------------------------ | :------------------------ |
+| --line-number-color      | Text color of the line numbers                          | `currentColor`            |
+| --border-color           | Border color of the column of line numbers              | `currentColor`            |
+| --padding                | Fallback padding for `--padding-left` / `--padding-right` | `1em`                   |
+| --padding-left           | Left padding for `td` elements                          | `var(--padding, 1em)`     |
+| --padding-right          | Right padding for `td` elements                         | `var(--padding, 1em)`     |
+| --highlighted-background | Background color of highlighted lines                   | `rgba(254, 241, 96, 0.2)` |
+
+See [Styling with CSS variables](#styling-with-css-variables) for the full list, including container-level variables like `--border-radius`, `--width`, and `--overflow-x`.
 
 ```svelte
 <Highlight language={typescript} {code} let:highlighted>
@@ -274,6 +329,8 @@ Use `--style-props` to customize styles.
     --padding-left={0}
     --padding-right="3em"
     --highlighted-background="#000"
+    --border-radius="8px"
+    --max-width="40rem"
   />
 </Highlight>
 ```

--- a/src/LangTag.svelte
+++ b/src/LangTag.svelte
@@ -12,7 +12,16 @@
   export let langtag = false;
 </script>
 
-<pre class:langtag={langtag} data-language={languageName} {...$$restProps}><code
+<pre
+  class:langtag={langtag}
+  data-language={languageName}
+  style:overflow-x="var(--overflow-x, auto)"
+  style:overflow-y="var(--overflow-y, auto)"
+  style:border-radius="var(--border-radius, 0)"
+  style:width="var(--width, auto)"
+  style:max-width="var(--max-width, none)"
+  {...$$restProps}
+><code
     class:hljs={true}
     >{#if highlighted}{@html highlighted}{:else}{code}{/if}</code
   ></pre>

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -33,7 +33,11 @@
 <div
   class:langtag={langtag}
   data-language={languageName}
-  style:overflow-x="auto"
+  style:overflow-x="var(--overflow-x, auto)"
+  style:overflow-y="var(--overflow-y, auto)"
+  style:border-radius="var(--border-radius, 0)"
+  style:width="var(--width, auto)"
+  style:max-width="var(--max-width, none)"
   {...$$restProps}
 >
   <table>
@@ -110,8 +114,8 @@
   }
 
   td {
-    padding-left: var(--padding-left, 1em);
-    padding-right: var(--padding-right, 1em);
+    padding-left: var(--padding-left, var(--padding, 1em));
+    padding-right: var(--padding-right, var(--padding, 1em));
   }
 
   td.hljs:not(.hideBorder):after {

--- a/tests/e2e/LineNumbers.cssVariables.test.svelte
+++ b/tests/e2e/LineNumbers.cssVariables.test.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  import Highlight, { LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+
+  const code = "const add = (a: number, b: number) => a + b";
+</script>
+
+<svelte:head> {@html horizonDark} </svelte:head>
+
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers
+    {highlighted}
+    --border-radius="12px"
+    --overflow-x="hidden"
+    --max-width="320px"
+  />
+</Highlight>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -3,6 +3,7 @@ import Highlight from "./Highlight.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
 import LangTag from "./LangTag.test.svelte";
+import LineNumbersCssVariables from "./LineNumbers.cssVariables.test.svelte";
 import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test.svelte";
 import LineNumbersHideBorder from "./LineNumbers.hideBorder.test.svelte";
 import LineNumbersLangtag from "./LineNumbers.langtag.test.svelte";
@@ -106,6 +107,26 @@ test("LineNumbers - langtag", async ({ mount, page }) => {
   );
   await expect(page.locator("div.langtag")).toHaveCSS("position", "relative");
   await expect(page.locator(".hljs-keyword")).toHaveText("const");
+});
+
+test("LineNumbers - CSS variables override container styles without !important", async ({
+  mount,
+  page,
+}) => {
+  await mount(LineNumbersCssVariables);
+
+  const container = page.locator("div[data-language]");
+  await expect(container).toBeVisible();
+
+  // --border-radius is applied to the outer container
+  await expect(container).toHaveCSS("border-top-left-radius", "12px");
+  await expect(container).toHaveCSS("border-bottom-right-radius", "12px");
+
+  // --overflow-x overrides the hard-coded "auto" default (resolves #280)
+  await expect(container).toHaveCSS("overflow-x", "hidden");
+
+  // --max-width is applied to the outer container
+  await expect(container).toHaveCSS("max-width", "320px");
 });
 
 test("Language tag styling", async ({ mount, page }) => {

--- a/www/components/LineNumbers/ContainerStyle.svelte
+++ b/www/components/LineNumbers/ContainerStyle.svelte
@@ -1,0 +1,11 @@
+<script>
+  import Basic from "./Basic.svelte";
+
+  const snippet = `<LineNumbers
+    {highlighted}
+    --border-radius="8px"
+    --max-width="24rem"
+  />`;
+</script>
+
+<Basic {snippet} --border-radius="8px" --max-width="24rem" />

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -1,6 +1,7 @@
 <script>
   import CodeSnippet from "@components/CodeSnippet.svelte";
   import Basic from "@components/LineNumbers/Basic.svelte";
+  import ContainerStyle from "@components/LineNumbers/ContainerStyle.svelte";
   import HideBorder from "@components/LineNumbers/HideBorder.svelte";
   import HighlightedLines from "@components/LineNumbers/HighlightedLines.svelte";
   import HighlightedLinesCustomColor from "@components/LineNumbers/HighlightedLinesCustomColor.svelte";
@@ -213,6 +214,18 @@
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <StyleProps /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Use container-level variables like
+      <code class="code">--border-radius</code>,
+      <code class="code">--width</code>, and
+      <code class="code">--max-width</code>
+      to style the outer container without
+      <code class="code">:global</code>
+      overrides.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <ContainerStyle /> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Use <code class="code">startingLineNumber</code> to customize the starting


### PR DESCRIPTION
This exposes a set of container-level CSS variables so the outer code block can be styled without `:global` overrides or `!important`, addressing #299.

Both `src/LangTag.svelte` (the `pre`) and `src/LineNumbers.svelte` (the `div`) now accept `--border-radius`, `--width`, `--max-width`, `--overflow-x`, and `--overflow-y`, and `LineNumbers` gains a `--padding` fallback for the existing `--padding-left/right`. The previously hard-coded `style:overflow-x="auto"` now reads `var(--overflow-x, auto)`, which resolves #280.

All existing variable names and defaults are unchanged, so this is fully backward-compatible. The README now has a "Styling with CSS variables" section enumerating every supported variable with its default, alongside a new docs demo and a cross-browser e2e test confirming an override takes effect without `!important`.

```svelte
<Highlight language={typescript} {code} let:highlighted>
  <LineNumbers
    {highlighted}
    --border-radius="8px"
    --max-width="40rem"
    --overflow-x="auto"
  />
</Highlight>
```
