### PR TITLE
feat(languages): add custom `json5`, `jsonc`, `dotenv` grammars

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 210 languages exported from highlight.js@11.11.1
+> 211 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -591,6 +591,20 @@
 
   // base import
   import { dos } from "svelte-highlight/languages";
+</script>
+```
+
+## dotenv (`dotenv`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import dotenv from "svelte-highlight/languages/dotenv";
+
+  // base import
+  import { dotenv } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 209 languages exported from highlight.js@11.11.1
+> 210 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1141,6 +1141,20 @@
 
   // base import
   import { json5 } from "svelte-highlight/languages";
+</script>
+```
+
+## jsonc (`jsonc`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import jsonc from "svelte-highlight/languages/jsonc";
+
+  // base import
+  import { jsonc } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 208 languages exported from highlight.js@11.11.1
+> 209 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1127,6 +1127,20 @@
 
   // base import
   import { json } from "svelte-highlight/languages";
+</script>
+```
+
+## json5 (`json5`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import json5 from "svelte-highlight/languages/json5";
+
+  // base import
+  import { json5 } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -103,6 +103,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "jsonc",
     path: `${import.meta.dir}/custom-languages/jsonc.js`,
   },
+  {
+    name: "dotenv",
+    moduleName: "dotenv",
+    path: `${import.meta.dir}/custom-languages/dotenv.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -93,6 +93,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "blade",
     path: `${import.meta.dir}/custom-languages/blade.js`,
   },
+  {
+    name: "json5",
+    moduleName: "json5",
+    path: `${import.meta.dir}/custom-languages/json5.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -98,6 +98,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "json5",
     path: `${import.meta.dir}/custom-languages/json5.js`,
   },
+  {
+    name: "jsonc",
+    moduleName: "jsonc",
+    path: `${import.meta.dir}/custom-languages/jsonc.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/custom-languages/dotenv.js
+++ b/scripts/custom-languages/dotenv.js
@@ -1,0 +1,44 @@
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineDotenv(hljs) {
+  const VARIABLE = {
+    className: "variable",
+    variants: [
+      { begin: /\$\{[A-Za-z_][A-Za-z0-9_]*\}/ },
+      { begin: /\$[A-Za-z_][A-Za-z0-9_]*/ },
+    ],
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE, VARIABLE] },
+      { begin: /'/, end: /'/ },
+    ],
+  };
+
+  return {
+    name: "dotenv",
+    aliases: ["env"],
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      { className: "keyword", begin: /^[ \t]*export(?=[ \t])/ },
+      {
+        className: "attr",
+        begin: /[A-Za-z_][A-Za-z0-9_]*(?=[ \t]*=)/,
+        relevance: 0,
+      },
+      { className: "operator", begin: /=/, relevance: 0 },
+      STRING,
+      VARIABLE,
+      { className: "number", begin: /\b\d+(?:\.\d+)?\b/, relevance: 0 },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineDotenv(hljs);
+}
+
+export const dotenv = { name: "dotenv", register };
+export default dotenv;

--- a/scripts/custom-languages/json5.js
+++ b/scripts/custom-languages/json5.js
@@ -1,0 +1,55 @@
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineJson5(hljs) {
+  const LITERALS = "true false null Infinity NaN";
+
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /[+-]?0[xX][0-9a-fA-F]+\b/ },
+      { begin: /[+-]?(?:Infinity|NaN)\b/ },
+      { begin: /[+-]?(?:\d+\.?\d*|\.\d+)(?:[eE][+-]?\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /'/, end: /'/, contains: [hljs.BACKSLASH_ESCAPE] },
+    ],
+  };
+
+  // JSON5 keys may be quoted (single or double) or bare ECMAScript identifiers.
+  const ATTR = {
+    className: "attr",
+    variants: [
+      { begin: /"(?:[^"\\]|\\.)*"(?=\s*:)/ },
+      { begin: /'(?:[^'\\]|\\.)*'(?=\s*:)/ },
+      { begin: /[A-Za-z_$][A-Za-z0-9_$]*(?=\s*:)/ },
+    ],
+    relevance: 0,
+  };
+
+  return {
+    name: "JSON5",
+    aliases: ["json5"],
+    keywords: { literal: LITERALS },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      ATTR,
+      STRING,
+      NUMBER,
+      { match: /[{}[\],:]/, className: "punctuation", relevance: 0 },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineJson5(hljs);
+}
+
+export const json5 = { name: "json5", register };
+export default json5;

--- a/scripts/custom-languages/jsonc.js
+++ b/scripts/custom-languages/jsonc.js
@@ -1,0 +1,36 @@
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineJsonc(hljs) {
+  const NUMBER = {
+    className: "number",
+    begin: /-?(?:0|[1-9]\d*)(?:\.\d+)?(?:[eE][+-]?\d+)?\b/,
+    relevance: 0,
+  };
+
+  const ATTR = {
+    className: "attr",
+    begin: /"(?:[^"\\]|\\.)*"(?=\s*:)/,
+    relevance: 1.01,
+  };
+
+  return {
+    name: "JSONC",
+    aliases: ["jsonc"],
+    keywords: { literal: "true false null" },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      ATTR,
+      { match: /[{}[\],:]/, className: "punctuation", relevance: 0 },
+      hljs.QUOTE_STRING_MODE,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineJsonc(hljs);
+}
+
+export const jsonc = { name: "jsonc", register };
+export default jsonc;

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -51,6 +51,7 @@ exports[`Languages 1`] = `
   "dns",
   "dockerfile",
   "dos",
+  "dotenv",
   "dsconfig",
   "dts",
   "dust",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -95,6 +95,7 @@ exports[`Languages 1`] = `
   "javascript",
   "jbossCli",
   "json",
+  "json5",
   "julia",
   "juliaRepl",
   "kotlin",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -96,6 +96,7 @@ exports[`Languages 1`] = `
   "jbossCli",
   "json",
   "json5",
+  "jsonc",
   "julia",
   "juliaRepl",
   "kotlin",

--- a/tests/dotenv-language.test.ts
+++ b/tests/dotenv-language.test.ts
@@ -1,0 +1,48 @@
+import hljs from "highlight.js/lib/core";
+import dotenv from "../src/languages/dotenv";
+
+hljs.registerLanguage(dotenv.name, dotenv.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "dotenv" }).value;
+
+test("dotenv highlights hash comments", () => {
+  const result = highlight("# a comment\nKEY=value");
+
+  expect(result).toContain('<span class="hljs-comment"># a comment</span>');
+});
+
+test("dotenv highlights keys as attributes and = as operator", () => {
+  const result = highlight("NODE_ENV=production");
+
+  expect(result).toContain('<span class="hljs-attr">NODE_ENV</span>');
+  expect(result).toContain('<span class="hljs-operator">=</span>');
+});
+
+test("dotenv highlights the export keyword", () => {
+  const result = highlight("export AWS_REGION=us-east-1");
+
+  expect(result).toContain('<span class="hljs-keyword">export</span>');
+  expect(result).toContain('<span class="hljs-attr">AWS_REGION</span>');
+});
+
+test("dotenv highlights quoted strings", () => {
+  const result = highlight("TOKEN=\"abc123\"\nRAW='literal'");
+
+  expect(result).toContain(
+    '<span class="hljs-string">&quot;abc123&quot;</span>',
+  );
+  expect(result).toContain(
+    '<span class="hljs-string">&#x27;literal&#x27;</span>',
+  );
+});
+
+test("dotenv highlights variable references inside double quotes", () => {
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: dotenv uses literal ${VAR} interpolation
+  const result = highlight('URL="http://${HOST}:${PORT}"');
+
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting the literal ${HOST} token
+  expect(result).toContain('<span class="hljs-variable">${HOST}</span>');
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: asserting the literal ${PORT} token
+  expect(result).toContain('<span class="hljs-variable">${PORT}</span>');
+});

--- a/tests/json5-language.test.ts
+++ b/tests/json5-language.test.ts
@@ -1,0 +1,46 @@
+import hljs from "highlight.js/lib/core";
+import json5 from "../src/languages/json5";
+
+hljs.registerLanguage(json5.name, json5.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "json5" }).value;
+
+test("json5 highlights line and block comments", () => {
+  const result = highlight("{\n  // line\n  /* block */\n}");
+
+  expect(result).toContain('<span class="hljs-comment">// line</span>');
+  expect(result).toContain('<span class="hljs-comment">/* block */</span>');
+});
+
+test("json5 highlights unquoted and quoted keys as attributes", () => {
+  const result = highlight("{ unquoted: 1, 'single': 2, \"double\": 3 }");
+
+  expect(result).toContain('<span class="hljs-attr">unquoted</span>');
+  expect(result).toContain("hljs-attr");
+});
+
+test("json5 highlights single- and double-quoted strings", () => {
+  const result = highlight("{ a: 'raw', b: \"value\" }");
+
+  expect(result).toContain('<span class="hljs-string">&#x27;raw&#x27;</span>');
+  expect(result).toContain(
+    '<span class="hljs-string">&quot;value&quot;</span>',
+  );
+});
+
+test("json5 highlights hex, float, and signed numbers", () => {
+  const result = highlight("{ a: 0xFF, b: -3.14, c: .5, d: +42 }");
+
+  expect(result).toContain('<span class="hljs-number">0xFF</span>');
+  expect(result).toContain("hljs-number");
+});
+
+test("json5 highlights Infinity, NaN, and boolean literals", () => {
+  const result = highlight("{ a: Infinity, b: NaN, c: true, d: null }");
+
+  expect(result).toContain('<span class="hljs-number">Infinity</span>');
+  expect(result).toContain('<span class="hljs-number">NaN</span>');
+  expect(result).toContain('<span class="hljs-literal">true</span>');
+  expect(result).toContain('<span class="hljs-literal">null</span>');
+});

--- a/tests/jsonc-language.test.ts
+++ b/tests/jsonc-language.test.ts
@@ -1,0 +1,43 @@
+import hljs from "highlight.js/lib/core";
+import jsonc from "../src/languages/jsonc";
+
+hljs.registerLanguage(jsonc.name, jsonc.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "jsonc" }).value;
+
+test("jsonc highlights line and block comments", () => {
+  const result = highlight('{\n  // line\n  /* block */\n  "a": 1\n}');
+
+  expect(result).toContain('<span class="hljs-comment">// line</span>');
+  expect(result).toContain('<span class="hljs-comment">/* block */</span>');
+});
+
+test("jsonc highlights quoted keys as attributes", () => {
+  const result = highlight('{ "name": "svelte" }');
+
+  expect(result).toContain('<span class="hljs-attr">&quot;name&quot;</span>');
+});
+
+test("jsonc highlights string values", () => {
+  const result = highlight('{ "name": "svelte" }');
+
+  expect(result).toContain(
+    '<span class="hljs-string">&quot;svelte&quot;</span>',
+  );
+});
+
+test("jsonc highlights numbers", () => {
+  const result = highlight('{ "count": 42, "ratio": 0.75 }');
+
+  expect(result).toContain('<span class="hljs-number">42</span>');
+  expect(result).toContain('<span class="hljs-number">0.75</span>');
+});
+
+test("jsonc highlights boolean and null literals", () => {
+  const result = highlight('{ "ok": true, "no": false, "empty": null }');
+
+  expect(result).toContain('<span class="hljs-literal">true</span>');
+  expect(result).toContain('<span class="hljs-literal">false</span>');
+  expect(result).toContain('<span class="hljs-literal">null</span>');
+});

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(208);
+  expect(languageNames.length).toEqual(209);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(210);
+  expect(languageNames.length).toEqual(211);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(209);
+  expect(languageNames.length).toEqual(210);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -2,6 +2,7 @@
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
   import { gleamPreviewSnippets } from "@www/preview/gleam-preview-snippets";
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
+  import { json5PreviewSnippets } from "@www/preview/json5-preview-snippets";
   import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
@@ -13,6 +14,7 @@
   import fish from "svelte-highlight/languages/fish";
   import gleam from "svelte-highlight/languages/gleam";
   import hcl from "svelte-highlight/languages/hcl";
+  import json5 from "svelte-highlight/languages/json5";
   import nushell from "svelte-highlight/languages/nushell";
   import prisma from "svelte-highlight/languages/prisma";
   import solidity from "svelte-highlight/languages/solidity";
@@ -25,7 +27,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5"} */
   export let language;
 
   const registry = {
@@ -37,6 +39,7 @@
     fish: { lang: fish, snippets: fishPreviewSnippets },
     nushell: { lang: nushell, snippets: nushellPreviewSnippets },
     gleam: { lang: gleam, snippets: gleamPreviewSnippets },
+    json5: { lang: json5, snippets: json5PreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { dotenvPreviewSnippets } from "@www/preview/dotenv-preview-snippets";
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
   import { gleamPreviewSnippets } from "@www/preview/gleam-preview-snippets";
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
@@ -12,6 +13,7 @@
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
+  import dotenv from "svelte-highlight/languages/dotenv";
   import fish from "svelte-highlight/languages/fish";
   import gleam from "svelte-highlight/languages/gleam";
   import hcl from "svelte-highlight/languages/hcl";
@@ -29,7 +31,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv"} */
   export let language;
 
   const registry = {
@@ -43,6 +45,7 @@
     gleam: { lang: gleam, snippets: gleamPreviewSnippets },
     json5: { lang: json5, snippets: json5PreviewSnippets },
     jsonc: { lang: jsonc, snippets: jsoncPreviewSnippets },
+    dotenv: { lang: dotenv, snippets: dotenvPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -3,6 +3,7 @@
   import { gleamPreviewSnippets } from "@www/preview/gleam-preview-snippets";
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
   import { json5PreviewSnippets } from "@www/preview/json5-preview-snippets";
+  import { jsoncPreviewSnippets } from "@www/preview/jsonc-preview-snippets";
   import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
@@ -15,6 +16,7 @@
   import gleam from "svelte-highlight/languages/gleam";
   import hcl from "svelte-highlight/languages/hcl";
   import json5 from "svelte-highlight/languages/json5";
+  import jsonc from "svelte-highlight/languages/jsonc";
   import nushell from "svelte-highlight/languages/nushell";
   import prisma from "svelte-highlight/languages/prisma";
   import solidity from "svelte-highlight/languages/solidity";
@@ -27,7 +29,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc"} */
   export let language;
 
   const registry = {
@@ -40,6 +42,7 @@
     nushell: { lang: nushell, snippets: nushellPreviewSnippets },
     gleam: { lang: gleam, snippets: gleamPreviewSnippets },
     json5: { lang: json5, snippets: json5PreviewSnippets },
+    jsonc: { lang: jsonc, snippets: jsoncPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -44,6 +44,7 @@
     "/preview-gleam": "Gleam language preview",
     "/preview-json5": "JSON5 language preview",
     "/preview-jsonc": "JSONC language preview",
+    "/preview-dotenv": "dotenv language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -43,6 +43,7 @@
     "/preview-nushell": "Nushell language preview",
     "/preview-gleam": "Gleam language preview",
     "/preview-json5": "JSON5 language preview",
+    "/preview-jsonc": "JSONC language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -42,6 +42,7 @@
     "/preview-fish": "fish language preview",
     "/preview-nushell": "Nushell language preview",
     "/preview-gleam": "Gleam language preview",
+    "/preview-json5": "JSON5 language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/pages/preview-dotenv.astro
+++ b/www/pages/preview-dotenv.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="dotenv language preview">
+  <LanguagePreview language="dotenv" client:idle />
+</Layout>

--- a/www/pages/preview-json5.astro
+++ b/www/pages/preview-json5.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="JSON5 language preview">
+  <LanguagePreview language="json5" client:idle />
+</Layout>

--- a/www/pages/preview-jsonc.astro
+++ b/www/pages/preview-jsonc.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="JSONC language preview">
+  <LanguagePreview language="jsonc" client:idle />
+</Layout>

--- a/www/preview/dotenv-preview-snippets.ts
+++ b/www/preview/dotenv-preview-snippets.ts
@@ -1,0 +1,35 @@
+export type DotenvPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const dotenvPreviewSnippets: DotenvPreviewSnippet[] = [
+  {
+    title: "Application config",
+    description: "comments, keys, and values",
+    code: `# application environment
+NODE_ENV=production
+PORT=8080
+DEBUG=false
+APP_NAME=svelte-highlight`,
+  },
+  {
+    title: "Quoting and interpolation",
+    description: "quoted values and variable references",
+    code: `HOST=localhost
+PORT=5432
+DATABASE_URL="postgres://\${HOST}:\${PORT}/app"
+GREETING='literal $not-expanded value'
+PATH_EXTRA="\${HOME}/bin"`,
+  },
+  {
+    title: "Exported variables",
+    description: "export prefix and secrets",
+    code: `export AWS_REGION=us-east-1
+export API_TOKEN="sk_live_0123456789"
+# feature flags
+ENABLE_CACHE=true
+MAX_RETRIES=3`,
+  },
+];

--- a/www/preview/json5-preview-snippets.ts
+++ b/www/preview/json5-preview-snippets.ts
@@ -1,0 +1,47 @@
+export type Json5PreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const json5PreviewSnippets: Json5PreviewSnippet[] = [
+  {
+    title: "Config with comments",
+    description: "line/block comments, unquoted keys, trailing commas",
+    code: `{
+  // build configuration
+  name: "svelte-highlight",
+  version: "1.0.0",
+  /* feature flags */
+  features: {
+    fastMode: true,
+    legacy: false,
+  },
+}`,
+  },
+  {
+    title: "Numbers and literals",
+    description: "hex, floats, signs, Infinity and NaN",
+    code: `{
+  hex: 0xDECAF,
+  float: -3.14,
+  leading: .5,
+  exponent: 6.022e23,
+  positive: +42,
+  infinity: Infinity,
+  notANumber: NaN,
+  nothing: null,
+}`,
+  },
+  {
+    title: "Strings and keys",
+    description: "single- or double-quoted strings and bare keys",
+    code: `{
+  'single-quoted': 'hello',
+  "double-quoted": "world",
+  unquoted: "value",
+  nested: { a: 1, b: 2 },
+  list: ["GET", "POST", "PUT"],
+}`,
+  },
+];

--- a/www/preview/jsonc-preview-snippets.ts
+++ b/www/preview/jsonc-preview-snippets.ts
@@ -1,0 +1,50 @@
+export type JsoncPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const jsoncPreviewSnippets: JsoncPreviewSnippet[] = [
+  {
+    title: "tsconfig.json",
+    description: "JSON with // and /* */ comments",
+    code: `{
+  // TypeScript compiler options
+  "compilerOptions": {
+    "target": "ESNext",
+    "strict": true,
+    /* module resolution */
+    "moduleResolution": "bundler",
+    "skipLibCheck": true
+  },
+  "include": ["src"]
+}`,
+  },
+  {
+    title: "VS Code settings",
+    description: "comments alongside standard JSON values",
+    code: `{
+  "editor.tabSize": 2,
+  "editor.formatOnSave": true,
+  // disable telemetry
+  "telemetry.telemetryLevel": "off",
+  "files.exclude": {
+    "**/.git": true,
+    "**/node_modules": false
+  }
+}`,
+  },
+  {
+    title: "Numbers, strings, and literals",
+    description: "standard JSON value types",
+    code: `{
+  "name": "svelte-highlight",
+  "version": "1.0.0",
+  "count": 42,
+  "ratio": 0.75,
+  "enabled": true,
+  "disabled": false,
+  "empty": null
+}`,
+  },
+];


### PR DESCRIPTION
Adds a handful of config/data grammars that are not shipped OOTB:
- JSON5
- JSONC (JSON with comments)
- dotenv (`.env`)