### PR TITLE
feat(languages): add custom `toml`, `fish`, `nushell`, `gleam`, `liquid`, `blade` grammars

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 202 languages exported from highlight.js@11.11.1
+> 203 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2199,6 +2199,20 @@
 
   // base import
   import { thrift } from "svelte-highlight/languages";
+</script>
+```
+
+## toml (`toml`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import toml from "svelte-highlight/languages/toml";
+
+  // base import
+  import { toml } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 204 languages exported from highlight.js@11.11.1
+> 205 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1523,6 +1523,20 @@
 
   // base import
   import { nsis } from "svelte-highlight/languages";
+</script>
+```
+
+## nushell (`nushell`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import nushell from "svelte-highlight/languages/nushell";
+
+  // base import
+  import { nushell } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 203 languages exported from highlight.js@11.11.1
+> 204 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -697,6 +697,20 @@
 
   // base import
   import { excel } from "svelte-highlight/languages";
+</script>
+```
+
+## fish (`fish`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import fish from "svelte-highlight/languages/fish";
+
+  // base import
+  import { fish } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 207 languages exported from highlight.js@11.11.1
+> 208 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -253,6 +253,20 @@
 
   // base import
   import { basic } from "svelte-highlight/languages";
+</script>
+```
+
+## blade (`blade`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import blade from "svelte-highlight/languages/blade";
+
+  // base import
+  import { blade } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 205 languages exported from highlight.js@11.11.1
+> 206 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -807,6 +807,20 @@
 
   // base import
   import { gherkin } from "svelte-highlight/languages";
+</script>
+```
+
+## gleam (`gleam`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import gleam from "svelte-highlight/languages/gleam";
+
+  // base import
+  import { gleam } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 206 languages exported from highlight.js@11.11.1
+> 207 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1209,6 +1209,20 @@
 
   // base import
   import { less } from "svelte-highlight/languages";
+</script>
+```
+
+## liquid (`liquid`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import liquid from "svelte-highlight/languages/liquid";
+
+  // base import
+  import { liquid } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -88,6 +88,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "liquid",
     path: `${import.meta.dir}/custom-languages/liquid.js`,
   },
+  {
+    name: "blade",
+    moduleName: "blade",
+    path: `${import.meta.dir}/custom-languages/blade.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -78,6 +78,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "nushell",
     path: `${import.meta.dir}/custom-languages/nushell.js`,
   },
+  {
+    name: "gleam",
+    moduleName: "gleam",
+    path: `${import.meta.dir}/custom-languages/gleam.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -73,6 +73,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "fish",
     path: `${import.meta.dir}/custom-languages/fish.js`,
   },
+  {
+    name: "nushell",
+    moduleName: "nushell",
+    path: `${import.meta.dir}/custom-languages/nushell.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -68,6 +68,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "toml",
     path: `${import.meta.dir}/custom-languages/toml.js`,
   },
+  {
+    name: "fish",
+    moduleName: "fish",
+    path: `${import.meta.dir}/custom-languages/fish.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -63,6 +63,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "zig",
     path: `${import.meta.dir}/custom-languages/zig.js`,
   },
+  {
+    name: "toml",
+    moduleName: "toml",
+    path: `${import.meta.dir}/custom-languages/toml.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -83,6 +83,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "gleam",
     path: `${import.meta.dir}/custom-languages/gleam.js`,
   },
+  {
+    name: "liquid",
+    moduleName: "liquid",
+    path: `${import.meta.dir}/custom-languages/liquid.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/custom-languages/blade.js
+++ b/scripts/custom-languages/blade.js
@@ -1,0 +1,56 @@
+import xmlRegister from "highlight.js/lib/languages/xml";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineBlade(hljs) {
+  const VARIABLE = {
+    className: "variable",
+    begin: /\$+[A-Za-z_]\w*/,
+    relevance: 0,
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /"/, end: /"/ },
+      { begin: /'/, end: /'/ },
+    ],
+  };
+
+  const DIRECTIVE = {
+    className: "keyword",
+    begin: /@[a-zA-Z]\w*/,
+    relevance: 10,
+  };
+
+  const COMMENT = hljs.COMMENT(/\{\{--/, /--\}\}/);
+
+  const RAW_ECHO = {
+    className: "template-variable",
+    begin: /\{!!/,
+    end: /!!\}/,
+    contains: [VARIABLE, STRING, hljs.NUMBER_MODE],
+  };
+
+  const ECHO = {
+    className: "template-variable",
+    begin: /\{\{-?/,
+    end: /-?\}\}/,
+    contains: [VARIABLE, STRING, hljs.NUMBER_MODE],
+  };
+
+  return {
+    name: "Blade",
+    aliases: ["blade"],
+    subLanguage: "xml",
+    contains: [COMMENT, DIRECTIVE, RAW_ECHO, ECHO],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  hljs.registerLanguage("xml", xmlRegister);
+  return defineBlade(hljs);
+}
+
+export const blade = { name: "blade", register };
+export default blade;

--- a/scripts/custom-languages/fish.js
+++ b/scripts/custom-languages/fish.js
@@ -1,0 +1,68 @@
+const FISH_KEYWORDS =
+  "function end if else switch case while for in begin and or not " +
+  "return break continue";
+
+const FISH_BUILTINS =
+  "set read echo printf string math test command builtin source eval " +
+  "exec status type abbr alias bind complete functions count contains " +
+  "argparse cd pwd exit history jobs trap fg bg wait";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineFish(hljs) {
+  const VARIABLE = {
+    className: "variable",
+    begin: /\$+[A-Za-z_][\w]*/,
+    relevance: 0,
+  };
+
+  const SUBSTITUTION = {
+    className: "subst",
+    begin: /\$\(/,
+    end: /\)/,
+    contains: [VARIABLE],
+  };
+
+  const STRING = {
+    className: "string",
+    begin: /"/,
+    end: /"/,
+    contains: [hljs.BACKSLASH_ESCAPE, VARIABLE, SUBSTITUTION],
+  };
+
+  const LITERAL_STRING = {
+    className: "string",
+    begin: /'/,
+    end: /'/,
+    contains: [hljs.BACKSLASH_ESCAPE],
+  };
+
+  const FUNCTION = {
+    beginKeywords: "function",
+    end: /$/,
+    excludeBegin: true,
+    contains: [{ className: "title function_", begin: /[A-Za-z_][\w-]*/ }],
+  };
+
+  return {
+    name: "fish",
+    aliases: ["fish"],
+    keywords: { keyword: FISH_KEYWORDS, built_in: FISH_BUILTINS },
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      FUNCTION,
+      STRING,
+      LITERAL_STRING,
+      VARIABLE,
+      SUBSTITUTION,
+      hljs.NUMBER_MODE,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineFish(hljs);
+}
+
+export const fish = { name: "fish", register };
+export default fish;

--- a/scripts/custom-languages/gleam.js
+++ b/scripts/custom-languages/gleam.js
@@ -1,0 +1,63 @@
+const GLEAM_KEYWORDS =
+  "as assert case const fn if import let opaque panic pub todo type use echo";
+
+const GLEAM_LITERALS = "True False Nil";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineGleam(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F][0-9a-fA-F_]*\b/ },
+      { begin: /\b0[oO][0-7][0-7_]*\b/ },
+      { begin: /\b0[bB][01][01_]*\b/ },
+      { begin: /\b\d[\d_]*(?:\.\d[\d_]*)?(?:[eE][+-]?\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const LITERAL = {
+    className: "literal",
+    begin: /\b(?:True|False|Nil)\b/,
+  };
+
+  const TYPE = {
+    className: "type",
+    begin: /\b[A-Z]\w*/,
+    relevance: 0,
+  };
+
+  const ATTRIBUTE = {
+    className: "meta",
+    begin: /@[a-z]\w*/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    begin: [/\bfn/, /\s+/, /[a-z_]\w*/],
+    beginScope: { 1: "keyword", 3: "title function_" },
+  };
+
+  return {
+    name: "Gleam",
+    aliases: ["gleam"],
+    keywords: { keyword: GLEAM_KEYWORDS, literal: GLEAM_LITERALS },
+    contains: [
+      hljs.COMMENT(/\/\/\/?\/?/, /$/),
+      hljs.QUOTE_STRING_MODE,
+      ATTRIBUTE,
+      NUMBER,
+      FUNCTION,
+      LITERAL,
+      TYPE,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineGleam(hljs);
+}
+
+export const gleam = { name: "gleam", register };
+export default gleam;

--- a/scripts/custom-languages/liquid.js
+++ b/scripts/custom-languages/liquid.js
@@ -1,0 +1,55 @@
+import xmlRegister from "highlight.js/lib/languages/xml";
+
+const LIQUID_KEYWORDS =
+  "if elsif else endif unless endunless case when endcase for endfor in " +
+  "break continue cycle tablerow endtablerow assign capture endcapture " +
+  "increment decrement include render section layout liquid echo with as " +
+  "empty blank and or not contains comment endcomment raw endraw limit " +
+  "offset reversed range";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineLiquid(hljs) {
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /"/, end: /"/ },
+      { begin: /'/, end: /'/ },
+    ],
+  };
+
+  const FILTER = {
+    begin: /\|\s*/,
+    contains: [{ className: "built_in", begin: /[a-z_]\w*/ }],
+    relevance: 0,
+  };
+
+  return {
+    name: "Liquid",
+    aliases: ["liquid"],
+    subLanguage: "xml",
+    contains: [
+      {
+        className: "template-tag",
+        begin: /\{%-?/,
+        end: /-?%\}/,
+        keywords: LIQUID_KEYWORDS,
+        contains: [STRING, hljs.NUMBER_MODE, FILTER],
+      },
+      {
+        className: "template-variable",
+        begin: /\{\{-?/,
+        end: /-?\}\}/,
+        contains: [STRING, hljs.NUMBER_MODE, FILTER],
+      },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  hljs.registerLanguage("xml", xmlRegister);
+  return defineLiquid(hljs);
+}
+
+export const liquid = { name: "liquid", register };
+export default liquid;

--- a/scripts/custom-languages/nushell.js
+++ b/scripts/custom-languages/nushell.js
@@ -1,0 +1,77 @@
+const NU_KEYWORDS =
+  "def def-env export use let mut const if else match for in while loop " +
+  "break continue return do try catch alias module overlay source hide " +
+  "where extern register";
+
+const NU_BUILTINS =
+  "echo print ls cd pwd open save get select reject where each reduce " +
+  "filter sort-by group-by uniq first last length reverse append prepend " +
+  "insert update upsert str split join lines parse from to into format " +
+  "math random http find skip take flatten wrap rename drop";
+
+const NU_LITERALS = "true false null";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineNushell(hljs) {
+  const VARIABLE = {
+    className: "variable",
+    begin: /\$[A-Za-z_][\w]*/,
+    relevance: 0,
+  };
+
+  const FLAG = {
+    className: "symbol",
+    begin: /(?:^|\s)--?[A-Za-z][\w-]*/,
+    relevance: 0,
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /'/, end: /'/ },
+      { begin: /`/, end: /`/ },
+    ],
+  };
+
+  const NUMBER = {
+    className: "number",
+    begin:
+      /\b\d[\d_]*(?:\.\d[\d_]*)?(?:ns|us|ms|sec|min|hr|day|wk|b|kb|mb|gb|tb|pb|kib|mib|gib)?\b/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    beginKeywords: "def def-env extern",
+    end: /[[{(]/,
+    excludeEnd: true,
+    contains: [{ className: "title function_", begin: /[\w-]+/ }],
+  };
+
+  return {
+    name: "Nushell",
+    aliases: ["nu"],
+    keywords: {
+      $pattern: "[A-Za-z][\\w-]*",
+      keyword: NU_KEYWORDS,
+      built_in: NU_BUILTINS,
+      literal: NU_LITERALS,
+    },
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      FUNCTION,
+      STRING,
+      VARIABLE,
+      FLAG,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineNushell(hljs);
+}
+
+export const nushell = { name: "nushell", register };
+export default nushell;

--- a/scripts/custom-languages/toml.js
+++ b/scripts/custom-languages/toml.js
@@ -1,0 +1,74 @@
+const TOML_LITERALS = "true false";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineToml(hljs) {
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /"""/, end: /"""/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /'''/, end: /'''/ },
+      { begin: /"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /'/, end: /'/ },
+    ],
+  };
+
+  const DATE = {
+    className: "number",
+    begin:
+      /\b\d{4}-\d{2}-\d{2}(?:[Tt ]\d{2}:\d{2}:\d{2}(?:\.\d+)?(?:[Zz]|[+-]\d{2}:\d{2})?)?\b/,
+    relevance: 10,
+  };
+
+  const TIME = {
+    className: "number",
+    begin: /\b\d{2}:\d{2}:\d{2}(?:\.\d+)?\b/,
+    relevance: 0,
+  };
+
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0x[0-9a-fA-F](?:[0-9a-fA-F_]*[0-9a-fA-F])?\b/ },
+      { begin: /\b0o[0-7](?:[0-7_]*[0-7])?\b/ },
+      { begin: /\b0b[01](?:[01_]*[01])?\b/ },
+      {
+        begin:
+          /[+-]?\b\d(?:[\d_]*\d)?(?:\.\d(?:[\d_]*\d)?)?(?:[eE][+-]?\d(?:[\d_]*\d)?)?\b/,
+      },
+      { begin: /[+-]?\b(?:inf|nan)\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const TABLE = {
+    className: "section",
+    begin: /^[ \t]*\[\[?/,
+    end: /\]\]?/,
+    contains: [
+      { className: "string", begin: /"/, end: /"/ },
+      { className: "string", begin: /'/, end: /'/ },
+    ],
+    relevance: 10,
+  };
+
+  const ATTR = {
+    className: "attr",
+    begin: /[A-Za-z0-9_-]+(?:\s*\.\s*[A-Za-z0-9_-]+)*(?=\s*=)/,
+    relevance: 0,
+  };
+
+  return {
+    name: "TOML",
+    aliases: ["toml"],
+    keywords: { literal: TOML_LITERALS },
+    contains: [hljs.HASH_COMMENT_MODE, TABLE, ATTR, STRING, DATE, TIME, NUMBER],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineToml(hljs);
+}
+
+export const toml = { name: "toml", register };
+export default toml;

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -128,6 +128,7 @@ exports[`Languages 1`] = `
   "nix",
   "nodeRepl",
   "nsis",
+  "nushell",
   "objectivec",
   "ocaml",
   "openscad",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -69,6 +69,7 @@ exports[`Languages 1`] = `
   "gauss",
   "gcode",
   "gherkin",
+  "gleam",
   "glsl",
   "gml",
   "go",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -102,6 +102,7 @@ exports[`Languages 1`] = `
   "ldif",
   "leaf",
   "less",
+  "liquid",
   "lisp",
   "livecodeserver",
   "livescript",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -184,6 +184,7 @@ exports[`Languages 1`] = `
   "tap",
   "tcl",
   "thrift",
+  "toml",
   "tp",
   "twig",
   "typescript",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -23,6 +23,7 @@ exports[`Languages 1`] = `
   "axapta",
   "bash",
   "basic",
+  "blade",
   "bnf",
   "brainfuck",
   "c",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -60,6 +60,7 @@ exports[`Languages 1`] = `
   "erlang",
   "erlangRepl",
   "excel",
+  "fish",
   "fix",
   "flix",
   "fortran",

--- a/tests/blade-language.test.ts
+++ b/tests/blade-language.test.ts
@@ -1,0 +1,39 @@
+import hljs from "highlight.js/lib/core";
+import blade from "../src/languages/blade";
+
+hljs.registerLanguage(blade.name, blade.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "blade" }).value;
+
+test("blade highlights directives", () => {
+  const result = highlight("@if($user)\n@endif");
+
+  expect(result).toContain('<span class="hljs-keyword">@if</span>');
+  expect(result).toContain('<span class="hljs-keyword">@endif</span>');
+});
+
+test("blade highlights echo statements", () => {
+  const result = highlight("{{ $user->name }}");
+
+  expect(result).toContain("hljs-template-variable");
+  expect(result).toContain('<span class="hljs-variable">$user</span>');
+});
+
+test("blade highlights raw echo statements", () => {
+  const result = highlight("{!! $html !!}");
+
+  expect(result).toContain("hljs-template-variable");
+});
+
+test("blade highlights comments", () => {
+  const result = highlight("{{-- a comment --}}");
+
+  expect(result).toContain("hljs-comment");
+});
+
+test("blade delegates surrounding markup to xml", () => {
+  const result = highlight("<p>{{ $name }}</p>");
+
+  expect(result).toContain("hljs-tag");
+});

--- a/tests/fish-language.test.ts
+++ b/tests/fish-language.test.ts
@@ -1,0 +1,41 @@
+import hljs from "highlight.js/lib/core";
+import fish from "../src/languages/fish";
+
+hljs.registerLanguage(fish.name, fish.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "fish" }).value;
+
+test("fish highlights keywords", () => {
+  const result = highlight("if test -f file\n  echo found\nend");
+
+  expect(result).toContain('<span class="hljs-keyword">if</span>');
+  expect(result).toContain('<span class="hljs-keyword">end</span>');
+});
+
+test("fish highlights builtins", () => {
+  const result = highlight("set name value\necho $name");
+
+  expect(result).toContain('<span class="hljs-built_in">set</span>');
+  expect(result).toContain('<span class="hljs-built_in">echo</span>');
+});
+
+test("fish highlights function definitions", () => {
+  const result = highlight("function greet\n  echo hi\nend");
+
+  expect(result).toContain('<span class="hljs-keyword">function</span>');
+  expect(result).toContain('<span class="hljs-title function_">greet</span>');
+});
+
+test("fish highlights variables", () => {
+  const result = highlight("echo $HOME");
+
+  expect(result).toContain('<span class="hljs-variable">$HOME</span>');
+});
+
+test("fish highlights strings with interpolation", () => {
+  const result = highlight('echo "hi $name"');
+
+  expect(result).toContain("hljs-string");
+  expect(result).toContain('<span class="hljs-variable">$name</span>');
+});

--- a/tests/gleam-language.test.ts
+++ b/tests/gleam-language.test.ts
@@ -1,0 +1,40 @@
+import hljs from "highlight.js/lib/core";
+import gleam from "../src/languages/gleam";
+
+hljs.registerLanguage(gleam.name, gleam.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "gleam" }).value;
+
+test("gleam highlights keywords", () => {
+  const result = highlight("pub fn main() {\n  let x = 0\n}");
+
+  expect(result).toContain('<span class="hljs-keyword">pub</span>');
+  expect(result).toContain('<span class="hljs-keyword">fn</span>');
+  expect(result).toContain('<span class="hljs-keyword">let</span>');
+});
+
+test("gleam highlights function names", () => {
+  const result = highlight("fn double(x) { x }");
+
+  expect(result).toContain('<span class="hljs-title function_">double</span>');
+});
+
+test("gleam highlights types and literals", () => {
+  const result = highlight("pub type Color {\n  Red\n}\nconst ok = True");
+
+  expect(result).toContain('<span class="hljs-type">Color</span>');
+  expect(result).toContain('<span class="hljs-literal">True</span>');
+});
+
+test("gleam highlights numbers", () => {
+  const result = highlight("let a = 0xFF\nlet b = 1_000\nlet c = 3.14");
+
+  expect(result).toContain("hljs-number");
+});
+
+test("gleam highlights attributes", () => {
+  const result = highlight('@external(erlang, "lib", "fun")\npub fn ext() {}');
+
+  expect(result).toContain('<span class="hljs-meta">@external</span>');
+});

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(205);
+  expect(languageNames.length).toEqual(206);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(203);
+  expect(languageNames.length).toEqual(204);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(207);
+  expect(languageNames.length).toEqual(208);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(206);
+  expect(languageNames.length).toEqual(207);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(202);
+  expect(languageNames.length).toEqual(203);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(204);
+  expect(languageNames.length).toEqual(205);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/liquid-language.test.ts
+++ b/tests/liquid-language.test.ts
@@ -1,0 +1,33 @@
+import hljs from "highlight.js/lib/core";
+import liquid from "../src/languages/liquid";
+
+hljs.registerLanguage(liquid.name, liquid.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "liquid" }).value;
+
+test("liquid highlights output objects", () => {
+  const result = highlight("{{ product.title }}");
+
+  expect(result).toContain("hljs-template-variable");
+});
+
+test("liquid highlights tags and keywords", () => {
+  const result = highlight("{% if user %}hi{% endif %}");
+
+  expect(result).toContain("hljs-template-tag");
+  expect(result).toContain('<span class="hljs-keyword">if</span>');
+  expect(result).toContain('<span class="hljs-keyword">endif</span>');
+});
+
+test("liquid highlights filters", () => {
+  const result = highlight("{{ name | upcase }}");
+
+  expect(result).toContain('<span class="hljs-built_in">upcase</span>');
+});
+
+test("liquid delegates surrounding markup to xml", () => {
+  const result = highlight("<h1>{{ title }}</h1>");
+
+  expect(result).toContain("hljs-tag");
+});

--- a/tests/nushell-language.test.ts
+++ b/tests/nushell-language.test.ts
@@ -1,0 +1,48 @@
+import hljs from "highlight.js/lib/core";
+import nushell from "../src/languages/nushell";
+
+hljs.registerLanguage(nushell.name, nushell.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "nushell" }).value;
+
+test("nushell highlights keywords", () => {
+  const result = highlight("let x = 1\nmut y = 2");
+
+  expect(result).toContain('<span class="hljs-keyword">let</span>');
+  expect(result).toContain('<span class="hljs-keyword">mut</span>');
+});
+
+test("nushell highlights builtin commands", () => {
+  const result = highlight("ls | where size > 10 | sort-by name");
+
+  expect(result).toContain('<span class="hljs-built_in">ls</span>');
+  expect(result).toContain('<span class="hljs-built_in">where</span>');
+  expect(result).toContain('<span class="hljs-built_in">sort-by</span>');
+});
+
+test("nushell highlights command definitions", () => {
+  const result = highlight("def greet [] { print hi }");
+
+  expect(result).toContain('<span class="hljs-keyword">def</span>');
+  expect(result).toContain('<span class="hljs-title function_">greet</span>');
+});
+
+test("nushell highlights variables", () => {
+  const result = highlight("print $greeting");
+
+  expect(result).toContain('<span class="hljs-variable">$greeting</span>');
+});
+
+test("nushell highlights flags", () => {
+  const result = highlight("ls --all -l");
+
+  expect(result).toContain("hljs-symbol");
+});
+
+test("nushell highlights numbers with units", () => {
+  const result = highlight("let dur = 5min\nlet size = 1kb");
+
+  expect(result).toContain('<span class="hljs-number">5min</span>');
+  expect(result).toContain('<span class="hljs-number">1kb</span>');
+});

--- a/tests/toml-language.test.ts
+++ b/tests/toml-language.test.ts
@@ -1,0 +1,51 @@
+import hljs from "highlight.js/lib/core";
+import toml from "../src/languages/toml";
+
+hljs.registerLanguage(toml.name, toml.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "toml" }).value;
+
+test("toml highlights tables and array-of-tables", () => {
+  const result = highlight("[server]\n\n[[products]]");
+
+  expect(result).toContain('<span class="hljs-section">[server]</span>');
+  expect(result).toContain('<span class="hljs-section">[[products]]</span>');
+});
+
+test("toml highlights keys as attributes", () => {
+  const result = highlight('host = "localhost"\ndotted.key = 1');
+
+  expect(result).toContain('<span class="hljs-attr">host</span>');
+  expect(result).toContain('<span class="hljs-attr">dotted.key</span>');
+});
+
+test("toml highlights strings", () => {
+  const result = highlight("name = \"value\"\nliteral = 'raw'");
+
+  expect(result).toContain(
+    '<span class="hljs-string">&quot;value&quot;</span>',
+  );
+  expect(result).toContain("hljs-string");
+});
+
+test("toml highlights numbers, hex, octal, and binary", () => {
+  const result = highlight("a = 42\nb = 0x1F\nc = 0o17\nd = 0b1010\ne = 3.14");
+
+  expect(result).toContain("hljs-number");
+});
+
+test("toml highlights dates", () => {
+  const result = highlight("updated = 2024-01-02T10:00:00Z");
+
+  expect(result).toContain(
+    '<span class="hljs-number">2024-01-02T10:00:00Z</span>',
+  );
+});
+
+test("toml highlights boolean literals", () => {
+  const result = highlight("enabled = true\ndisabled = false");
+
+  expect(result).toContain('<span class="hljs-literal">true</span>');
+  expect(result).toContain('<span class="hljs-literal">false</span>');
+});

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -3,12 +3,14 @@
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
+  import { tomlPreviewSnippets } from "@www/preview/toml-preview-snippets";
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
   import hcl from "svelte-highlight/languages/hcl";
   import prisma from "svelte-highlight/languages/prisma";
   import solidity from "svelte-highlight/languages/solidity";
+  import toml from "svelte-highlight/languages/toml";
   import zig from "svelte-highlight/languages/zig";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import dracula from "svelte-highlight/styles/dracula";
@@ -17,7 +19,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml"} */
   export let language;
 
   const registry = {
@@ -25,6 +27,7 @@
     hcl: { lang: hcl, snippets: hclPreviewSnippets },
     zig: { lang: zig, snippets: zigPreviewSnippets },
     prisma: { lang: prisma, snippets: prismaPreviewSnippets },
+    toml: { lang: toml, snippets: tomlPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
@@ -7,6 +8,7 @@
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
+  import fish from "svelte-highlight/languages/fish";
   import hcl from "svelte-highlight/languages/hcl";
   import prisma from "svelte-highlight/languages/prisma";
   import solidity from "svelte-highlight/languages/solidity";
@@ -19,7 +21,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish"} */
   export let language;
 
   const registry = {
@@ -28,6 +30,7 @@
     zig: { lang: zig, snippets: zigPreviewSnippets },
     prisma: { lang: prisma, snippets: prismaPreviewSnippets },
     toml: { lang: toml, snippets: tomlPreviewSnippets },
+    fish: { lang: fish, snippets: fishPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,6 +1,7 @@
 <script>
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
+  import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
@@ -10,6 +11,7 @@
   import { Highlight } from "svelte-highlight";
   import fish from "svelte-highlight/languages/fish";
   import hcl from "svelte-highlight/languages/hcl";
+  import nushell from "svelte-highlight/languages/nushell";
   import prisma from "svelte-highlight/languages/prisma";
   import solidity from "svelte-highlight/languages/solidity";
   import toml from "svelte-highlight/languages/toml";
@@ -21,7 +23,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell"} */
   export let language;
 
   const registry = {
@@ -31,6 +33,7 @@
     prisma: { lang: prisma, snippets: prismaPreviewSnippets },
     toml: { lang: toml, snippets: tomlPreviewSnippets },
     fish: { lang: fish, snippets: fishPreviewSnippets },
+    nushell: { lang: nushell, snippets: nushellPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,5 +1,6 @@
 <script>
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
+  import { gleamPreviewSnippets } from "@www/preview/gleam-preview-snippets";
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
   import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
@@ -10,6 +11,7 @@
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
   import fish from "svelte-highlight/languages/fish";
+  import gleam from "svelte-highlight/languages/gleam";
   import hcl from "svelte-highlight/languages/hcl";
   import nushell from "svelte-highlight/languages/nushell";
   import prisma from "svelte-highlight/languages/prisma";
@@ -23,7 +25,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam"} */
   export let language;
 
   const registry = {
@@ -34,6 +36,7 @@
     toml: { lang: toml, snippets: tomlPreviewSnippets },
     fish: { lang: fish, snippets: fishPreviewSnippets },
     nushell: { lang: nushell, snippets: nushellPreviewSnippets },
+    gleam: { lang: gleam, snippets: gleamPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -39,6 +39,7 @@
     "/preview-solidity": "Solidity language preview",
     "/preview-zig": "Zig language preview",
     "/preview-toml": "TOML language preview",
+    "/preview-fish": "fish language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -41,6 +41,7 @@
     "/preview-toml": "TOML language preview",
     "/preview-fish": "fish language preview",
     "/preview-nushell": "Nushell language preview",
+    "/preview-gleam": "Gleam language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -40,6 +40,7 @@
     "/preview-zig": "Zig language preview",
     "/preview-toml": "TOML language preview",
     "/preview-fish": "fish language preview",
+    "/preview-nushell": "Nushell language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -38,6 +38,7 @@
     "/preview-prisma": "Prisma language preview",
     "/preview-solidity": "Solidity language preview",
     "/preview-zig": "Zig language preview",
+    "/preview-toml": "TOML language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/pages/preview-fish.astro
+++ b/www/pages/preview-fish.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="fish language preview">
+  <LanguagePreview language="fish" client:idle />
+</Layout>

--- a/www/pages/preview-gleam.astro
+++ b/www/pages/preview-gleam.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Gleam language preview">
+  <LanguagePreview language="gleam" client:idle />
+</Layout>

--- a/www/pages/preview-nushell.astro
+++ b/www/pages/preview-nushell.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Nushell language preview">
+  <LanguagePreview language="nushell" client:idle />
+</Layout>

--- a/www/pages/preview-toml.astro
+++ b/www/pages/preview-toml.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="TOML language preview">
+  <LanguagePreview language="toml" client:idle />
+</Layout>

--- a/www/preview/fish-preview-snippets.ts
+++ b/www/preview/fish-preview-snippets.ts
@@ -1,0 +1,37 @@
+export type FishPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const fishPreviewSnippets: FishPreviewSnippet[] = [
+  {
+    title: "Function with arguments",
+    description: "function/end, set, and variable interpolation",
+    code: `function greet
+    set -l name $argv[1]
+    echo "Hello, $name!"
+end
+
+greet world`,
+  },
+  {
+    title: "Conditionals and loops",
+    description: "if/else/end, for/in, and builtins",
+    code: `for file in *.txt
+    if test -s $file
+        echo "$file is not empty"
+    else
+        echo "$file is empty"
+    end
+end`,
+  },
+  {
+    title: "Command substitution",
+    description: "$(...) substitution and string builtin",
+    code: `set -l branch $(git rev-parse --abbrev-ref HEAD)
+set -l count (count *.md)
+
+string upper "$branch has $count docs"`,
+  },
+];

--- a/www/preview/gleam-preview-snippets.ts
+++ b/www/preview/gleam-preview-snippets.ts
@@ -1,0 +1,48 @@
+export type GleamPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const gleamPreviewSnippets: GleamPreviewSnippet[] = [
+  {
+    title: "Main with imports",
+    description: "import, pub fn, and types",
+    code: `import gleam/io
+import gleam/int
+
+pub fn main() -> Nil {
+  let total = add(2, 3)
+  io.println("Sum: " <> int.to_string(total))
+}
+
+fn add(a: Int, b: Int) -> Int {
+  a + b
+}`,
+  },
+  {
+    title: "Custom types and case",
+    description: "type definitions, constructors, and pattern matching",
+    code: `pub type Shape {
+  Circle(radius: Float)
+  Square(side: Float)
+}
+
+pub fn area(shape: Shape) -> Float {
+  case shape {
+    Circle(r) -> 3.14 *. r *. r
+    Square(s) -> s *. s
+  }
+}`,
+  },
+  {
+    title: "Literals and externals",
+    description: "True/False/Nil, number bases, and @external",
+    code: `const enabled = True
+const mask = 0xFF
+const flags = 0b1010
+
+@external(erlang, "rand", "uniform")
+pub fn random() -> Float`,
+  },
+];

--- a/www/preview/nushell-preview-snippets.ts
+++ b/www/preview/nushell-preview-snippets.ts
@@ -1,0 +1,38 @@
+export type NushellPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const nushellPreviewSnippets: NushellPreviewSnippet[] = [
+  {
+    title: "Pipelines",
+    description: "structured commands, flags, and filters",
+    code: `ls
+| where size > 1mb
+| sort-by modified
+| select name size
+| first 5`,
+  },
+  {
+    title: "Custom command",
+    description: "def, let/mut, and string interpolation",
+    code: `def greet [name: string] {
+    let message = $"Hello, ($name)!"
+    print $message
+}
+
+greet "world"`,
+  },
+  {
+    title: "Values with units",
+    description: "durations, file sizes, and literals",
+    code: `let timeout = 30sec
+let limit = 256mb
+let enabled = true
+
+if $enabled {
+    print $"timeout is ($timeout)"
+}`,
+  },
+];

--- a/www/preview/toml-preview-snippets.ts
+++ b/www/preview/toml-preview-snippets.ts
@@ -1,0 +1,44 @@
+export type TomlPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const tomlPreviewSnippets: TomlPreviewSnippet[] = [
+  {
+    title: "Package manifest",
+    description: "tables, strings, and arrays",
+    code: `# project metadata
+[package]
+name = "svelte-highlight"
+version = "1.0.0"
+authors = ["Jane Doe <jane@example.com>"]
+keywords = ["syntax", "highlight"]`,
+  },
+  {
+    title: "Numbers and dates",
+    description: "hex/octal/binary, floats, and RFC 3339 dates",
+    code: `[build]
+threads = 8
+ratio = 0.75
+mask = 0xDEAD_BEEF
+permissions = 0o755
+flags = 0b1010
+released = 2024-01-02T10:30:00Z`,
+  },
+  {
+    title: "Nested tables and inline tables",
+    description: "array-of-tables and dotted keys",
+    code: `[server]
+host = "localhost"
+port = 8080
+
+[database]
+connection = { user = "admin", timeout = 30 }
+ssl.enabled = true
+
+[[server.endpoints]]
+path = "/api"
+methods = ["GET", "POST"]`,
+  },
+];


### PR DESCRIPTION
Adds a handful of grammars that are not shipped OOTB:
- TOML
- fish
- Nushell
- Gleam
- Liquid
- Blade (Laravel)