### PR TITLE
feat(languages): add custom `hcl`, `prisma`, `solidity`, `zig` grammars

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 198 languages exported from highlight.js@11.11.1
+> 199 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -925,6 +925,20 @@
 
   // base import
   import { haxe } from "svelte-highlight/languages";
+</script>
+```
+
+## hcl (`hcl`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import hcl from "svelte-highlight/languages/hcl";
+
+  // base import
+  import { hcl } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 200 languages exported from highlight.js@11.11.1
+> 201 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2027,6 +2027,20 @@
 
   // base import
   import { sml } from "svelte-highlight/languages";
+</script>
+```
+
+## solidity (`solidity`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import solidity from "svelte-highlight/languages/solidity";
+
+  // base import
+  import { solidity } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 201 languages exported from highlight.js@11.11.1
+> 202 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2429,5 +2429,19 @@
 
   // base import
   import { zephir } from "svelte-highlight/languages";
+</script>
+```
+
+## zig (`zig`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import zig from "svelte-highlight/languages/zig";
+
+  // base import
+  import { zig } from "svelte-highlight/languages";
 </script>
 ```

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 199 languages exported from highlight.js@11.11.1
+> 200 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1665,6 +1665,20 @@
 
   // base import
   import { powershell } from "svelte-highlight/languages";
+</script>
+```
+
+## prisma (`prisma`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import prisma from "svelte-highlight/languages/prisma";
+
+  // base import
+  import { prisma } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -58,6 +58,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "solidity",
     path: `${import.meta.dir}/custom-languages/solidity.js`,
   },
+  {
+    name: "zig",
+    moduleName: "zig",
+    path: `${import.meta.dir}/custom-languages/zig.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -48,6 +48,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "hcl",
     path: `${import.meta.dir}/custom-languages/hcl.js`,
   },
+  {
+    name: "prisma",
+    moduleName: "prisma",
+    path: `${import.meta.dir}/custom-languages/prisma.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -43,6 +43,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "marko",
     path: `${import.meta.dir}/custom-languages/marko.js`,
   },
+  {
+    name: "hcl",
+    moduleName: "hcl",
+    path: `${import.meta.dir}/custom-languages/hcl.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -53,6 +53,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "prisma",
     path: `${import.meta.dir}/custom-languages/prisma.js`,
   },
+  {
+    name: "solidity",
+    moduleName: "solidity",
+    path: `${import.meta.dir}/custom-languages/solidity.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/custom-languages/hcl.js
+++ b/scripts/custom-languages/hcl.js
@@ -1,0 +1,84 @@
+const HCL_BLOCK_TYPES =
+  "resource data variable output module provider terraform locals " +
+  "provisioner connection backend dynamic lifecycle moved import check " +
+  "removed";
+
+const HCL_KEYWORDS =
+  "for in if else endif endfor for_each count depends_on " +
+  "source version providers";
+
+const HCL_LITERALS = "true false null";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineHcl(hljs) {
+  const NUMBER = {
+    className: "number",
+    begin: /\b\d[\d_]*(?:\.\d+)?(?:[eE][+-]?\d+)?\b/,
+    relevance: 0,
+  };
+
+  const INTERPOLATION = {
+    className: "subst",
+    begin: /[$%]\{/,
+    end: /\}/,
+    keywords: { keyword: HCL_KEYWORDS, literal: HCL_LITERALS },
+    contains: [{ className: "built_in", begin: /\b[a-z_][\w-]*(?=\()/ }],
+  };
+
+  const STRING = {
+    className: "string",
+    begin: /"/,
+    end: /"/,
+    contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+  };
+
+  const HEREDOC = {
+    className: "string",
+    begin: /<<-?\s*(["']?)(\w+)\1/,
+    end: /^\s*\w+\s*$/,
+    contains: [INTERPOLATION],
+    relevance: 10,
+  };
+
+  return {
+    name: "HCL",
+    aliases: ["terraform", "tf"],
+    keywords: {
+      keyword: HCL_KEYWORDS,
+      literal: HCL_LITERALS,
+    },
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      HEREDOC,
+      STRING,
+      NUMBER,
+      {
+        begin: [
+          new RegExp(
+            String.raw`\b(?:${HCL_BLOCK_TYPES.split(" ").join("|")})\b`,
+          ),
+          /\s+/,
+        ],
+        beginScope: { 1: "keyword" },
+        end: /(?=\{)/,
+        contains: [{ className: "string", begin: /"/, end: /"/ }],
+      },
+      {
+        className: "attr",
+        begin: /[A-Za-z_][\w-]*(?=\s*=(?!=))/,
+        relevance: 0,
+      },
+      { className: "built_in", begin: /\b[a-z_][\w-]*(?=\()/, relevance: 0 },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineHcl(hljs);
+}
+
+export const hcl = { name: "hcl", register };
+export default hcl;

--- a/scripts/custom-languages/prisma.js
+++ b/scripts/custom-languages/prisma.js
@@ -1,0 +1,70 @@
+const PRISMA_KEYWORDS = "model enum type view datasource generator";
+
+const PRISMA_TYPES =
+  "String Boolean Int BigInt Float Decimal DateTime Json Bytes Unsupported";
+
+const PRISMA_LITERALS = "true false null";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function definePrisma(hljs) {
+  const NUMBER = {
+    className: "number",
+    begin: /\b\d+(?:\.\d+)?\b/,
+    relevance: 0,
+  };
+
+  const STRING = hljs.QUOTE_STRING_MODE;
+
+  const ATTRIBUTE = {
+    className: "meta",
+    begin: /@@?[A-Za-z_][\w.]*/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    className: "built_in",
+    begin: /\b[a-z_]\w*(?=\()/,
+    relevance: 0,
+  };
+
+  const FIELD_TYPE = {
+    className: "type",
+    begin: new RegExp(String.raw`\b(?:${PRISMA_TYPES.split(" ").join("|")})\b`),
+    relevance: 0,
+  };
+
+  return {
+    name: "Prisma",
+    aliases: ["prisma-schema"],
+    keywords: {
+      keyword: PRISMA_KEYWORDS,
+      literal: PRISMA_LITERALS,
+    },
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      {
+        begin: [
+          new RegExp(
+            String.raw`\b(?:${PRISMA_KEYWORDS.split(" ").join("|")})\b`,
+          ),
+          /\s+/,
+          /[A-Za-z_]\w*/,
+        ],
+        beginScope: { 1: "keyword", 3: "title class_" },
+      },
+      ATTRIBUTE,
+      STRING,
+      FIELD_TYPE,
+      FUNCTION,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return definePrisma(hljs);
+}
+
+export const prisma = { name: "prisma", register };
+export default prisma;

--- a/scripts/custom-languages/solidity.js
+++ b/scripts/custom-languages/solidity.js
@@ -1,0 +1,101 @@
+const SOLIDITY_KEYWORDS =
+  "pragma import as from using is abstract contract interface library " +
+  "function modifier constructor fallback receive event error struct enum " +
+  "mapping returns return if else for while do break continue throw emit " +
+  "try catch revert assembly unchecked new delete override virtual " +
+  "public private internal external pure view payable constant immutable " +
+  "storage memory calldata indexed anonymous type this super " +
+  "selfdestruct";
+
+const SOLIDITY_LITERALS =
+  "true false wei gwei szabo finney ether " +
+  "seconds minutes hours days weeks years";
+
+const SOLIDITY_BUILT_INS =
+  "msg block tx abi require assert keccak256 sha256 ripemd160 ecrecover " +
+  "addmod mulgmod gasleft blockhash now";
+
+const SOLIDITY_TYPE = {
+  className: "type",
+  begin:
+    /\b(?:address|bool|string|byte|(?:u?int|bytes)\d{0,3}|u?fixed(?:\d{1,3}x\d{1,2})?)\b/,
+  relevance: 0,
+};
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineSolidity(hljs) {
+  const NATSPEC = {
+    className: "doctag",
+    begin:
+      /@(?:title|author|notice|dev|param|return|inheritdoc|custom:[\w-]+)\b/,
+  };
+
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F]+\b/ },
+      { begin: /\b\d[\d_]*(?:\.[\d_]+)?(?:[eE][+-]?\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      {
+        begin: /(?:hex|unicode)?"/,
+        end: /"/,
+        illegal: /\n/,
+        contains: [hljs.BACKSLASH_ESCAPE],
+      },
+      {
+        begin: /(?:hex|unicode)?'/,
+        end: /'/,
+        illegal: /\n/,
+        contains: [hljs.BACKSLASH_ESCAPE],
+      },
+    ],
+  };
+
+  return {
+    name: "Solidity",
+    aliases: ["sol"],
+    keywords: {
+      keyword: SOLIDITY_KEYWORDS,
+      literal: SOLIDITY_LITERALS,
+      built_in: SOLIDITY_BUILT_INS,
+    },
+    contains: [
+      hljs.COMMENT(/\/\/\//, /$/, { contains: [NATSPEC] }),
+      hljs.COMMENT(/\/\*\*/, /\*\//, { contains: [NATSPEC] }),
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      STRING,
+      NUMBER,
+      SOLIDITY_TYPE,
+      {
+        beginKeywords: "contract interface library",
+        end: /\{/,
+        excludeEnd: true,
+        keywords: "contract interface library is abstract",
+        contains: [{ className: "title", begin: /[A-Za-z_]\w*/, relevance: 0 }],
+      },
+      {
+        beginKeywords: "function modifier event error",
+        end: /[({]/,
+        excludeEnd: true,
+        contains: [{ className: "title function_", begin: /[A-Za-z_]\w*/ }],
+        keywords: SOLIDITY_KEYWORDS,
+      },
+      { className: "title class_", begin: /\b[A-Z]\w*/, relevance: 0 },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineSolidity(hljs);
+}
+
+export const solidity = { name: "solidity", register };
+export default solidity;

--- a/scripts/custom-languages/zig.js
+++ b/scripts/custom-languages/zig.js
@@ -1,0 +1,100 @@
+const ZIG_KEYWORDS =
+  "const var fn pub return if else while for switch break continue " +
+  "defer errdefer try catch comptime inline noinline struct enum union " +
+  "error test and or orelse unreachable async await suspend resume " +
+  "nosuspend export extern packed align allowzero volatile linksection " +
+  "threadlocal usingnamespace asm anytype noalias callconv opaque " +
+  "anyframe fn";
+
+const ZIG_LITERALS = "true false null undefined";
+
+const ZIG_TYPES =
+  "bool void type anyerror anytype noreturn comptime_int comptime_float " +
+  "isize usize c_char c_short c_ushort c_int c_uint c_long c_ulong " +
+  "c_longlong c_ulonglong c_longdouble f16 f32 f64 f80 f128";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineZig(hljs) {
+  const INT_TYPE = {
+    className: "type",
+    begin: /\b[iu]\d+\b/,
+    relevance: 0,
+  };
+
+  const NAMED_TYPE = {
+    className: "type",
+    begin: new RegExp(String.raw`\b(?:${ZIG_TYPES.split(" ").join("|")})\b`),
+    relevance: 0,
+  };
+
+  const BUILTIN = {
+    className: "built_in",
+    begin: /@[a-zA-Z_]\w*/,
+    relevance: 0,
+  };
+
+  const NUMBER = {
+    className: "number",
+    variants: [
+      {
+        begin:
+          /\b0[xX][0-9a-fA-F][0-9a-fA-F_]*(?:\.[0-9a-fA-F_]+)?(?:[pP][+-]?\d+)?/,
+      },
+      { begin: /\b0[oO][0-7_]+/ },
+      { begin: /\b0[bB][01_]+/ },
+      { begin: /\b\d[\d_]*(?:\.[\d_]+)?(?:[eE][+-]?\d+)?/ },
+    ],
+    relevance: 0,
+  };
+
+  const MULTILINE_STRING = {
+    className: "string",
+    begin: /\\\\/,
+    end: /$/,
+    relevance: 0,
+  };
+
+  const CHAR = {
+    className: "string",
+    begin: /'/,
+    end: /'/,
+    contains: [hljs.BACKSLASH_ESCAPE],
+    relevance: 0,
+  };
+
+  return {
+    name: "Zig",
+    aliases: ["zir"],
+    keywords: {
+      keyword: ZIG_KEYWORDS,
+      literal: ZIG_LITERALS,
+      type: ZIG_TYPES,
+    },
+    contains: [
+      hljs.COMMENT(/\/\/[!/]/, /$/, { className: "doctag" }),
+      hljs.C_LINE_COMMENT_MODE,
+      MULTILINE_STRING,
+      hljs.QUOTE_STRING_MODE,
+      CHAR,
+      BUILTIN,
+      NUMBER,
+      INT_TYPE,
+      NAMED_TYPE,
+      {
+        beginKeywords: "fn",
+        end: /[(\s]/,
+        excludeEnd: true,
+        contains: [{ className: "title function_", begin: /[A-Za-z_]\w*/ }],
+      },
+      { className: "title class_", begin: /\b[A-Z]\w*/, relevance: 0 },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineZig(hljs);
+}
+
+export const zig = { name: "zig", register };
+export default zig;

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -79,6 +79,7 @@ exports[`Languages 1`] = `
   "handlebars",
   "haskell",
   "haxe",
+  "hcl",
   "hsp",
   "html",
   "http",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -203,5 +203,6 @@ exports[`Languages 1`] = `
   "xquery",
   "yaml",
   "zephir",
+  "zig",
 ]
 `;

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -140,6 +140,7 @@ exports[`Languages 1`] = `
   "plaintext",
   "pony",
   "powershell",
+  "prisma",
   "processing",
   "profile",
   "prolog",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -170,6 +170,7 @@ exports[`Languages 1`] = `
   "smali",
   "smalltalk",
   "sml",
+  "solidity",
   "sqf",
   "sql",
   "stan",

--- a/tests/hcl-language.test.ts
+++ b/tests/hcl-language.test.ts
@@ -1,0 +1,41 @@
+import hljs from "highlight.js/lib/core";
+import hcl from "../src/languages/hcl";
+
+hljs.registerLanguage(hcl.name, hcl.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "hcl" }).value;
+
+test("hcl highlights block type keywords", () => {
+  const result = highlight(`resource "aws_instance" "web" {}`);
+
+  expect(result).toContain('<span class="hljs-keyword">resource</span>');
+  expect(result).toContain(
+    '<span class="hljs-string">&quot;aws_instance&quot;</span>',
+  );
+  expect(result).toContain('<span class="hljs-string">&quot;web&quot;</span>');
+});
+
+test("hcl highlights attributes", () => {
+  const result = highlight(`instance_type = "t3.micro"`);
+
+  expect(result).toContain('<span class="hljs-attr">instance_type</span>');
+});
+
+test("hcl highlights interpolation as subst", () => {
+  const result = highlight(`name = "web-\${count.index}"`);
+
+  expect(result).toContain("hljs-subst");
+});
+
+test("hcl highlights heredoc strings", () => {
+  const result = highlight("policy = <<-EOT\n  hello\nEOT");
+
+  expect(result).toContain("hljs-string");
+});
+
+test("hcl highlights hash and slash comments", () => {
+  const result = highlight("# a comment\n// another\nx = 1");
+
+  expect(result).toContain("hljs-comment");
+});

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(201);
+  expect(languageNames.length).toEqual(202);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(200);
+  expect(languageNames.length).toEqual(201);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(199);
+  expect(languageNames.length).toEqual(200);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(198);
+  expect(languageNames.length).toEqual(199);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/prisma-language.test.ts
+++ b/tests/prisma-language.test.ts
@@ -1,0 +1,45 @@
+import hljs from "highlight.js/lib/core";
+import prisma from "../src/languages/prisma";
+
+hljs.registerLanguage(prisma.name, prisma.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "prisma" }).value;
+
+test("prisma highlights block keywords and names", () => {
+  const result = highlight("model User {\n  id Int\n}");
+
+  expect(result).toContain('<span class="hljs-keyword">model</span>');
+  expect(result).toContain('<span class="hljs-title class_">User</span>');
+});
+
+test("prisma highlights scalar types", () => {
+  const result = highlight("name String\ncount Int\nactive Boolean");
+
+  expect(result).toContain('<span class="hljs-type">String</span>');
+  expect(result).toContain('<span class="hljs-type">Int</span>');
+  expect(result).toContain('<span class="hljs-type">Boolean</span>');
+});
+
+test("prisma highlights field and block attributes", () => {
+  const result = highlight(
+    `id Int @id @default(autoincrement())\n@@map("users")`,
+  );
+
+  expect(result).toContain('<span class="hljs-meta">@id</span>');
+  expect(result).toContain('<span class="hljs-meta">@default</span>');
+  expect(result).toContain('<span class="hljs-meta">@@map</span>');
+});
+
+test("prisma highlights functions in attribute args", () => {
+  const result = highlight(`url = env("DATABASE_URL")`);
+
+  expect(result).toContain('<span class="hljs-built_in">env</span>');
+});
+
+test("prisma highlights datasource and enum blocks", () => {
+  const result = highlight("datasource db {}\nenum Role {\n  USER\n}");
+
+  expect(result).toContain('<span class="hljs-keyword">datasource</span>');
+  expect(result).toContain('<span class="hljs-keyword">enum</span>');
+});

--- a/tests/solidity-language.test.ts
+++ b/tests/solidity-language.test.ts
@@ -1,0 +1,49 @@
+import hljs from "highlight.js/lib/core";
+import solidity from "../src/languages/solidity";
+
+hljs.registerLanguage(solidity.name, solidity.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "solidity" }).value;
+
+test("solidity highlights pragma and contract keywords", () => {
+  const result = highlight("pragma solidity ^0.8.24;\ncontract Token {}");
+
+  expect(result).toContain('<span class="hljs-keyword">pragma</span>');
+  expect(result).toContain('<span class="hljs-keyword">contract</span>');
+});
+
+test("solidity highlights elementary value types", () => {
+  const result = highlight(
+    "mapping(address => uint256) balances;\nbytes32 salt;\nuint8 decimals;",
+  );
+
+  expect(result).toContain('<span class="hljs-type">address</span>');
+  expect(result).toContain('<span class="hljs-type">uint256</span>');
+  expect(result).toContain('<span class="hljs-type">bytes32</span>');
+  expect(result).toContain('<span class="hljs-type">uint8</span>');
+});
+
+test("solidity highlights NatSpec doc tags inside doc comments", () => {
+  const result = highlight(
+    "/// @notice transfers tokens\n/// @param to recipient",
+  );
+
+  expect(result).toContain("hljs-comment");
+  expect(result).toContain('<span class="hljs-doctag">@notice</span>');
+  expect(result).toContain('<span class="hljs-doctag">@param</span>');
+});
+
+test("solidity highlights ether units as literals", () => {
+  const result = highlight("uint256 fee = 1 ether;\nuint256 d = 30 days;");
+
+  expect(result).toContain('<span class="hljs-literal">ether</span>');
+  expect(result).toContain('<span class="hljs-literal">days</span>');
+});
+
+test("solidity highlights built-in globals", () => {
+  const result = highlight("require(msg.sender == owner);");
+
+  expect(result).toContain('<span class="hljs-built_in">require</span>');
+  expect(result).toContain('<span class="hljs-built_in">msg</span>');
+});

--- a/tests/zig-language.test.ts
+++ b/tests/zig-language.test.ts
@@ -1,0 +1,47 @@
+import hljs from "highlight.js/lib/core";
+import zig from "../src/languages/zig";
+
+hljs.registerLanguage(zig.name, zig.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "zig" }).value;
+
+test("zig highlights keywords", () => {
+  const result = highlight("pub fn main() !void {\n  const x = 0;\n}");
+
+  expect(result).toContain('<span class="hljs-keyword">pub</span>');
+  expect(result).toContain('<span class="hljs-keyword">fn</span>');
+  expect(result).toContain('<span class="hljs-keyword">const</span>');
+});
+
+test("zig highlights @builtins", () => {
+  const result = highlight(`const std = @import("std");`);
+
+  expect(result).toContain('<span class="hljs-built_in">@import</span>');
+});
+
+test("zig highlights sized and named types", () => {
+  const result = highlight(
+    "var x: u32 = 0;\nvar y: f64 = 0;\nvar z: bool = true;",
+  );
+
+  expect(result).toContain('<span class="hljs-type">u32</span>');
+  expect(result).toContain('<span class="hljs-type">f64</span>');
+  expect(result).toContain('<span class="hljs-type">bool</span>');
+});
+
+test("zig highlights hex and binary number literals", () => {
+  const result = highlight("const mask = 0xFF_00;\nconst flags = 0b1010;");
+
+  expect(result).toContain("hljs-number");
+});
+
+test("zig highlights literals", () => {
+  const result = highlight(
+    "const a = true;\nconst b = null;\nconst c = undefined;",
+  );
+
+  expect(result).toContain('<span class="hljs-literal">true</span>');
+  expect(result).toContain('<span class="hljs-literal">null</span>');
+  expect(result).toContain('<span class="hljs-literal">undefined</span>');
+});

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,9 +1,11 @@
 <script>
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
+  import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
   import hcl from "svelte-highlight/languages/hcl";
+  import prisma from "svelte-highlight/languages/prisma";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import dracula from "svelte-highlight/styles/dracula";
   import github from "svelte-highlight/styles/github";
@@ -11,11 +13,12 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"hcl"} */
+  /** @type {"hcl" | "prisma"} */
   export let language;
 
   const registry = {
     hcl: { lang: hcl, snippets: hclPreviewSnippets },
+    prisma: { lang: prisma, snippets: prismaPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -3,11 +3,13 @@
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
+  import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
   import hcl from "svelte-highlight/languages/hcl";
   import prisma from "svelte-highlight/languages/prisma";
   import solidity from "svelte-highlight/languages/solidity";
+  import zig from "svelte-highlight/languages/zig";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import dracula from "svelte-highlight/styles/dracula";
   import github from "svelte-highlight/styles/github";
@@ -15,13 +17,14 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"hcl" | "prisma" | "solidity"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma"} */
   export let language;
 
   const registry = {
-    hcl: { lang: hcl, snippets: hclPreviewSnippets },
-    prisma: { lang: prisma, snippets: prismaPreviewSnippets },
     solidity: { lang: solidity, snippets: solidityPreviewSnippets },
+    hcl: { lang: hcl, snippets: hclPreviewSnippets },
+    zig: { lang: zig, snippets: zigPreviewSnippets },
+    prisma: { lang: prisma, snippets: prismaPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,0 +1,60 @@
+<script>
+  import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
+  import { previewThemes } from "@www/preview/preview-themes";
+  import { Column, Row } from "carbon-components-svelte";
+  import { Highlight } from "svelte-highlight";
+  import hcl from "svelte-highlight/languages/hcl";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+  import dracula from "svelte-highlight/styles/dracula";
+  import github from "svelte-highlight/styles/github";
+  import githubDark from "svelte-highlight/styles/github-dark";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+  import nord from "svelte-highlight/styles/nord";
+
+  /** @type {"hcl"} */
+  export let language;
+
+  const registry = {
+    hcl: { lang: hcl, snippets: hclPreviewSnippets },
+  };
+
+  $: ({ lang, snippets } = registry[language]);
+
+  /** @type {Record<string, string>} */
+  const themeCss = {
+    horizonDark,
+    atomOneDark,
+    githubDark,
+    dracula,
+    nord,
+    github,
+  };
+</script>
+
+<svelte:head>
+  {#each Object.values(themeCss) as css}
+    {@html css}
+  {/each}
+</svelte:head>
+
+{#each snippets as snippet, index}
+  <Row class="mb-9">
+    <Column xlg={12}>
+      <h3>{index + 1}. {snippet.title}</h3>
+      {#if snippet.description}
+        <div class="label-01 mb-3">{snippet.description}</div>
+      {/if}
+    </Column>
+    {#each previewThemes as theme}
+      <Column xlg={10} lg={10} md={12} class="mb-5">
+        <div class="label-01 mb-3">{theme.name}</div>
+        <Highlight
+          class={theme.moduleName}
+          language={lang}
+          code={snippet.code}
+          langtag
+        />
+      </Column>
+    {/each}
+  </Row>
+{/each}

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -2,10 +2,12 @@
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
+  import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
   import hcl from "svelte-highlight/languages/hcl";
   import prisma from "svelte-highlight/languages/prisma";
+  import solidity from "svelte-highlight/languages/solidity";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import dracula from "svelte-highlight/styles/dracula";
   import github from "svelte-highlight/styles/github";
@@ -13,12 +15,13 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"hcl" | "prisma"} */
+  /** @type {"hcl" | "prisma" | "solidity"} */
   export let language;
 
   const registry = {
     hcl: { lang: hcl, snippets: hclPreviewSnippets },
     prisma: { lang: prisma, snippets: prismaPreviewSnippets },
+    solidity: { lang: solidity, snippets: solidityPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -34,6 +34,7 @@
     "/preview-vue": "Vue language preview",
     "/preview-mdx": "MDX language preview",
     "/preview-marko": "Marko language preview",
+    "/preview-hcl": "HCL language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -35,6 +35,7 @@
     "/preview-mdx": "MDX language preview",
     "/preview-marko": "Marko language preview",
     "/preview-hcl": "HCL language preview",
+    "/preview-prisma": "Prisma language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -36,6 +36,7 @@
     "/preview-marko": "Marko language preview",
     "/preview-hcl": "HCL language preview",
     "/preview-prisma": "Prisma language preview",
+    "/preview-solidity": "Solidity language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -37,6 +37,7 @@
     "/preview-hcl": "HCL language preview",
     "/preview-prisma": "Prisma language preview",
     "/preview-solidity": "Solidity language preview",
+    "/preview-zig": "Zig language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/pages/preview-hcl.astro
+++ b/www/pages/preview-hcl.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="HCL language preview">
+  <LanguagePreview language="hcl" client:idle />
+</Layout>

--- a/www/pages/preview-prisma.astro
+++ b/www/pages/preview-prisma.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Prisma language preview">
+  <LanguagePreview language="prisma" client:idle />
+</Layout>

--- a/www/pages/preview-solidity.astro
+++ b/www/pages/preview-solidity.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Solidity language preview">
+  <LanguagePreview language="solidity" client:idle />
+</Layout>

--- a/www/pages/preview-zig.astro
+++ b/www/pages/preview-zig.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Zig language preview">
+  <LanguagePreview language="zig" client:idle />
+</Layout>

--- a/www/preview/hcl-preview-snippets.ts
+++ b/www/preview/hcl-preview-snippets.ts
@@ -1,0 +1,76 @@
+export type HclPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const hclPreviewSnippets: HclPreviewSnippet[] = [
+  {
+    title: "Resource block",
+    // biome-ignore lint/suspicious/noTemplateCurlyInString: interpolation
+    description: 'resource blocks and "${...}" interpolation',
+    code: `# Web server
+resource "aws_instance" "web" {
+  ami           = var.ami_id
+  instance_type = "t3.micro"
+  count         = 2
+
+  tags = {
+    Name = "web-\${count.index}"
+    Env  = var.environment
+  }
+}`,
+  },
+  {
+    title: "Terraform settings",
+    description: "terraform, variable, output, and locals blocks",
+    code: `terraform {
+  required_version = ">= 1.6.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+  }
+}
+
+variable "environment" {
+  type    = string
+  default = "dev"
+}
+
+locals {
+  is_prod = var.environment == "prod"
+}
+
+output "instance_ids" {
+  value = aws_instance.web[*].id
+}`,
+  },
+  {
+    title: "Heredoc and dynamic blocks",
+    description: "<<- heredoc and dynamic ingress",
+    code: `resource "aws_iam_policy" "this" {
+  name = "example"
+
+  policy = <<-EOT
+    {
+      "Version": "2012-10-17",
+      "Statement": []
+    }
+  EOT
+}
+
+resource "aws_security_group" "this" {
+  dynamic "ingress" {
+    for_each = var.ports
+    content {
+      from_port = ingress.value
+      to_port   = ingress.value
+      protocol  = "tcp"
+    }
+  }
+}`,
+  },
+];

--- a/www/preview/prisma-preview-snippets.ts
+++ b/www/preview/prisma-preview-snippets.ts
@@ -1,0 +1,51 @@
+export type PrismaPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const prismaPreviewSnippets: PrismaPreviewSnippet[] = [
+  {
+    title: "Datasource and generator",
+    description: "datasource and generator blocks",
+    code: `datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+generator client {
+  provider = "prisma-client-js"
+}`,
+  },
+  {
+    title: "Model fields",
+    description: "scalar types, ?, [], and @attributes",
+    code: `model User {
+  id        Int      @id @default(autoincrement())
+  email     String   @unique
+  name      String?
+  role      Role     @default(USER)
+  posts     Post[]
+  createdAt DateTime @default(now())
+
+  @@map("users")
+}`,
+  },
+  {
+    title: "Relations and enums",
+    description: "@relation, @@index, and enum Role",
+    code: `model Post {
+  id       Int    @id @default(autoincrement())
+  title    String
+  author   User   @relation(fields: [authorId], references: [id])
+  authorId Int
+
+  @@index([authorId])
+}
+
+enum Role {
+  USER
+  ADMIN
+}`,
+  },
+];

--- a/www/preview/solidity-preview-snippets.ts
+++ b/www/preview/solidity-preview-snippets.ts
@@ -1,0 +1,85 @@
+export type SolidityPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const solidityPreviewSnippets: SolidityPreviewSnippet[] = [
+  {
+    title: "NatSpec comments",
+    description: "/// @title, @notice, @param",
+    code: `// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.24;
+
+/// @title A simple counter
+/// @notice Stores a number that anyone can increment
+contract Counter {
+  uint256 public count;
+
+  /// @param amount the value to add
+  function increment(uint256 amount) external {
+    count += amount;
+    emit Incremented(msg.sender, amount);
+  }
+
+  event Incremented(address indexed by, uint256 amount);
+}`,
+  },
+  {
+    title: "Mappings and modifiers",
+    description: "uint8, bytes32, mapping, modifier, require",
+    code: `pragma solidity ^0.8.24;
+
+contract Token {
+  mapping(address => uint256) private _balances;
+  uint8 public constant decimals = 18;
+  bytes32 public immutable salt;
+  address payable public owner;
+
+  modifier onlyOwner() {
+    require(msg.sender == owner, "not owner");
+    _;
+  }
+
+  function transfer(address to, uint256 amount)
+    public
+    returns (bool success)
+  {
+    require(_balances[msg.sender] >= amount, "insufficient");
+    _balances[msg.sender] -= amount;
+    _balances[to] += amount;
+    return true;
+  }
+}`,
+  },
+  {
+    title: "Interface and library",
+    description: "interface, library, is, ether, assembly",
+    code: `pragma solidity ^0.8.24;
+
+interface IERC20 {
+  function totalSupply() external view returns (uint256);
+}
+
+library Math {
+  function max(uint256 a, uint256 b) internal pure returns (uint256) {
+    return a >= b ? a : b;
+  }
+}
+
+contract Vault is IERC20 {
+  using Math for uint256;
+
+  uint256 public totalSupply = 1_000 ether;
+  uint256 public lockUntil = block.timestamp + 30 days;
+
+  function totalSupply() external view returns (uint256) {
+    uint256 free;
+    assembly {
+      free := sload(0)
+    }
+    return free;
+  }
+}`,
+  },
+];

--- a/www/preview/zig-preview-snippets.ts
+++ b/www/preview/zig-preview-snippets.ts
@@ -1,0 +1,59 @@
+export type ZigPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const zigPreviewSnippets: ZigPreviewSnippet[] = [
+  {
+    title: "Main with @import",
+    description: "@import, try, and !void",
+    code: `const std = @import("std");
+
+pub fn main() !void {
+    const stdout = std.io.getStdOut().writer();
+    try stdout.print("Hello, {s}!\\n", .{"world"});
+}`,
+  },
+  {
+    title: "Comptime struct",
+    description: "struct methods and comptime List(T)",
+    code: `const Point = struct {
+    x: f32,
+    y: f32,
+
+    pub fn distance(self: Point, other: Point) f32 {
+        const dx = self.x - other.x;
+        const dy = self.y - other.y;
+        return @sqrt(dx * dx + dy * dy);
+    }
+};
+
+fn List(comptime T: type) type {
+    return struct {
+        items: []T,
+        len: usize = 0,
+    };
+}`,
+  },
+  {
+    title: "Literals and switch",
+    description: "0x/0b literals, enum, switch, \\\\ strings",
+    code: `const Color = enum { red, green, blue };
+
+const mask: u32 = 0xFF_00;
+const flags: u8 = 0b1010_0101;
+
+fn describe(c: Color) []const u8 {
+    return switch (c) {
+        .red => "warm",
+        .green, .blue => "cool",
+    };
+}
+
+const banner =
+    \\\\Welcome
+    \\\\to Zig
+;`,
+  },
+];


### PR DESCRIPTION
Closes #206 

Adds a handful of grammars that are not shipped OOTB:
- HCL (Terraform)
- Prisma
- Solidity
- Zig

---

<img width="959" height="444" alt="Screenshot 2026-06-20 at 10 22 12 AM" src="https://github.com/user-attachments/assets/9216465a-1bf7-4c57-b9a9-a8a0cab5596f" />
<img width="798" height="221" alt="Screenshot 2026-06-20 at 10 22 46 AM" src="https://github.com/user-attachments/assets/9d5bc0ad-8558-45a7-a950-43d5b05f328e" />
<img width="810" height="258" alt="Screenshot 2026-06-20 at 10 22 36 AM" src="https://github.com/user-attachments/assets/712b3f81-707f-408a-b4ba-8741b0659e90" />
<img width="789" height="337" alt="Screenshot 2026-06-20 at 10 22 23 AM" src="https://github.com/user-attachments/assets/4d161bb7-a58c-42ee-8663-d51c87280e79" />
