### PR TITLE
feat: add `CopyButton`

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,20 @@ These apply to the outer container of every component (the `pre` element for `Hi
 | --padding-left           | Left padding for `td` elements                    | `var(--padding, 1em)`     |
 | --padding-right          | Right padding for `td` elements                   | `var(--padding, 1em)`     |
 
+### `CopyButton` variables
+
+| Variable             | Description                          | Default value |
+| :------------------- | :----------------------------------- | :------------ |
+| --copy-top           | Top offset of the button             | `0.5em`       |
+| --copy-right         | Right offset of the button           | `0.5em`       |
+| --copy-size          | Width and height of the button       | `2em`         |
+| --copy-padding       | Inner padding of the button          | `0.5em`       |
+| --copy-background    | Background color of the button       | `inherit`     |
+| --copy-color         | Foreground color of the button       | `inherit`     |
+| --copy-border-radius | Border radius of the button          | `4px`         |
+| --copy-border        | Border of the button                 | `none`        |
+| --copy-z-index       | Stacking order of the button         | `2`           |
+
 ### Language tag variables
 
 These apply when `langtag` is set to `true`.
@@ -415,6 +429,111 @@ With `HighlightAuto`:
 </HighlightAuto>
 ```
 
+## Copy Button
+
+Compose the `CopyButton` component alongside `Highlight` to add a copy-to-clipboard button. Wrap both in a relatively-positioned container so the button can be positioned over the code block.
+
+By default, it copies the `code` using the native [Clipboard API](https://developer.mozilla.org/en-US/docs/Web/API/Clipboard/writeText) and shows a transient "copied" state. The button renders a copy icon that swaps to a checkmark on success; the `text` / `copiedText` props set the `aria-label` for each state. Clicks are ignored while in the "copied" state, so no duplicate copy fires.
+
+```svelte
+<script>
+  import { Highlight, CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const add = (a: number, b: number) => a + b";
+</script>
+
+<svelte:head>
+  {@html atomOneDark}
+</svelte:head>
+
+<div style="position: relative">
+  <Highlight language={typescript} {code} />
+  <CopyButton {code} />
+</div>
+```
+
+### Custom Copy Behavior
+
+Pass a `copy` function to override the default copy behavior. It receives the `code` to copy and may be async (return a promise); the "copied" state is shown only once it resolves. Clicks are ignored while a copy is in flight, so a slow async `copy` can't fire duplicates.
+
+```svelte
+<script>
+  function copy(code) {
+    navigator.clipboard.writeText(code);
+    console.log("Copied:", code);
+  }
+</script>
+
+<CopyButton {code} {copy} />
+```
+
+The component dispatches a `copy` event on success and an `error` event if the copy behavior throws.
+
+```svelte
+<CopyButton
+  {code}
+  on:copy={(e) => console.log(e.detail.code)}
+  on:error={(e) => console.error(e.detail.error)}
+/>
+```
+
+### Custom Button Content
+
+Provide custom button content using the default slot to replace the default icons. The slot exposes a `copied` boolean and a `copying` boolean (`true` while an async `copy` is in flight), so you can render a pending state for slow copy functions.
+
+```svelte
+<CopyButton {code} let:copied let:copying>
+  {#if copying}Copying…{:else if copied}Copied!{:else}Copy{/if}
+</CopyButton>
+```
+
+### Custom Styles
+
+Use `--copy-*` style props to customize the button.
+
+```svelte
+<CopyButton
+  {code}
+  --copy-background="rgba(255, 255, 255, 0.1)"
+  --copy-color="#fff"
+  --copy-border-radius="8px"
+/>
+```
+
+### With Line Numbers
+
+Compose `CopyButton` with `LineNumbers` by wrapping both in a relatively-positioned container.
+
+```svelte
+<div style="position: relative">
+  <Highlight language={typescript} {code} let:highlighted>
+    <LineNumbers {highlighted} />
+  </Highlight>
+  <CopyButton {code} />
+</div>
+```
+
+### With Language Tag
+
+When using a language tag alongside `CopyButton`, offset `--langtag-top` and `--langtag-right` so the tag sits to the left of the button (the copy button defaults to `--copy-top: 0.5em`, `--copy-right: 0.5em`, and `--copy-size: 2em`).
+
+```svelte
+<div style="position: relative">
+  <Highlight
+    language={typescript}
+    {code}
+    langtag
+    --langtag-top="0"
+    --langtag-right="3em"
+    --langtag-padding="0.25em 0.5em"
+    --langtag-font-size="0.75em"
+  />
+  <CopyButton {code} />
+</div>
+```
+
 ## Language Targeting
 
 All `Highlight` components apply a `data-language` attribute on the codeblock containing the language name.
@@ -614,6 +733,33 @@ In the example below, the `HighlightAuto` component and injected styles are dyna
 | languageName       | `string`   | `"plaintext"`  |
 
 `$$restProps` are forwarded to the top-level `div` element.
+
+### `CopyButton`
+
+#### Props
+
+| Name       | Type                                       | Default value                                |
+| :--------- | :----------------------------------------- | :------------------------------------------- |
+| code       | `string`                                   | N/A (required)                               |
+| copy       | `(code: string) => void \| Promise<void>`  | `(code) => navigator.clipboard.writeText(code)` |
+| timeout    | `number`                                   | `2000`                                       |
+| text       | `string`                                   | `"Copy"`                                     |
+| copiedText | `string`                                   | `"Copied!"`                                  |
+
+`$$restProps` are forwarded to the top-level `button` element.
+
+#### Dispatched Events
+
+- **on:copy**: fired after a successful copy, with `{ code }`
+- **on:error**: fired if the copy behavior throws, with `{ error }`
+
+```svelte
+<CopyButton
+  {code}
+  on:copy={(e) => console.log(e.detail.code)}
+  on:error={(e) => console.error(e.detail.error)}
+/>
+```
 
 ### `HighlightSvelte`
 

--- a/src/CopyButton.svelte
+++ b/src/CopyButton.svelte
@@ -1,0 +1,118 @@
+<script>
+  /** @type {string} */
+  export let code;
+
+  /**
+   * Override the copy behavior. Receives the `code` to copy and may
+   * return a promise. When omitted, the native Clipboard API is used.
+   * @type {(code: string) => void | Promise<void>}
+   */
+  export let copy = (code) => navigator.clipboard.writeText(code);
+
+  /** @type {number} */
+  export let timeout = 2_000;
+
+  /** @type {string} */
+  export let text = "Copy";
+
+  /** @type {string} */
+  export let copiedText = "Copied!";
+
+  import { createEventDispatcher, onMount } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  /** @type {boolean} */
+  let copied = false;
+
+  /** @type {boolean} */
+  let copying = false;
+
+  /** @type {ReturnType<typeof setTimeout> | undefined} */
+  let timeoutId;
+
+  async function handleClick() {
+    // Ignore clicks while a copy is in flight or the "copied" state is active,
+    // so no duplicate copy fires (even for slow async `copy` functions) and the
+    // "copied" icon stays visible until the timeout elapses.
+    if (copying || copied) return;
+
+    try {
+      copying = true;
+      await copy(code);
+      copied = true;
+      dispatch("copy", { code });
+      timeoutId = setTimeout(() => {
+        copied = false;
+      }, timeout);
+    } catch (error) {
+      dispatch("error", { error });
+    } finally {
+      copying = false;
+    }
+  }
+
+  onMount(() => () => clearTimeout(timeoutId));
+</script>
+
+<button
+  type="button"
+  aria-label={copied ? copiedText : text}
+  on:click={handleClick}
+  on:mouseenter
+  on:mouseleave
+  {...$$restProps}
+>
+  <slot {copied} {copying}>
+    {#if copied}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 32 32"
+        width="16"
+        height="16"
+        fill="currentColor"
+        preserveAspectRatio="xMidYMid meet"
+        aria-hidden="true"
+      >
+        <path
+          d="M13 24 4 15 5.414 13.586 13 21.171 26.586 7.586 28 9 13 24z"
+        ></path>
+      </svg>
+    {:else}
+      <svg
+        xmlns="http://www.w3.org/2000/svg"
+        viewBox="0 0 32 32"
+        width="16"
+        height="16"
+        fill="currentColor"
+        preserveAspectRatio="xMidYMid meet"
+        aria-hidden="true"
+      >
+        <path
+          d="M28,10V28H10V10H28m0-2H10a2,2,0,0,0-2,2V28a2,2,0,0,0,2,2H28a2,2,0,0,0,2-2V10a2,2,0,0,0-2-2Z"
+        ></path>
+        <path d="M4,18H2V4A2,2,0,0,1,4,2H18V4H4Z"></path>
+      </svg>
+    {/if}
+  </slot>
+</button>
+
+<style>
+  button {
+    position: absolute;
+    top: var(--copy-top, 0.5em);
+    right: var(--copy-right, 0.5em);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: var(--copy-size, 2em);
+    height: var(--copy-size, 2em);
+    padding: var(--copy-padding, 0.5em);
+    background: var(--copy-background, inherit);
+    color: var(--copy-color, inherit);
+    border-radius: var(--copy-border-radius, 4px);
+    border: var(--copy-border, none);
+    z-index: var(--copy-z-index, 2);
+    cursor: pointer;
+  }
+</style>

--- a/src/CopyButton.svelte.d.ts
+++ b/src/CopyButton.svelte.d.ts
@@ -1,0 +1,138 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLButtonAttributes } from "svelte/elements";
+
+export type CopyButtonProps = HTMLButtonAttributes & {
+  /**
+   * Specify the text to copy to the clipboard.
+   */
+  code: string;
+
+  /**
+   * Override the copy behavior. Receives the `code` to copy and may
+   * return a promise. When omitted, the native Clipboard API is used.
+   * @default (code) => navigator.clipboard.writeText(code)
+   */
+  copy?: (code: string) => void | Promise<void>;
+
+  /**
+   * Set the duration in milliseconds to show the
+   * "copied" state before reverting.
+   * @default 2000
+   */
+  timeout?: number;
+
+  /**
+   * Specify the accessible label (`aria-label`) for the button.
+   * Used as the fallback text only if the default icon slot is overridden.
+   * @default "Copy"
+   */
+  text?: string;
+
+  /**
+   * Specify the accessible label (`aria-label`) shown after a successful copy.
+   * Used as the fallback text only if the default icon slot is overridden.
+   * @default "Copied!"
+   */
+  copiedText?: string;
+
+  /**
+   * Customize the top offset of the button.
+   * @default "0.5em"
+   */
+  "--copy-top"?: string;
+
+  /**
+   * Customize the right offset of the button.
+   * @default "0.5em"
+   */
+  "--copy-right"?: string;
+
+  /**
+   * Customize the width and height of the button.
+   * @default "2em"
+   */
+  "--copy-size"?: string;
+
+  /**
+   * Customize the inner padding of the button.
+   * @default "0.5em"
+   */
+  "--copy-padding"?: string;
+
+  /**
+   * Customize the background color of the button.
+   * @default "inherit"
+   */
+  "--copy-background"?: string;
+
+  /**
+   * Customize the foreground color of the button.
+   * @default "inherit"
+   */
+  "--copy-color"?: string;
+
+  /**
+   * Customize the border radius of the button.
+   * @default "4px"
+   */
+  "--copy-border-radius"?: string;
+
+  /**
+   * Customize the border of the button.
+   * @default "none"
+   */
+  "--copy-border"?: string;
+
+  /**
+   * Customize the stacking order of the button.
+   * @default 2
+   */
+  "--copy-z-index"?: string | number;
+};
+
+export type CopyButtonEvents = {
+  copy: CustomEvent<{
+    /**
+     * The code that was copied.
+     */
+    code: string;
+  }>;
+  error: CustomEvent<{
+    /**
+     * The error thrown by the copy behavior.
+     */
+    error: unknown;
+  }>;
+
+  /**
+   * Forwarded from the `button` element. Useful for prefetching
+   * an async copy on hover.
+   */
+  mouseenter: MouseEvent;
+
+  /**
+   * Forwarded from the `button` element.
+   */
+  mouseleave: MouseEvent;
+};
+
+export type CopyButtonSlots = {
+  default: {
+    /**
+     * `true` while the "copied" state is active.
+     */
+    copied: boolean;
+
+    /**
+     * `true` while an async `copy` is in flight (before it resolves).
+     * Useful for rendering a pending state for slow copy functions.
+     */
+    copying: boolean;
+  };
+};
+
+export default class CopyButton extends SvelteComponentTyped<
+  CopyButtonProps,
+  CopyButtonEvents,
+  CopyButtonSlots
+> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,4 @@
+export { default as CopyButton } from "./CopyButton.svelte";
 export { default as Highlight, default } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export { default as CopyButton } from "./CopyButton.svelte";
 export { default, default as Highlight } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";

--- a/src/langtag.css
+++ b/src/langtag.css
@@ -14,4 +14,5 @@
   color: var(--langtag-color, inherit);
   border-radius: var(--langtag-border-radius, 0);
   padding: var(--langtag-padding, 1em);
+  font-size: var(--langtag-font-size, inherit);
 }

--- a/tests/SvelteHighlightPackage.test.svelte
+++ b/tests/SvelteHighlightPackage.test.svelte
@@ -1,5 +1,9 @@
 <script lang="ts">
-  import Highlight, { HighlightAuto, LineNumbers } from "../package";
+  import Highlight, {
+    CopyButton,
+    HighlightAuto,
+    LineNumbers,
+  } from "../package";
   import Highlight2 from "../package/Highlight.svelte";
   import { typescript } from "../package/languages";
   import javascript from "../package/languages/javascript";
@@ -49,6 +53,36 @@
     console.log(e.detail.language);
   }}
 />
+
+<div style="position: relative">
+  <Highlight language={typescript} code="" />
+  <CopyButton
+    code=""
+    timeout={3000}
+    text="Copy"
+    copiedText="Copied!"
+    copy={(code) => navigator.clipboard.writeText(code)}
+    on:copy={(e) => {
+      console.log(e.detail.code);
+    }}
+    on:error={(e) => {
+      console.error(e.detail.error);
+    }}
+    --copy-top="0.5em"
+    --copy-right="0.5em"
+    --copy-size="2em"
+    --copy-padding="0.5em"
+    --copy-background="inherit"
+    --copy-color="inherit"
+    --copy-border-radius="4px"
+    --copy-border="none"
+    --copy-z-index={2}
+    let:copied
+    let:copying
+  >
+    {copying ? "…" : copied ? "Copied!" : "Copy"}
+  </CopyButton>
+</div>
 
 <Highlight
   code=""

--- a/tests/e2e/CopyButton.asyncCopy.test.svelte
+++ b/tests/e2e/CopyButton.asyncCopy.test.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+  import Highlight, { CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+
+  let count = 0;
+
+  /** A slow async copy to exercise the in-flight dedup guard. */
+  function copy() {
+    count += 1;
+    return new Promise<void>((resolve) => setTimeout(resolve, 500));
+  }
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<div style="position: relative">
+  <Highlight language={typescript} {code} />
+  <CopyButton {code} {copy} timeout={1000} let:copying>
+    {#if copying}
+      <span data-testid="pending">…</span>
+    {/if}
+  </CopyButton>
+</div>
+
+<output data-testid="count">{count}</output>

--- a/tests/e2e/CopyButton.customCopy.test.svelte
+++ b/tests/e2e/CopyButton.customCopy.test.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import Highlight, { CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+
+  let copied = "";
+  let count = 0;
+
+  /** Override the copy behavior; bypasses the native Clipboard API. */
+  function copy(value: string) {
+    copied = value;
+    count += 1;
+  }
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<div style="position: relative">
+  <Highlight language={typescript} {code} />
+  <CopyButton
+    {code}
+    {copy}
+    timeout={1000}
+    --copy-size="60px"
+    --copy-z-index="5"
+  />
+</div>
+
+<output data-testid="copied">{copied}</output>
+<output data-testid="count">{count}</output>

--- a/tests/e2e/CopyButton.test.svelte
+++ b/tests/e2e/CopyButton.test.svelte
@@ -1,0 +1,14 @@
+<script lang="ts">
+  import Highlight, { CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<div style="position: relative">
+  <Highlight language={typescript} {code} />
+  <CopyButton {code} timeout={1000} />
+</div>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1,4 +1,7 @@
 import { expect, test } from "@playwright/experimental-ct-svelte";
+import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
+import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
+import CopyButton from "./CopyButton.test.svelte";
 import Highlight from "./Highlight.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
@@ -222,4 +225,101 @@ test("LangTag", async ({ mount, page }) => {
 
   const preElement = page.locator("pre.langtag");
   await expect(preElement).toHaveCSS("position", "relative");
+});
+
+test("CopyButton - copies via the native Clipboard API", async ({
+  mount,
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== "chromium",
+    "Clipboard permissions are Chromium-only",
+  );
+
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  const component = await mount(CopyButton);
+
+  const button = page.getByRole("button", { name: "Copy" });
+  await expect(button).toBeVisible();
+  await button.click();
+
+  const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboard).toBe("const add = (a: number, b: number) => a + b;");
+
+  // The "copied" state is reflected on the button, then reverts after the timeout.
+  await expect(
+    component.getByRole("button", { name: "Copied!" }),
+  ).toBeVisible();
+  await expect(component.getByRole("button", { name: "Copy" })).toBeVisible({
+    timeout: 3_000,
+  });
+});
+
+test("CopyButton - custom copy prop overrides the Clipboard API", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(CopyButtonCustomCopy);
+
+  await expect(page.getByTestId("copied")).toHaveText("");
+  const button = component.getByRole("button");
+  await button.click();
+  await expect(page.getByTestId("copied")).toHaveText(
+    "const add = (a: number, b: number) => a + b;",
+  );
+
+  // CSS custom properties customize the button without !important.
+  await expect(button).toHaveCSS("width", "60px");
+  await expect(button).toHaveCSS("z-index", "5");
+});
+
+test("CopyButton - ignores duplicate clicks while in the copied state", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(CopyButtonCustomCopy);
+
+  const button = component.getByRole("button");
+  await button.click();
+
+  // The "copied" icon is shown (aria-label reflects the copied state).
+  await expect(button).toHaveAttribute("aria-label", "Copied!");
+  await expect(page.getByTestId("count")).toHaveText("1");
+
+  // Clicking again while copied must not fire another copy...
+  await button.click();
+  await expect(page.getByTestId("count")).toHaveText("1");
+  // ...and the "copied" icon remains visible.
+  await expect(button).toHaveAttribute("aria-label", "Copied!");
+
+  // The state reverts after the configured timeout (1000ms here).
+  await expect(button).toHaveAttribute("aria-label", "Copy", {
+    timeout: 3_000,
+  });
+});
+
+test("CopyButton - dedupes clicks while an async copy is in flight", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(CopyButtonAsyncCopy);
+
+  const button = component.getByRole("button");
+  await button.click();
+
+  // The copy is in flight (slot exposes `copying`); clicking again is ignored.
+  await expect(page.getByTestId("pending")).toBeVisible();
+  await expect(page.getByTestId("count")).toHaveText("1");
+  await button.click();
+  await expect(page.getByTestId("count")).toHaveText("1");
+
+  // Once it resolves, the "copied" state is shown, then reverts.
+  await expect(button).toHaveAttribute("aria-label", "Copied!", {
+    timeout: 3_000,
+  });
+  await expect(button).toHaveAttribute("aria-label", "Copy", {
+    timeout: 3_000,
+  });
 });

--- a/www/components/CopyButton/Basic.svelte
+++ b/www/components/CopyButton/Basic.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+
+  export let snippet = "<CopyButton {code} />";
+
+  import { CopyButton, HighlightSvelte } from "svelte-highlight";
+
+  const code = `<script>
+  import Highlight, { CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+  const code = "const add = (a: number, b: number) => a + b";
+<\/script>
+
+<svelte:head>
+  {@html ${THEME_MODULE_NAME}}
+</svelte:head>
+
+<div style="position: relative">
+  <Highlight language={typescript} {code} />
+  ${snippet}
+</div>`;
+</script>
+
+<div style="position: relative">
+  <HighlightSvelte {code} class={THEME_MODULE_NAME} />
+  <CopyButton {code} {...$$restProps} />
+</div>

--- a/www/components/CopyButton/CustomFunction.svelte
+++ b/www/components/CopyButton/CustomFunction.svelte
@@ -1,0 +1,39 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+  import { CopyButton, HighlightSvelte } from "svelte-highlight";
+
+  const snippet = `const code = "const add = (a: number, b: number) => a + b";
+
+  // Override the default Clipboard API behavior.
+  function copy(code) {
+    navigator.clipboard.writeText(code);
+    console.log("Copied:", code);
+  }`;
+
+  const code = `<script>
+  import Highlight, { CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+  ${snippet}
+<\/script>
+
+<svelte:head>
+  {@html ${THEME_MODULE_NAME}}
+</svelte:head>
+
+<div style="position: relative">
+  <Highlight language={typescript} {code} />
+  <CopyButton {code} {copy} />
+</div>`;
+
+  function copy(value) {
+    navigator.clipboard.writeText(value);
+    console.log("Copied:", value);
+  }
+</script>
+
+<div style="position: relative">
+  <HighlightSvelte {code} class={THEME_MODULE_NAME} />
+  <CopyButton {code} {copy} />
+</div>

--- a/www/components/CopyButton/Langtag.svelte
+++ b/www/components/CopyButton/Langtag.svelte
@@ -1,0 +1,42 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+  import { CopyButton, HighlightSvelte } from "svelte-highlight";
+
+  const code = `<script>
+  import Highlight, { CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+  const code = "const add = (a: number, b: number) => a + b";
+<\/script>
+
+<svelte:head>
+  {@html ${THEME_MODULE_NAME}}
+</svelte:head>
+
+<div style="position: relative">
+  <Highlight
+    language={typescript}
+    {code}
+    langtag
+    --langtag-top="0"
+    --langtag-right="3em"
+    --langtag-padding="0.25em 0.5em"
+    --langtag-font-size="0.75em"
+  />
+  <CopyButton {code} />
+</div>`;
+</script>
+
+<div style="position: relative">
+  <HighlightSvelte
+    {code}
+    class={THEME_MODULE_NAME}
+    langtag
+    --langtag-top="0"
+    --langtag-right="3em"
+    --langtag-padding="0.25em 0.5em"
+    --langtag-font-size="0.75em"
+  />
+  <CopyButton {code} />
+</div>

--- a/www/components/CopyButton/LineNumbers.svelte
+++ b/www/components/CopyButton/LineNumbers.svelte
@@ -1,0 +1,30 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+  import { CopyButton, HighlightSvelte, LineNumbers } from "svelte-highlight";
+
+  const code = `<script>
+  import Highlight, { CopyButton, LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+  const code = "const add = (a: number, b: number) => a + b";
+<\/script>
+
+<svelte:head>
+  {@html ${THEME_MODULE_NAME}}
+</svelte:head>
+
+<div style="position: relative">
+  <Highlight language={typescript} {code} let:highlighted>
+    <LineNumbers {highlighted} />
+  </Highlight>
+  <CopyButton {code} />
+</div>`;
+</script>
+
+<div style="position: relative">
+  <HighlightSvelte {code} let:highlighted>
+    <LineNumbers class={THEME_MODULE_NAME} {highlighted} />
+  </HighlightSvelte>
+  <CopyButton {code} />
+</div>

--- a/www/components/CopyButton/Slot.svelte
+++ b/www/components/CopyButton/Slot.svelte
@@ -1,0 +1,38 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+  import { CopyButton, HighlightSvelte } from "svelte-highlight";
+
+  const code = `<script>
+  import Highlight, { CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+  const code = "const add = (a: number, b: number) => a + b";
+<\/script>
+
+<svelte:head>
+  {@html ${THEME_MODULE_NAME}}
+</svelte:head>
+
+<div style="position: relative">
+  <Highlight language={typescript} {code} />
+  <CopyButton {code} let:copied --copy-right="2em">
+    {#if copied}
+      Copied!
+    {:else}
+      Copy
+    {/if}
+  </CopyButton>
+</div>`;
+</script>
+
+<div style="position: relative">
+  <HighlightSvelte {code} class={THEME_MODULE_NAME} />
+  <CopyButton {code} let:copied --copy-right="2em">
+    {#if copied}
+      Copied!
+    {:else}
+      Copy
+    {/if}
+  </CopyButton>
+</div>

--- a/www/components/CopyButton/StyleProps.svelte
+++ b/www/components/CopyButton/StyleProps.svelte
@@ -1,0 +1,19 @@
+<script>
+  import Basic from "./Basic.svelte";
+
+  const snippet = `<CopyButton
+    {code}
+    --copy-background="rgba(255, 255, 255, 0.1)"
+    --copy-color="#fff"
+    --copy-border-radius="8px"
+    --copy-size="2.5em"
+  />`;
+</script>
+
+<Basic
+  {snippet}
+  --copy-background="rgba(255, 255, 255, 0.1)"
+  --copy-color="#fff"
+  --copy-border-radius="8px"
+  --copy-size="2.5em"
+/>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -1,5 +1,11 @@
 <script>
   import CodeSnippet from "@components/CodeSnippet.svelte";
+  import CopyButtonBasic from "@components/CopyButton/Basic.svelte";
+  import CopyButtonCustomFunction from "@components/CopyButton/CustomFunction.svelte";
+  import CopyButtonLangtag from "@components/CopyButton/Langtag.svelte";
+  import CopyButtonLineNumbers from "@components/CopyButton/LineNumbers.svelte";
+  import CopyButtonSlot from "@components/CopyButton/Slot.svelte";
+  import CopyButtonStyleProps from "@components/CopyButton/StyleProps.svelte";
   import Basic from "@components/LineNumbers/Basic.svelte";
   import ContainerStyle from "@components/LineNumbers/ContainerStyle.svelte";
   import FocusLines from "@components/LineNumbers/FocusLines.svelte";
@@ -288,6 +294,64 @@
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <Langtag /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Copy Button</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Compose the <code class="code">CopyButton</code> component alongside
+      <code class="code">Highlight</code>
+      to add a copy-to-clipboard button. Position it by wrapping both in a
+      relatively-positioned container.
+    </p>
+    <p class="mb-5">
+      By default, it copies the <code class="code">code</code> using the native
+      Clipboard API and shows a transient "copied" state.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CopyButtonBasic /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Pass a <code class="code">copy</code> function to override the default
+      copy behavior—for example, to add logging or a custom toast.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CopyButtonCustomFunction /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Provide custom button content using the default slot. The slot exposes a
+      <code class="code">copied</code>
+      boolean.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CopyButtonSlot /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Use <code class="code">--copy-*</code> style props to customize the
+      offset, size, and colors of the button.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CopyButtonStyleProps /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Compose <code class="code">CopyButton</code> with
+      <code class="code">LineNumbers</code>
+      by wrapping both in a relatively-positioned container.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CopyButtonLineNumbers /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      When using a language tag alongside
+      <code class="code">CopyButton</code>, offset
+      <code class="code">--langtag-top</code>
+      and
+      <code class="code">--langtag-right</code>
+      so the tag sits to the left of the button.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CopyButtonLangtag /> </Column>
 </Row>
 
 <Row class="mb-9">


### PR DESCRIPTION
Closes #343, closes #377, closes #351

Adds a `CopyButton`: composable, with forwarded/dispatched events, async support, full style customization.