### PR TITLE
feat: add focus mode to dim/blur un-highlighted lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -191,6 +191,8 @@ These apply to the outer container of every component (the `pre` element for `Hi
 | --line-number-color      | Text color of the line numbers                    | `currentColor`            |
 | --border-color           | Border color of the column of line numbers        | `currentColor`            |
 | --highlighted-background | Background color of highlighted lines             | `rgba(254, 241, 96, 0.2)` |
+| --unhighlighted-opacity  | Opacity of un-highlighted lines (focus mode)      | `1`                       |
+| --unhighlighted-filter   | CSS filter for un-highlighted lines (focus mode)  | `none`                    |
 | --padding                | Fallback padding for `--padding-left` / `--padding-right` | `1em`              |
 | --padding-left           | Left padding for `td` elements                    | `var(--padding, 1em)`     |
 | --padding-right          | Right padding for `td` elements                   | `var(--padding, 1em)`     |
@@ -326,6 +328,24 @@ The line number starts at `1`. Customize this via the `startingLineNumber` prop.
 
 Specify the lines to highlight using the `highlightedLines` prop. Indices start at zero.
 
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers {highlighted} highlightedLines={[0, 2, 3, 14]} />
+</Highlight>
+```
+
+Use `--unhighlighted-opacity` or `--unhighlighted-filter` to de-emphasize the remaining lines and focus attention on the highlighted ones. Both only take effect when `highlightedLines` is non-empty.
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers
+    {highlighted}
+    highlightedLines={[0, 2, 3, 14]}
+    --unhighlighted-opacity="0.4"
+  />
+</Highlight>
+```
+
 Use `--highlighted-background` to customize the background color of highlighted lines.
 
 ```svelte
@@ -350,6 +370,8 @@ Use `--style-props` to customize styles.
 | --padding-left           | Left padding for `td` elements                          | `var(--padding, 1em)`     |
 | --padding-right          | Right padding for `td` elements                         | `var(--padding, 1em)`     |
 | --highlighted-background | Background color of highlighted lines                   | `rgba(254, 241, 96, 0.2)` |
+| --unhighlighted-opacity  | Opacity of un-highlighted lines (focus mode)            | `1`                       |
+| --unhighlighted-filter   | CSS filter for un-highlighted lines (focus mode)        | `none`                    |
 
 See [Styling with CSS variables](#styling-with-css-variables) for the full list, including container-level variables like `--border-radius`, `--width`, and `--overflow-x`.
 

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -25,6 +25,7 @@
   const HIGHLIGHTED_BACKGROUND = "rgba(254, 241, 96, 0.2)";
 
   $: lines = highlighted.split("\n");
+  $: focusMode = highlightedLines.length > 0;
   $: len_digits = lines.length.toString().length;
   $: len = len_digits - MIN_DIGITS < 1 ? MIN_DIGITS : len_digits;
   $: width = len * DIGIT_WIDTH;
@@ -44,7 +45,8 @@
     <tbody class:hljs={true}>
       {#each lines as line, i}
         {@const lineNumber = i + startingLineNumber}
-        <tr>
+        {@const isHighlighted = highlightedLines.includes(i)}
+        <tr class:dimmed={focusMode && !isHighlighted}>
           <td
             class:hljs={true}
             class:hideBorder
@@ -57,7 +59,7 @@
             <code style:color="var(--line-number-color, currentColor)">
               {lineNumber}
             </code>
-            {#if highlightedLines.includes(i)}
+            {#if isHighlighted}
               <div
                 class:line-background={true}
                 style:background="var(--highlighted-background, {HIGHLIGHTED_BACKGROUND})"
@@ -66,7 +68,7 @@
           </td>
           <td>
             <pre class:wrapLines><code>{@html line || "\n"}</code></pre>
-            {#if highlightedLines.includes(i)}
+            {#if isHighlighted}
               <div
                 class:line-background={true}
                 style:background="var(--highlighted-background, {HIGHLIGHTED_BACKGROUND})"
@@ -163,5 +165,11 @@
 
   tr:last-of-type td .line-background {
     bottom: 1em;
+  }
+
+  tr.dimmed td > code,
+  tr.dimmed pre {
+    opacity: var(--unhighlighted-opacity, 1);
+    filter: var(--unhighlighted-filter, none);
   }
 </style>

--- a/src/LineNumbers.svelte.d.ts
+++ b/src/LineNumbers.svelte.d.ts
@@ -81,6 +81,22 @@ export type LineNumbersProps = HTMLAttributes<HTMLDivElement> &
      * @example "#fff"
      */
     "--highlighted-background"?: string;
+
+    /**
+     * Specify the opacity of un-highlighted lines.
+     * Only applies when `highlightedLines` is non-empty.
+     * @default 1
+     * @example 0.4
+     */
+    "--unhighlighted-opacity"?: number | string;
+
+    /**
+     * Specify a CSS filter for un-highlighted lines.
+     * Only applies when `highlightedLines` is non-empty.
+     * @default none
+     * @example "blur(2px)"
+     */
+    "--unhighlighted-filter"?: string;
   };
 
 export type LineNumbersEvents = {};

--- a/tests/e2e/LineNumbers.focusLines.test.svelte
+++ b/tests/e2e/LineNumbers.focusLines.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import Highlight, { LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+
+  const code = `const a = 1;
+const b = 2;
+const c = 3;`;
+</script>
+
+<svelte:head> {@html horizonDark} </svelte:head>
+
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers
+    {highlighted}
+    highlightedLines={[1]}
+    --unhighlighted-opacity="0.4"
+    --unhighlighted-filter="blur(2px)"
+  />
+</Highlight>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -5,6 +5,7 @@ import HighlightAuto from "./HighlightAuto.test.svelte";
 import LangTag from "./LangTag.test.svelte";
 import LineNumbersCssVariables from "./LineNumbers.cssVariables.test.svelte";
 import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test.svelte";
+import LineNumbersFocusLines from "./LineNumbers.focusLines.test.svelte";
 import LineNumbersHideBorder from "./LineNumbers.hideBorder.test.svelte";
 import LineNumbersLangtag from "./LineNumbers.langtag.test.svelte";
 import LineNumbers from "./LineNumbers.test.svelte";
@@ -145,6 +146,26 @@ test("LineNumbers - CSS variables override container styles without !important",
 
   // --max-width is applied to the outer container
   await expect(container).toHaveCSS("max-width", "320px");
+});
+
+test("LineNumbers - focus lines dim/blur un-highlighted lines", async ({
+  mount,
+  page,
+}) => {
+  await mount(LineNumbersFocusLines);
+
+  const rows = page.locator("tr");
+
+  // The highlighted line (index 1) is not dimmed.
+  await expect(rows.nth(1)).not.toHaveClass(/dimmed/);
+
+  // The remaining lines are dimmed and receive the opacity/filter effect.
+  await expect(rows.nth(0)).toHaveClass(/dimmed/);
+  await expect(rows.nth(2)).toHaveClass(/dimmed/);
+
+  const dimmedCode = rows.nth(0).locator("pre");
+  await expect(dimmedCode).toHaveCSS("opacity", "0.4");
+  await expect(dimmedCode).toHaveCSS("filter", "blur(2px)");
 });
 
 test("Language tag styling", async ({ mount, page }) => {

--- a/www/components/LineNumbers/FocusLines.svelte
+++ b/www/components/LineNumbers/FocusLines.svelte
@@ -1,0 +1,15 @@
+<script>
+  import Basic from "./Basic.svelte";
+
+  const snippet = `<LineNumbers
+    {highlighted}
+    highlightedLines={[0, 2, 3, 14]}
+    --unhighlighted-opacity="0.4"
+  />`;
+</script>
+
+<Basic
+  {snippet}
+  highlightedLines={[0, 2, 3, 14]}
+  --unhighlighted-opacity="0.4"
+/>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -2,6 +2,7 @@
   import CodeSnippet from "@components/CodeSnippet.svelte";
   import Basic from "@components/LineNumbers/Basic.svelte";
   import ContainerStyle from "@components/LineNumbers/ContainerStyle.svelte";
+  import FocusLines from "@components/LineNumbers/FocusLines.svelte";
   import HideBorder from "@components/LineNumbers/HideBorder.svelte";
   import HighlightedLines from "@components/LineNumbers/HighlightedLines.svelte";
   import HighlightedLinesCustomColor from "@components/LineNumbers/HighlightedLinesCustomColor.svelte";
@@ -260,6 +261,15 @@
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <HighlightedLines /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Use <code class="code">--unhighlighted-opacity</code> or
+      <code class="code">--unhighlighted-filter</code>
+      to de-emphasize the remaining lines and focus attention on the highlighted
+      ones.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <FocusLines /> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Use <code class="code">--highlighted-background</code> to customize the


### PR DESCRIPTION
Closes #259

Inverse of `highlightedLines`: expose `--unhighlighted-opacity` and `--unhighlighted-filter` to de-emphasize the rest. Applied to content, not the sticky `td`, since `filter` would break sticky.

---

<img width="778" height="490" alt="Screenshot 2026-06-20 at 10 18 36 AM" src="https://github.com/user-attachments/assets/39d70e11-23bd-40dc-9634-cbd8a0d0535f" />
