### PR TITLE
feat(languages): add custom `wgsl`, `cypher`, `promql`, `bicep`, `rescript`, `starlark`, `move`, `cairo`, `vyper`, `clarity`, `cue`, `jsonnet`, `dhall`, `pkl`, `nickel`, `pug`, `razor`, `v`, `odin`, `caddy`, `d2`, `bibtex` grammars

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 227 languages exported from highlight.js@11.11.1
+> 228 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2103,6 +2103,20 @@
 
   // base import
   import { r } from "svelte-highlight/languages";
+</script>
+```
+
+## razor (`razor`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import razor from "svelte-highlight/languages/razor";
+
+  // base import
+  import { razor } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 228 languages exported from highlight.js@11.11.1
+> 229 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2571,6 +2571,20 @@
 
   // base import
   import { typescript } from "svelte-highlight/languages";
+</script>
+```
+
+## v (`v`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import v from "svelte-highlight/languages/v";
+
+  // base import
+  import { v } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 231 languages exported from highlight.js@11.11.1
+> 232 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -591,6 +591,20 @@
 
   // base import
   import { d } from "svelte-highlight/languages";
+</script>
+```
+
+## d2 (`d2`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import d2 from "svelte-highlight/languages/d2";
+
+  // base import
+  import { d2 } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 212 languages exported from highlight.js@11.11.1
+> 213 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -495,6 +495,20 @@
 
   // base import
   import { css } from "svelte-highlight/languages";
+</script>
+```
+
+## cypher (`cypher`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import cypher from "svelte-highlight/languages/cypher";
+
+  // base import
+  import { cypher } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 219 languages exported from highlight.js@11.11.1
+> 220 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2557,6 +2557,20 @@
 
   // base import
   import { vue } from "svelte-highlight/languages";
+</script>
+```
+
+## vyper (`vyper`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import vyper from "svelte-highlight/languages/vyper";
+
+  // base import
+  import { vyper } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 222 languages exported from highlight.js@11.11.1
+> 223 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1239,6 +1239,20 @@
 
   // base import
   import { jsonc } from "svelte-highlight/languages";
+</script>
+```
+
+## jsonnet (`jsonnet`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import jsonnet from "svelte-highlight/languages/jsonnet";
+
+  // base import
+  import { jsonnet } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 215 languages exported from highlight.js@11.11.1
+> 216 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1989,6 +1989,20 @@
 
   // base import
   import { reasonml } from "svelte-highlight/languages";
+</script>
+```
+
+## rescript (`rescript`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import rescript from "svelte-highlight/languages/rescript";
+
+  // base import
+  import { rescript } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 221 languages exported from highlight.js@11.11.1
+> 222 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -537,6 +537,20 @@
 
   // base import
   import { css } from "svelte-highlight/languages";
+</script>
+```
+
+## cue (`cue`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import cue from "svelte-highlight/languages/cue";
+
+  // base import
+  import { cue } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 220 languages exported from highlight.js@11.11.1
+> 221 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -367,6 +367,20 @@
 
   // base import
   import { ceylon } from "svelte-highlight/languages";
+</script>
+```
+
+## clarity (`clarity`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import clarity from "svelte-highlight/languages/clarity";
+
+  // base import
+  import { clarity } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 223 languages exported from highlight.js@11.11.1
+> 224 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -601,6 +601,20 @@
 
   // base import
   import { delphi } from "svelte-highlight/languages";
+</script>
+```
+
+## dhall (`dhall`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import dhall from "svelte-highlight/languages/dhall";
+
+  // base import
+  import { dhall } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 226 languages exported from highlight.js@11.11.1
+> 227 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2005,6 +2005,20 @@
 
   // base import
   import { protobuf } from "svelte-highlight/languages";
+</script>
+```
+
+## pug (`pug`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import pug from "svelte-highlight/languages/pug";
+
+  // base import
+  import { pug } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 216 languages exported from highlight.js@11.11.1
+> 217 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2245,6 +2245,20 @@
 
   // base import
   import { stan } from "svelte-highlight/languages";
+</script>
+```
+
+## starlark (`starlark`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import starlark from "svelte-highlight/languages/starlark";
+
+  // base import
+  import { starlark } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 232 languages exported from highlight.js@11.11.1
+> 233 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -253,6 +253,20 @@
 
   // base import
   import { basic } from "svelte-highlight/languages";
+</script>
+```
+
+## bibtex (`bibtex`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import bibtex from "svelte-highlight/languages/bibtex";
+
+  // base import
+  import { bibtex } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 229 languages exported from highlight.js@11.11.1
+> 230 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1771,6 +1771,20 @@
 
   // base import
   import { ocaml } from "svelte-highlight/languages";
+</script>
+```
+
+## odin (`odin`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import odin from "svelte-highlight/languages/odin";
+
+  // base import
+  import { odin } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 218 languages exported from highlight.js@11.11.1
+> 219 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -317,6 +317,20 @@
 
   // base import
   import { c } from "svelte-highlight/languages";
+</script>
+```
+
+## cairo (`cairo`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import cairo from "svelte-highlight/languages/cairo";
+
+  // base import
+  import { cairo } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 217 languages exported from highlight.js@11.11.1
+> 218 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1551,6 +1551,20 @@
 
   // base import
   import { moonscript } from "svelte-highlight/languages";
+</script>
+```
+
+## move (`move`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import move from "svelte-highlight/languages/move";
+
+  // base import
+  import { move } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 225 languages exported from highlight.js@11.11.1
+> 226 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1671,6 +1671,20 @@
 
   // base import
   import { nginx } from "svelte-highlight/languages";
+</script>
+```
+
+## nickel (`nickel`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import nickel from "svelte-highlight/languages/nickel";
+
+  // base import
+  import { nickel } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 213 languages exported from highlight.js@11.11.1
+> 214 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1841,6 +1841,20 @@
 
   // base import
   import { prolog } from "svelte-highlight/languages";
+</script>
+```
+
+## promql (`promql`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import promql from "svelte-highlight/languages/promql";
+
+  // base import
+  import { promql } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 211 languages exported from highlight.js@11.11.1
+> 212 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -2471,6 +2471,20 @@
 
   // base import
   import { wasm } from "svelte-highlight/languages";
+</script>
+```
+
+## wgsl (`wgsl`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import wgsl from "svelte-highlight/languages/wgsl";
+
+  // base import
+  import { wgsl } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 224 languages exported from highlight.js@11.11.1
+> 225 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -1853,6 +1853,20 @@
 
   // base import
   import { phpTemplate } from "svelte-highlight/languages";
+</script>
+```
+
+## pkl (`pkl`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import pkl from "svelte-highlight/languages/pkl";
+
+  // base import
+  import { pkl } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 214 languages exported from highlight.js@11.11.1
+> 215 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -253,6 +253,20 @@
 
   // base import
   import { basic } from "svelte-highlight/languages";
+</script>
+```
+
+## bicep (`bicep`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import bicep from "svelte-highlight/languages/bicep";
+
+  // base import
+  import { bicep } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 230 languages exported from highlight.js@11.11.1
+> 231 languages exported from highlight.js@11.11.1
 
 ## 1c (`_1c`)
 
@@ -317,6 +317,20 @@
 
   // base import
   import { c } from "svelte-highlight/languages";
+</script>
+```
+
+## caddy (`caddy`)
+
+> Custom svelte-highlight language (not exported by highlight.js)
+
+```html
+<script>
+  // direct import (recommended)
+  import caddy from "svelte-highlight/languages/caddy";
+
+  // base import
+  import { caddy } from "svelte-highlight/languages";
 </script>
 ```
 

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -208,6 +208,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "caddy",
     path: `${import.meta.dir}/custom-languages/caddy.js`,
   },
+  {
+    name: "d2",
+    moduleName: "d2",
+    path: `${import.meta.dir}/custom-languages/d2.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -188,6 +188,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "pug",
     path: `${import.meta.dir}/custom-languages/pug.js`,
   },
+  {
+    name: "razor",
+    moduleName: "razor",
+    path: `${import.meta.dir}/custom-languages/razor.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -153,6 +153,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "vyper",
     path: `${import.meta.dir}/custom-languages/vyper.js`,
   },
+  {
+    name: "clarity",
+    moduleName: "clarity",
+    path: `${import.meta.dir}/custom-languages/clarity.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -128,6 +128,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "bicep",
     path: `${import.meta.dir}/custom-languages/bicep.js`,
   },
+  {
+    name: "rescript",
+    moduleName: "rescript",
+    path: `${import.meta.dir}/custom-languages/rescript.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -163,6 +163,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "cue",
     path: `${import.meta.dir}/custom-languages/cue.js`,
   },
+  {
+    name: "jsonnet",
+    moduleName: "jsonnet",
+    path: `${import.meta.dir}/custom-languages/jsonnet.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -133,6 +133,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "rescript",
     path: `${import.meta.dir}/custom-languages/rescript.js`,
   },
+  {
+    name: "starlark",
+    moduleName: "starlark",
+    path: `${import.meta.dir}/custom-languages/starlark.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -118,6 +118,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "cypher",
     path: `${import.meta.dir}/custom-languages/cypher.js`,
   },
+  {
+    name: "promql",
+    moduleName: "promql",
+    path: `${import.meta.dir}/custom-languages/promql.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -108,6 +108,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "dotenv",
     path: `${import.meta.dir}/custom-languages/dotenv.js`,
   },
+  {
+    name: "wgsl",
+    moduleName: "wgsl",
+    path: `${import.meta.dir}/custom-languages/wgsl.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -138,6 +138,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "starlark",
     path: `${import.meta.dir}/custom-languages/starlark.js`,
   },
+  {
+    name: "move",
+    moduleName: "move",
+    path: `${import.meta.dir}/custom-languages/move.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -203,6 +203,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "odin",
     path: `${import.meta.dir}/custom-languages/odin.js`,
   },
+  {
+    name: "caddy",
+    moduleName: "caddy",
+    path: `${import.meta.dir}/custom-languages/caddy.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -113,6 +113,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "wgsl",
     path: `${import.meta.dir}/custom-languages/wgsl.js`,
   },
+  {
+    name: "cypher",
+    moduleName: "cypher",
+    path: `${import.meta.dir}/custom-languages/cypher.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -178,6 +178,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "pkl",
     path: `${import.meta.dir}/custom-languages/pkl.js`,
   },
+  {
+    name: "nickel",
+    moduleName: "nickel",
+    path: `${import.meta.dir}/custom-languages/nickel.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -168,6 +168,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "jsonnet",
     path: `${import.meta.dir}/custom-languages/jsonnet.js`,
   },
+  {
+    name: "dhall",
+    moduleName: "dhall",
+    path: `${import.meta.dir}/custom-languages/dhall.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -198,6 +198,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "v",
     path: `${import.meta.dir}/custom-languages/v.js`,
   },
+  {
+    name: "odin",
+    moduleName: "odin",
+    path: `${import.meta.dir}/custom-languages/odin.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -213,6 +213,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "d2",
     path: `${import.meta.dir}/custom-languages/d2.js`,
   },
+  {
+    name: "bibtex",
+    moduleName: "bibtex",
+    path: `${import.meta.dir}/custom-languages/bibtex.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -173,6 +173,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "dhall",
     path: `${import.meta.dir}/custom-languages/dhall.js`,
   },
+  {
+    name: "pkl",
+    moduleName: "pkl",
+    path: `${import.meta.dir}/custom-languages/pkl.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -158,6 +158,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "clarity",
     path: `${import.meta.dir}/custom-languages/clarity.js`,
   },
+  {
+    name: "cue",
+    moduleName: "cue",
+    path: `${import.meta.dir}/custom-languages/cue.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -143,6 +143,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "move",
     path: `${import.meta.dir}/custom-languages/move.js`,
   },
+  {
+    name: "cairo",
+    moduleName: "cairo",
+    path: `${import.meta.dir}/custom-languages/cairo.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -148,6 +148,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "cairo",
     path: `${import.meta.dir}/custom-languages/cairo.js`,
   },
+  {
+    name: "vyper",
+    moduleName: "vyper",
+    path: `${import.meta.dir}/custom-languages/vyper.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -123,6 +123,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "promql",
     path: `${import.meta.dir}/custom-languages/promql.js`,
   },
+  {
+    name: "bicep",
+    moduleName: "bicep",
+    path: `${import.meta.dir}/custom-languages/bicep.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -183,6 +183,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "nickel",
     path: `${import.meta.dir}/custom-languages/nickel.js`,
   },
+  {
+    name: "pug",
+    moduleName: "pug",
+    path: `${import.meta.dir}/custom-languages/pug.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -193,6 +193,11 @@ const CUSTOM_LANGUAGES: readonly CustomLanguage[] = [
     moduleName: "razor",
     path: `${import.meta.dir}/custom-languages/razor.js`,
   },
+  {
+    name: "v",
+    moduleName: "v",
+    path: `${import.meta.dir}/custom-languages/v.js`,
+  },
 ];
 
 type LanguageEntry = {

--- a/scripts/custom-languages/bibtex.js
+++ b/scripts/custom-languages/bibtex.js
@@ -1,0 +1,47 @@
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineBibtex(hljs) {
+  // Only braces/quotes that follow `field =` are values; the outer entry
+  // braces stay plain so the body's fields can still be highlighted.
+  // Brace-delimited values can nest, so this mode references itself.
+  /** @type {import("highlight.js").Mode} */
+  const BRACED_VALUE = { className: "string", begin: /\{/, end: /\}/ };
+  BRACED_VALUE.contains = [BRACED_VALUE];
+
+  const QUOTED_VALUE = {
+    className: "string",
+    begin: /"/,
+    end: /"/,
+    contains: [hljs.BACKSLASH_ESCAPE],
+  };
+
+  const NUMBER = { className: "number", begin: /\b\d+\b/ };
+
+  const FIELD = {
+    begin: [/\b[a-zA-Z][a-zA-Z0-9_-]*/, /\s*/, /=/],
+    beginScope: { 1: "attr", 3: "operator" },
+    end: /(?=,|\}|\n)/,
+    contains: [BRACED_VALUE, QUOTED_VALUE, NUMBER],
+    relevance: 0,
+  };
+
+  const ENTRY = {
+    className: "keyword",
+    begin: /@[a-zA-Z]+/,
+    relevance: 0,
+  };
+
+  return {
+    name: "BibTeX",
+    aliases: ["bibtex", "bib"],
+    case_insensitive: true,
+    contains: [hljs.COMMENT(/%/, /$/), ENTRY, FIELD],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineBibtex(hljs);
+}
+
+export const bibtex = { name: "bibtex", register };
+export default bibtex;

--- a/scripts/custom-languages/bicep.js
+++ b/scripts/custom-languages/bicep.js
@@ -1,0 +1,72 @@
+const BICEP_KEYWORDS =
+  "targetScope resource module param var output existing for in if func type import metadata assert provider extends with using as";
+
+const BICEP_TYPES = "string int bool object array secureString secureObject";
+
+const BICEP_LITERALS = "true false null";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineBicep(hljs) {
+  const NUMBER = {
+    className: "number",
+    begin: /\b\d+\b/,
+    relevance: 0,
+  };
+
+  const INTERPOLATION = {
+    className: "subst",
+    begin: /\$\{/,
+    end: /\}/,
+    keywords: { keyword: BICEP_KEYWORDS, literal: BICEP_LITERALS },
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /'''/, end: /'''/ },
+      {
+        begin: /'/,
+        end: /'/,
+        contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+      },
+    ],
+  };
+
+  const DECORATOR = {
+    className: "meta",
+    begin: /@[a-zA-Z_]\w*/,
+    relevance: 0,
+  };
+
+  const RESOURCE_TYPE = {
+    className: "type",
+    begin: /'[A-Za-z][\w.]+\/[\w./]+@[\d-]+'/,
+    relevance: 0,
+  };
+
+  return {
+    name: "Bicep",
+    aliases: ["bicep"],
+    keywords: {
+      keyword: BICEP_KEYWORDS,
+      type: BICEP_TYPES,
+      literal: BICEP_LITERALS,
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      DECORATOR,
+      RESOURCE_TYPE,
+      STRING,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineBicep(hljs);
+}
+
+export const bicep = { name: "bicep", register };
+export default bicep;

--- a/scripts/custom-languages/caddy.js
+++ b/scripts/custom-languages/caddy.js
@@ -1,0 +1,59 @@
+const CADDY_DIRECTIVES =
+  "reverse_proxy file_server root encode tls header header_down header_up redir respond route handle handle_path handle_errors rewrite uri log basicauth basic_auth forward_auth php_fastcgi try_files bind import templates request_body push map vars metrics tracing acme_server abort error method bcrypt invoke";
+
+const CADDY_GLOBAL =
+  "admin auto_https debug http_port https_port grace_period default_sni order storage acme_ca acme_dns email on_demand_tls local_certs skip_install_trust";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineCaddy(hljs) {
+  const PLACEHOLDER = {
+    className: "variable",
+    begin: /\{[a-zA-Z0-9_.$>-]+\}/,
+    relevance: 0,
+  };
+
+  const MATCHER = {
+    className: "symbol",
+    begin: /@[a-zA-Z_][\w-]*/,
+    relevance: 0,
+  };
+
+  const SITE_ADDRESS = {
+    className: "attr",
+    begin: /^\s*(?:https?:\/\/)?(?:[a-zA-Z0-9*.-]+)(?::\d+)?(?=\s*\{)/,
+    relevance: 0,
+  };
+
+  const SNIPPET = {
+    className: "title",
+    begin: /^\s*\([\w-]+\)/,
+    relevance: 0,
+  };
+
+  return {
+    name: "Caddyfile",
+    aliases: ["caddy", "caddyfile"],
+    case_insensitive: false,
+    keywords: {
+      keyword: CADDY_DIRECTIVES,
+      built_in: CADDY_GLOBAL,
+    },
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      hljs.QUOTE_STRING_MODE,
+      SNIPPET,
+      SITE_ADDRESS,
+      MATCHER,
+      PLACEHOLDER,
+      { className: "number", begin: /\b\d+\b/, relevance: 0 },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineCaddy(hljs);
+}
+
+export const caddy = { name: "caddy", register };
+export default caddy;

--- a/scripts/custom-languages/cairo.js
+++ b/scripts/custom-languages/cairo.js
@@ -1,0 +1,69 @@
+const CAIRO_KEYWORDS =
+  "fn let mut const if else loop while for return match struct enum trait impl mod use pub extern type ref in of as self Self break continue where dyn move box nopanic implicits";
+
+const CAIRO_TYPES =
+  "felt252 u8 u16 u32 u64 u128 u256 usize i8 i16 i32 i64 i128 bool Array Span Option Result ContractAddress ClassHash ByteArray";
+
+const CAIRO_LITERALS = "true false";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineCairo(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F][0-9a-fA-F_]*\b/ },
+      { begin: /\b0[oO][0-7][0-7_]*\b/ },
+      { begin: /\b0[bB][01][01_]*\b/ },
+      {
+        begin:
+          /\b\d[\d_]*(?:_(?:felt252|u8|u16|u32|u64|u128|u256|usize|i8|i16|i32|i64|i128))?\b/,
+      },
+    ],
+    relevance: 0,
+  };
+
+  const ATTRIBUTE = {
+    className: "meta",
+    begin: /#!?\[/,
+    end: /\]/,
+    relevance: 5,
+  };
+
+  const TYPE = {
+    className: "type",
+    begin: /\b[A-Z]\w*/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    begin: [/\bfn/, /\s+/, /[a-z_]\w*/],
+    beginScope: { 1: "keyword", 3: "title.function" },
+  };
+
+  return {
+    name: "Cairo",
+    aliases: ["cairo"],
+    keywords: {
+      keyword: CAIRO_KEYWORDS,
+      type: CAIRO_TYPES,
+      literal: CAIRO_LITERALS,
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      hljs.QUOTE_STRING_MODE,
+      ATTRIBUTE,
+      FUNCTION,
+      TYPE,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineCairo(hljs);
+}
+
+export const cairo = { name: "cairo", register };
+export default cairo;

--- a/scripts/custom-languages/clarity.js
+++ b/scripts/custom-languages/clarity.js
@@ -1,0 +1,55 @@
+const CLARITY_KEYWORDS =
+  "define-public define-private define-read-only define-map define-data-var define-constant define-fungible-token define-non-fungible-token define-trait use-trait impl-trait let begin if match map-get? map-set map-insert map-delete var-get var-set contract-call? as-contract try! unwrap! unwrap-err! unwrap-panic unwrap-err-panic asserts! ok err some none print";
+
+const CLARITY_BUILTINS =
+  "and or not is-eq is-none is-some is-ok is-err map filter fold append concat len element-at index-of list tuple get merge to-uint to-int buff-to-int-le buff-to-uint-le buff-to-int-be buff-to-uint-be hash160 sha256 sha512 keccak256 secp256k1-recover? secp256k1-verify principal-of? stx-transfer? stx-burn? stx-get-balance ft-transfer? ft-mint? ft-burn? nft-transfer? nft-mint? nft-burn? nft-get-owner?";
+
+const CLARITY_TYPES =
+  "uint int bool principal buff string-ascii string-utf8 list optional response tuple";
+
+const CLARITY_LITERALS = "true false none";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineClarity(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\bu\d+\b/ },
+      { begin: /\b\d+\b/ },
+      { begin: /\b0x[0-9a-fA-F]+\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const KEYWORD_LITERAL = {
+    className: "symbol",
+    begin: /'[A-Z0-9]+(?:\.[a-zA-Z][\w-]*)?/,
+    relevance: 0,
+  };
+
+  return {
+    name: "Clarity",
+    aliases: ["clarity", "clar"],
+    keywords: {
+      $pattern: "[a-zA-Z_][a-zA-Z0-9_-]*[?!]?",
+      keyword: CLARITY_KEYWORDS,
+      built_in: CLARITY_BUILTINS,
+      type: CLARITY_TYPES,
+      literal: CLARITY_LITERALS,
+    },
+    contains: [
+      hljs.COMMENT(/;;/, /$/),
+      hljs.QUOTE_STRING_MODE,
+      KEYWORD_LITERAL,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineClarity(hljs);
+}
+
+export const clarity = { name: "clarity", register };
+export default clarity;

--- a/scripts/custom-languages/cue.js
+++ b/scripts/custom-languages/cue.js
@@ -1,0 +1,76 @@
+const CUE_KEYWORDS = "package import if for in let";
+
+const CUE_TYPES =
+  "string bytes bool int float number uint uint8 uint16 uint32 uint64 uint128 int8 int16 int32 int64 int128 float32 float64 rune";
+
+const CUE_LITERALS = "true false null";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineCue(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F_]+\b/ },
+      { begin: /\b0[oO][0-7_]+\b/ },
+      { begin: /\b0[bB][01_]+\b/ },
+      { begin: /\b\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?(?:[KMGTPE]i?)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const INTERPOLATION = {
+    className: "subst",
+    begin: /\\\(/,
+    end: /\)/,
+    keywords: { keyword: CUE_KEYWORDS, literal: CUE_LITERALS },
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      {
+        begin: /"""/,
+        end: /"""/,
+        contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+      },
+      {
+        begin: /"/,
+        end: /"/,
+        contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+      },
+      { begin: /#"/, end: /"#/ },
+    ],
+  };
+
+  const DEFINITION = {
+    className: "title.class",
+    begin: /#[A-Za-z_]\w*/,
+    relevance: 0,
+  };
+
+  const ATTRIBUTE = {
+    className: "meta",
+    begin: /@[a-zA-Z_]\w*\(/,
+    end: /\)/,
+    relevance: 0,
+  };
+
+  return {
+    name: "CUE",
+    aliases: ["cue"],
+    keywords: {
+      keyword: CUE_KEYWORDS,
+      type: CUE_TYPES,
+      literal: CUE_LITERALS,
+    },
+    contains: [hljs.C_LINE_COMMENT_MODE, ATTRIBUTE, STRING, DEFINITION, NUMBER],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineCue(hljs);
+}
+
+export const cue = { name: "cue", register };
+export default cue;

--- a/scripts/custom-languages/cypher.js
+++ b/scripts/custom-languages/cypher.js
@@ -1,0 +1,61 @@
+const CYPHER_KEYWORDS =
+  "MATCH OPTIONAL WHERE RETURN WITH CREATE MERGE DELETE DETACH SET REMOVE ORDER BY SKIP LIMIT UNION UNWIND CALL YIELD FOREACH USING INDEX CONSTRAINT ON DROP LOAD CSV FROM AS DISTINCT ASC DESC ASCENDING DESCENDING CASE WHEN THEN ELSE END";
+
+const CYPHER_OPERATORS = "AND OR XOR NOT IN STARTS ENDS CONTAINS IS";
+
+const CYPHER_LITERALS = "true false null TRUE FALSE NULL";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineCypher(hljs) {
+  const NUMBER = {
+    className: "number",
+    begin: /\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/,
+    relevance: 0,
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /'/, end: /'/, contains: [hljs.BACKSLASH_ESCAPE] },
+    ],
+  };
+
+  const LABEL = {
+    className: "type",
+    begin: /:[A-Za-z_]\w*/,
+    relevance: 0,
+  };
+
+  const PARAMETER = {
+    className: "variable",
+    begin: /\$[A-Za-z_]\w*/,
+  };
+
+  return {
+    name: "Cypher",
+    aliases: ["cypher"],
+    case_insensitive: true,
+    keywords: {
+      keyword: CYPHER_KEYWORDS,
+      operator: CYPHER_OPERATORS,
+      literal: CYPHER_LITERALS,
+    },
+    contains: [
+      hljs.COMMENT(/\/\//, /$/),
+      hljs.C_BLOCK_COMMENT_MODE,
+      STRING,
+      LABEL,
+      PARAMETER,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineCypher(hljs);
+}
+
+export const cypher = { name: "cypher", register };
+export default cypher;

--- a/scripts/custom-languages/d2.js
+++ b/scripts/custom-languages/d2.js
@@ -1,0 +1,61 @@
+const D2_KEYWORDS =
+  "shape style label icon near direction width height tooltip link constraint source-arrowhead target-arrowhead grid-rows grid-columns grid-gap vertical-gap horizontal-gap class classes vars";
+
+const D2_VALUES =
+  "rectangle square page parallelogram document cylinder queue package step callout stored_data person diamond oval circle hexagon cloud text code class sequence_diagram up down left right none triangle arrow diamond filled-diamond circle filled-circle box";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineD2(hljs) {
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /'/, end: /'/ },
+    ],
+  };
+
+  const CONNECTION = {
+    className: "operator",
+    begin: /<->|<-|->|--/,
+    relevance: 0,
+  };
+
+  const KEY = {
+    className: "attr",
+    begin: /[a-zA-Z_][\w -]*(?=\s*:)/,
+    relevance: 0,
+  };
+
+  const ATTRIBUTE = {
+    className: "keyword",
+    begin:
+      /\.(?:shape|style|label|icon|near|width|height|tooltip|link|class)\b/,
+    relevance: 0,
+  };
+
+  return {
+    name: "D2",
+    aliases: ["d2"],
+    keywords: {
+      $pattern: "[a-zA-Z_][\\w-]*",
+      keyword: D2_KEYWORDS,
+      literal: D2_VALUES,
+    },
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      STRING,
+      CONNECTION,
+      ATTRIBUTE,
+      KEY,
+      { className: "number", begin: /\b\d+(?:\.\d+)?\b/, relevance: 0 },
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineD2(hljs);
+}
+
+export const d2 = { name: "d2", register };
+export default d2;

--- a/scripts/custom-languages/dhall.js
+++ b/scripts/custom-languages/dhall.js
@@ -1,0 +1,74 @@
+const DHALL_KEYWORDS =
+  "let in if then else merge toMap assert as using with forall Some None";
+
+const DHALL_TYPES =
+  "Natural Integer Double Text Bool Bytes Date Time TimeZone List Optional Type Kind Sort";
+
+const DHALL_LITERALS = "True False NaN Infinity";
+
+const DHALL_BUILTINS =
+  "Natural/fold Natural/build Natural/isZero Natural/even Natural/odd Natural/toInteger Natural/show Natural/subtract List/build List/fold List/length List/head List/last List/indexed List/reverse Text/show Text/replace Optional/fold Optional/build Integer/show Integer/toDouble Double/show";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineDhall(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F]+\b/ },
+      { begin: /[+-]?\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const INTERPOLATION = {
+    className: "subst",
+    begin: /\$\{/,
+    end: /\}/,
+    keywords: { keyword: DHALL_KEYWORDS, literal: DHALL_LITERALS },
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /''/, end: /''/, contains: [INTERPOLATION] },
+      {
+        begin: /"/,
+        end: /"/,
+        contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+      },
+    ],
+  };
+
+  const IMPORT = {
+    className: "link",
+    begin: /(?:https?:\/\/[^\s]+|env:[A-Za-z_]\w*|\.\.?\/[^\s]+)/,
+    relevance: 0,
+  };
+
+  return {
+    name: "Dhall",
+    aliases: ["dhall"],
+    keywords: {
+      $pattern: "[A-Za-z_][A-Za-z0-9_/]*",
+      keyword: DHALL_KEYWORDS,
+      type: DHALL_TYPES,
+      literal: DHALL_LITERALS,
+      built_in: DHALL_BUILTINS,
+    },
+    contains: [
+      hljs.COMMENT(/--/, /$/),
+      hljs.COMMENT(/\{-/, /-\}/),
+      STRING,
+      IMPORT,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineDhall(hljs);
+}
+
+export const dhall = { name: "dhall", register };
+export default dhall;

--- a/scripts/custom-languages/jsonnet.js
+++ b/scripts/custom-languages/jsonnet.js
@@ -1,0 +1,64 @@
+const JSONNET_KEYWORDS =
+  "local function if then else for in import importstr importbin error assert tailstrict";
+
+const JSONNET_LITERALS = "true false null self super";
+
+const JSONNET_BUILTINS =
+  "std length type makeArray join split format substr foldl foldr map filter mapWithKey objectFields objectHas mergePatch manifestJson manifestYamlDoc parseJson parseYaml toString prune range";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineJsonnet(hljs) {
+  const NUMBER = {
+    className: "number",
+    begin: /\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/,
+    relevance: 0,
+  };
+
+  const TEXT_BLOCK = {
+    className: "string",
+    begin: /\|\|\|/,
+    end: /\|\|\|/,
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /@"/, end: /"/ },
+      { begin: /@'/, end: /'/ },
+      { begin: /"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /'/, end: /'/, contains: [hljs.BACKSLASH_ESCAPE] },
+    ],
+  };
+
+  const FUNCTION = {
+    begin: [/\blocal/, /\s+/, /[a-zA-Z_]\w*/, /\s*(?=\()/],
+    beginScope: { 1: "keyword", 3: "title.function" },
+  };
+
+  return {
+    name: "Jsonnet",
+    aliases: ["jsonnet", "libsonnet"],
+    keywords: {
+      keyword: JSONNET_KEYWORDS,
+      literal: JSONNET_LITERALS,
+      built_in: JSONNET_BUILTINS,
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      hljs.HASH_COMMENT_MODE,
+      TEXT_BLOCK,
+      STRING,
+      FUNCTION,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineJsonnet(hljs);
+}
+
+export const jsonnet = { name: "jsonnet", register };
+export default jsonnet;

--- a/scripts/custom-languages/move.js
+++ b/scripts/custom-languages/move.js
@@ -1,0 +1,72 @@
+const MOVE_KEYWORDS =
+  "module script fun public entry native struct has let mut if else while loop return abort break continue use friend const acquires spec as move copy while invariant assume aborts_if ensures requires schema include phantom";
+
+const MOVE_ABILITIES = "copy drop store key";
+
+const MOVE_TYPES = "u8 u16 u32 u64 u128 u256 bool address vector signer";
+
+const MOVE_LITERALS = "true false";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineMove(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      {
+        begin: /\b0[xX][0-9a-fA-F][0-9a-fA-F_]*(?:u(?:8|16|32|64|128|256))?\b/,
+      },
+      { begin: /\b\d[\d_]*(?:u(?:8|16|32|64|128|256))?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const ADDRESS = {
+    className: "symbol",
+    begin: /@(?:0x[0-9a-fA-F]+|[A-Za-z_]\w*)/,
+    relevance: 0,
+  };
+
+  const TYPE = {
+    className: "type",
+    begin: /\b[A-Z]\w*/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    begin: [/\bfun/, /\s+/, /[a-z_]\w*/],
+    beginScope: { 1: "keyword", 3: "title.function" },
+  };
+
+  return {
+    name: "Move",
+    aliases: ["move"],
+    keywords: {
+      keyword: `${MOVE_KEYWORDS} ${MOVE_ABILITIES}`,
+      type: MOVE_TYPES,
+      literal: MOVE_LITERALS,
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      {
+        className: "string",
+        begin: /b?"/,
+        end: /"/,
+        contains: [hljs.BACKSLASH_ESCAPE],
+      },
+      { className: "string", begin: /x"/, end: /"/ },
+      ADDRESS,
+      FUNCTION,
+      TYPE,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineMove(hljs);
+}
+
+export const move = { name: "move", register };
+export default move;

--- a/scripts/custom-languages/nickel.js
+++ b/scripts/custom-languages/nickel.js
@@ -1,0 +1,65 @@
+const NICKEL_KEYWORDS =
+  "let in if then else fun match import default doc optional priority force rec forall not";
+
+const NICKEL_TYPES = "Number String Bool Array Dyn";
+
+const NICKEL_LITERALS = "true false null";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineNickel(hljs) {
+  const NUMBER = {
+    className: "number",
+    begin: /\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/,
+    relevance: 0,
+  };
+
+  const INTERPOLATION = {
+    className: "subst",
+    begin: /%\{/,
+    end: /\}/,
+    keywords: { keyword: NICKEL_KEYWORDS, literal: NICKEL_LITERALS },
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /m%"/, end: /"%/, contains: [INTERPOLATION] },
+      {
+        begin: /"/,
+        end: /"/,
+        contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+      },
+    ],
+  };
+
+  const ENUM_TAG = {
+    className: "symbol",
+    begin: /'[A-Za-z_]\w*/,
+    relevance: 0,
+  };
+
+  const META = {
+    className: "meta",
+    begin: /\b(?:std|builtin)\b/,
+    relevance: 0,
+  };
+
+  return {
+    name: "Nickel",
+    aliases: ["nickel", "ncl"],
+    keywords: {
+      keyword: NICKEL_KEYWORDS,
+      type: NICKEL_TYPES,
+      literal: NICKEL_LITERALS,
+    },
+    contains: [hljs.HASH_COMMENT_MODE, STRING, ENUM_TAG, META, NUMBER],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineNickel(hljs);
+}
+
+export const nickel = { name: "nickel", register };
+export default nickel;

--- a/scripts/custom-languages/odin.js
+++ b/scripts/custom-languages/odin.js
@@ -1,0 +1,78 @@
+const ODIN_KEYWORDS =
+  "package import foreign when if else for in switch case defer return proc struct enum union map bit_set bit_field distinct using cast transmute auto_cast or_else or_return or_break or_continue do break continue fallthrough dynamic matrix typeid context where not_in";
+
+const ODIN_TYPES =
+  "int i8 i16 i32 i64 i128 uint u8 u16 u32 u64 u128 uintptr f16 f32 f64 complex32 complex64 complex128 quaternion64 quaternion128 quaternion256 bool b8 b16 b32 b64 string cstring rune rawptr any byte typeid";
+
+const ODIN_LITERALS = "true false nil";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineOdin(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F][0-9a-fA-F_]*\b/ },
+      { begin: /\b0[oO][0-7][0-7_]*\b/ },
+      { begin: /\b0[bB][01][01_]*\b/ },
+      { begin: /\b\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?[ij]?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const DIRECTIVE = {
+    className: "meta",
+    begin: /#[a-zA-Z_]\w*/,
+    relevance: 0,
+  };
+
+  const ATTRIBUTE = {
+    className: "meta",
+    begin: /@\(?[a-zA-Z_]\w*/,
+    relevance: 0,
+  };
+
+  const TYPE = {
+    className: "type",
+    begin: /\b[A-Z]\w*/,
+    relevance: 0,
+  };
+
+  return {
+    name: "Odin",
+    aliases: ["odin", "odinlang"],
+    keywords: {
+      keyword: ODIN_KEYWORDS,
+      type: ODIN_TYPES,
+      literal: ODIN_LITERALS,
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      {
+        className: "string",
+        begin: /"/,
+        end: /"/,
+        contains: [hljs.BACKSLASH_ESCAPE],
+      },
+      { className: "string", begin: /`/, end: /`/ },
+      {
+        className: "string",
+        begin: /'/,
+        end: /'/,
+        contains: [hljs.BACKSLASH_ESCAPE],
+      },
+      DIRECTIVE,
+      ATTRIBUTE,
+      TYPE,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineOdin(hljs);
+}
+
+export const odin = { name: "odin", register };
+export default odin;

--- a/scripts/custom-languages/pkl.js
+++ b/scripts/custom-languages/pkl.js
@@ -1,0 +1,82 @@
+const PKL_KEYWORDS =
+  "abstract amends as class const else extends external fixed for function hidden if import in is let local module new open out outer read super this throw trace typealias when";
+
+const PKL_TYPES =
+  "String Int Float Boolean Number Listing Mapping List Map Set Collection Pair Dynamic Object Class Module Null Any Duration DataSize";
+
+const PKL_LITERALS = "true false null nothing unknown";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function definePkl(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F_]+\b/ },
+      { begin: /\b0[oO][0-7_]+\b/ },
+      { begin: /\b0[bB][01_]+\b/ },
+      { begin: /\b\d[\d_]*(?:\.[\d_]+)?(?:[eE][+-]?\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const INTERPOLATION = {
+    className: "subst",
+    begin: /\\\(/,
+    end: /\)/,
+    keywords: { keyword: PKL_KEYWORDS, literal: PKL_LITERALS },
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      {
+        begin: /"""/,
+        end: /"""/,
+        contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+      },
+      { begin: /#"/, end: /"#/ },
+      {
+        begin: /"/,
+        end: /"/,
+        contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+      },
+    ],
+  };
+
+  const ANNOTATION = {
+    className: "meta",
+    begin: /@[a-zA-Z_]\w*/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    begin: [/\bfunction/, /\s+/, /[a-zA-Z_]\w*/],
+    beginScope: { 1: "keyword", 3: "title.function" },
+  };
+
+  return {
+    name: "Pkl",
+    aliases: ["pkl"],
+    keywords: {
+      keyword: PKL_KEYWORDS,
+      type: PKL_TYPES,
+      literal: PKL_LITERALS,
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      ANNOTATION,
+      STRING,
+      FUNCTION,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return definePkl(hljs);
+}
+
+export const pkl = { name: "pkl", register };
+export default pkl;

--- a/scripts/custom-languages/promql.js
+++ b/scripts/custom-languages/promql.js
@@ -1,0 +1,61 @@
+const PROMQL_AGGREGATORS =
+  "sum min max avg group stddev stdvar count count_values bottomk topk quantile limitk limit_ratio";
+
+const PROMQL_KEYWORDS =
+  "by without on ignoring group_left group_right offset bool and or unless";
+
+const PROMQL_FUNCTIONS =
+  "abs absent absent_over_time ceil changes clamp clamp_max clamp_min day_of_month day_of_week day_of_year days_in_month delta deriv exp floor histogram_quantile histogram_count histogram_sum histogram_fraction holt_winters hour idelta increase irate label_join label_replace ln log2 log10 minute month predict_linear rate resets round scalar sgn sort sort_desc sqrt time timestamp vector year avg_over_time min_over_time max_over_time sum_over_time count_over_time quantile_over_time stddev_over_time stdvar_over_time last_over_time present_over_time mad_over_time";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function definePromQL(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b\d+(?:\.\d+)?(?:ms|[smhdwy])\b/ },
+      { begin: /\b0[xX][0-9a-fA-F]+\b/ },
+      { begin: /\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/ },
+      { begin: /\b(?:Inf|NaN)\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /'/, end: /'/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /`/, end: /`/ },
+    ],
+  };
+
+  const LABEL = {
+    className: "attr",
+    begin: /[a-zA-Z_]\w*(?=\s*(?:=~|!~|=|!=))/,
+    relevance: 0,
+  };
+
+  const METRIC = {
+    className: "built_in",
+    begin: /\b[a-zA-Z_:][a-zA-Z0-9_:]*(?=\s*\{)/,
+    relevance: 0,
+  };
+
+  return {
+    name: "PromQL",
+    aliases: ["promql"],
+    keywords: {
+      keyword: PROMQL_KEYWORDS,
+      built_in: `${PROMQL_AGGREGATORS} ${PROMQL_FUNCTIONS}`,
+    },
+    contains: [hljs.HASH_COMMENT_MODE, STRING, LABEL, METRIC, NUMBER],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return definePromQL(hljs);
+}
+
+export const promql = { name: "promql", register };
+export default promql;

--- a/scripts/custom-languages/pug.js
+++ b/scripts/custom-languages/pug.js
@@ -1,0 +1,50 @@
+const PUG_KEYWORDS =
+  "if else unless case when default each for in while block extends include append prepend mixin yield";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function definePug(hljs) {
+  const INTERPOLATION = {
+    className: "subst",
+    begin: /[#!]\{/,
+    end: /\}/,
+    relevance: 0,
+  };
+
+  const ATTRIBUTES = {
+    className: "attr",
+    begin: /\(/,
+    end: /\)/,
+    contains: [hljs.QUOTE_STRING_MODE, hljs.APOS_STRING_MODE, INTERPOLATION],
+    relevance: 0,
+  };
+
+  return {
+    name: "Pug",
+    aliases: ["pug", "jade"],
+    case_insensitive: true,
+    keywords: { keyword: PUG_KEYWORDS },
+    contains: [
+      hljs.COMMENT(/^\s*\/\/-/, /$/),
+      { className: "meta", begin: /^\s*doctype\b/, end: /$/ },
+      // tag with optional id/class shorthand at line start
+      {
+        begin: /^\s*(?=[a-zA-Z])/,
+        contains: [{ className: "selector-tag", begin: /[a-zA-Z][\w:-]*/ }],
+        relevance: 0,
+      },
+      { className: "selector-id", begin: /#[\w-]+/ },
+      { className: "selector-class", begin: /\.[\w-]+/ },
+      { className: "keyword", begin: /\+[a-zA-Z][\w-]*/ },
+      ATTRIBUTES,
+      INTERPOLATION,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return definePug(hljs);
+}
+
+export const pug = { name: "pug", register };
+export default pug;

--- a/scripts/custom-languages/razor.js
+++ b/scripts/custom-languages/razor.js
@@ -1,0 +1,69 @@
+const RAZOR_DIRECTIVES =
+  "page model using inject inherits implements layout namespace section functions code attribute preservewhitespace addTagHelper removeTagHelper tagHelperPrefix rendermode typeparam";
+
+const RAZOR_CSHARP_KEYWORDS =
+  "if else for foreach while do switch case default try catch finally return await async var new using lock";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineRazor(hljs) {
+  const CSHARP_STRING = {
+    className: "string",
+    variants: [
+      { begin: /@?"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /'/, end: /'/, contains: [hljs.BACKSLASH_ESCAPE] },
+    ],
+  };
+
+  const DIRECTIVE = {
+    className: "meta",
+    begin:
+      /@(?:page|model|using|inject|inherits|implements|layout|namespace|section|functions|code|attribute|preservewhitespace|addTagHelper|removeTagHelper|tagHelperPrefix|rendermode|typeparam)\b/,
+  };
+
+  const CODE_BLOCK = {
+    begin: /@\{/,
+    end: /\}/,
+    keywords: { keyword: RAZOR_CSHARP_KEYWORDS },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      CSHARP_STRING,
+      { className: "number", begin: /\b\d+(?:\.\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const EXPRESSION = {
+    className: "template-variable",
+    begin: /@[A-Za-z_][\w.]*/,
+    relevance: 0,
+  };
+
+  const TAG = {
+    className: "tag",
+    begin: /<\/?[a-zA-Z][\w-]*/,
+    end: />/,
+    relevance: 0,
+  };
+
+  return {
+    name: "Razor",
+    aliases: ["razor", "cshtml"],
+    keywords: { keyword: RAZOR_DIRECTIVES },
+    contains: [
+      hljs.COMMENT(/@\*/, /\*@/),
+      DIRECTIVE,
+      CODE_BLOCK,
+      EXPRESSION,
+      TAG,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineRazor(hljs);
+}
+
+export const razor = { name: "razor", register };
+export default razor;

--- a/scripts/custom-languages/rescript.js
+++ b/scripts/custom-languages/rescript.js
@@ -1,0 +1,71 @@
+const RESCRIPT_KEYWORDS =
+  "and as assert async await catch constraint downto else exception external false for if in include lazy let module mutable of open private rec switch then to true try type when while with";
+
+const RESCRIPT_LITERALS = "true false";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineReScript(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F][0-9a-fA-F_]*\b/ },
+      { begin: /\b0[oO][0-7][0-7_]*\b/ },
+      { begin: /\b0[bB][01][01_]*\b/ },
+      { begin: /\b\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const POLY_VARIANT = {
+    className: "symbol",
+    begin: /#[A-Za-z_]\w*/,
+    relevance: 0,
+  };
+
+  const CONSTRUCTOR = {
+    className: "type",
+    begin: /\b[A-Z]\w*/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    begin: [/\blet\b/, /\s+/, /[a-z_]\w*/, /\s*=\s*/, /\(/],
+    beginScope: { 1: "keyword", 3: "title.function" },
+  };
+
+  const DECORATOR = {
+    className: "meta",
+    begin: /@@?[a-zA-Z_][\w.]*/,
+    relevance: 0,
+  };
+
+  return {
+    name: "ReScript",
+    aliases: ["rescript", "res"],
+    keywords: { keyword: RESCRIPT_KEYWORDS, literal: RESCRIPT_LITERALS },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      hljs.QUOTE_STRING_MODE,
+      {
+        className: "string",
+        begin: /`/,
+        end: /`/,
+        contains: [hljs.BACKSLASH_ESCAPE],
+      },
+      DECORATOR,
+      POLY_VARIANT,
+      FUNCTION,
+      CONSTRUCTOR,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineReScript(hljs);
+}
+
+export const rescript = { name: "rescript", register };
+export default rescript;

--- a/scripts/custom-languages/starlark.js
+++ b/scripts/custom-languages/starlark.js
@@ -1,0 +1,54 @@
+const STARLARK_KEYWORDS =
+  "and break continue def elif else for if in lambda load not or pass return while";
+
+const STARLARK_LITERALS = "True False None";
+
+const STARLARK_BUILTINS =
+  "glob select package licenses exports_files depset struct provider rule attr aspect fail print len range enumerate reversed sorted zip dict list tuple type hasattr getattr dir repr str int bool hash all any min max";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineStarlark(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F]+\b/ },
+      { begin: /\b0[oO][0-7]+\b/ },
+      { begin: /\b\d+(?:\.\d*)?(?:[eE][+-]?\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      { begin: /[rb]?"""/, end: /"""/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /[rb]?'''/, end: /'''/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /[rb]?"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+      { begin: /[rb]?'/, end: /'/, contains: [hljs.BACKSLASH_ESCAPE] },
+    ],
+  };
+
+  const FUNCTION = {
+    begin: [/\bdef/, /\s+/, /[a-zA-Z_]\w*/],
+    beginScope: { 1: "keyword", 3: "title.function" },
+  };
+
+  return {
+    name: "Starlark",
+    aliases: ["starlark", "bazel", "bzl"],
+    keywords: {
+      keyword: STARLARK_KEYWORDS,
+      literal: STARLARK_LITERALS,
+      built_in: STARLARK_BUILTINS,
+    },
+    contains: [hljs.HASH_COMMENT_MODE, STRING, FUNCTION, NUMBER],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineStarlark(hljs);
+}
+
+export const starlark = { name: "starlark", register };
+export default starlark;

--- a/scripts/custom-languages/v.js
+++ b/scripts/custom-languages/v.js
@@ -1,0 +1,90 @@
+const V_KEYWORDS =
+  "module import fn struct enum interface union pub mut const type if else for in match return go spawn defer unsafe or break continue assert as is sizeof typeof isreftype dump __global shared lock rlock select atomic static volatile asm goto none";
+
+const V_TYPES =
+  "int i8 i16 i32 i64 i128 u8 u16 u32 u64 u128 f32 f64 bool string rune byte char voidptr any isize usize map array thread";
+
+const V_LITERALS = "true false none";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineV(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F][0-9a-fA-F_]*\b/ },
+      { begin: /\b0[oO][0-7][0-7_]*\b/ },
+      { begin: /\b0[bB][01][01_]*\b/ },
+      { begin: /\b\d[\d_]*(?:\.[\d_]*)?(?:[eE][+-]?\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const INTERPOLATION = {
+    className: "subst",
+    begin: /\$\{/,
+    end: /\}/,
+    keywords: { keyword: V_KEYWORDS, literal: V_LITERALS },
+  };
+
+  const STRING = {
+    className: "string",
+    variants: [
+      {
+        begin: /[rc]?"/,
+        end: /"/,
+        contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+      },
+      {
+        begin: /[rc]?'/,
+        end: /'/,
+        contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
+      },
+      { begin: /`/, end: /`/ },
+    ],
+  };
+
+  const ATTRIBUTE = {
+    className: "meta",
+    begin: /^\s*\[[a-zA-Z_]/,
+    end: /\]/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    begin: [/\bfn/, /\s+/, /[a-z_]\w*/],
+    beginScope: { 1: "keyword", 3: "title.function" },
+  };
+
+  const TYPE = {
+    className: "type",
+    begin: /\b[A-Z]\w*/,
+    relevance: 0,
+  };
+
+  return {
+    name: "V",
+    aliases: ["v", "vlang"],
+    keywords: {
+      keyword: V_KEYWORDS,
+      type: V_TYPES,
+      literal: V_LITERALS,
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      ATTRIBUTE,
+      STRING,
+      FUNCTION,
+      TYPE,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineV(hljs);
+}
+
+export const v = { name: "v", register };
+export default v;

--- a/scripts/custom-languages/vyper.js
+++ b/scripts/custom-languages/vyper.js
@@ -1,0 +1,57 @@
+const VYPER_KEYWORDS =
+  "def return if elif else for in while pass break continue assert raise event struct interface enum flag implements import from as constant immutable public private external internal payable nonpayable view pure indexed log and or not range";
+
+const VYPER_TYPES =
+  "uint8 uint16 uint32 uint64 uint128 uint256 int8 int16 int32 int64 int128 int256 address bool bytes32 bytes Bytes String string decimal HashMap DynArray map";
+
+const VYPER_LITERALS = "True False self msg block tx chain empty";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineVyper(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F]+\b/ },
+      { begin: /\b\d+(?:\.\d+)?(?:[eE][+-]?\d+)?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const DECORATOR = {
+    className: "meta",
+    begin: /@[a-zA-Z_]\w*/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    begin: [/\bdef/, /\s+/, /[a-zA-Z_]\w*/],
+    beginScope: { 1: "keyword", 3: "title.function" },
+  };
+
+  return {
+    name: "Vyper",
+    aliases: ["vyper"],
+    keywords: {
+      keyword: VYPER_KEYWORDS,
+      type: VYPER_TYPES,
+      literal: VYPER_LITERALS,
+    },
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      { className: "string", begin: /"""/, end: /"""/ },
+      hljs.QUOTE_STRING_MODE,
+      hljs.APOS_STRING_MODE,
+      DECORATOR,
+      FUNCTION,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineVyper(hljs);
+}
+
+export const vyper = { name: "vyper", register };
+export default vyper;

--- a/scripts/custom-languages/wgsl.js
+++ b/scripts/custom-languages/wgsl.js
@@ -1,0 +1,56 @@
+const WGSL_KEYWORDS =
+  "alias break case const const_assert continue continuing default diagnostic discard else enable fn for if let loop override requires return struct switch var while";
+
+const WGSL_TYPES =
+  "bool f16 f32 i32 u32 vec2 vec3 vec4 mat2x2 mat2x3 mat2x4 mat3x2 mat3x3 mat3x4 mat4x2 mat4x3 mat4x4 array atomic ptr sampler sampler_comparison texture_1d texture_2d texture_2d_array texture_3d texture_cube texture_cube_array texture_multisampled_2d texture_storage_1d texture_storage_2d texture_storage_2d_array texture_storage_3d texture_depth_2d texture_depth_2d_array texture_depth_cube texture_depth_cube_array texture_depth_multisampled_2d";
+
+const WGSL_LITERALS = "true false";
+
+/** @param {import("highlight.js").HLJSApi} hljs */
+function defineWgsl(hljs) {
+  const NUMBER = {
+    className: "number",
+    variants: [
+      { begin: /\b0[xX][0-9a-fA-F]+[iuhf]?\b/ },
+      { begin: /\b\d+(?:\.\d*)?(?:[eE][+-]?\d+)?[ifh]?\b/ },
+      { begin: /\.\d+(?:[eE][+-]?\d+)?[ifh]?\b/ },
+    ],
+    relevance: 0,
+  };
+
+  const ATTRIBUTE = {
+    className: "meta",
+    begin: /@[a-zA-Z_]\w*/,
+    relevance: 0,
+  };
+
+  const FUNCTION = {
+    begin: [/\bfn/, /\s+/, /[a-zA-Z_]\w*/],
+    beginScope: { 1: "keyword", 3: "title.function" },
+  };
+
+  return {
+    name: "WGSL",
+    aliases: ["wgsl"],
+    keywords: {
+      keyword: WGSL_KEYWORDS,
+      type: WGSL_TYPES,
+      literal: WGSL_LITERALS,
+    },
+    contains: [
+      hljs.C_LINE_COMMENT_MODE,
+      hljs.C_BLOCK_COMMENT_MODE,
+      ATTRIBUTE,
+      FUNCTION,
+      NUMBER,
+    ],
+  };
+}
+
+/** @type {import("highlight.js").LanguageFn} */
+function register(hljs) {
+  return defineWgsl(hljs);
+}
+
+export const wgsl = { name: "wgsl", register };
+export default wgsl;

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -186,6 +186,7 @@ exports[`Languages 1`] = `
   "sqf",
   "sql",
   "stan",
+  "starlark",
   "stata",
   "step21",
   "stylus",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -211,6 +211,7 @@ exports[`Languages 1`] = `
   "tp",
   "twig",
   "typescript",
+  "v",
   "vala",
   "vbnet",
   "vbscript",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -32,6 +32,7 @@ exports[`Languages 1`] = `
   "cal",
   "capnproto",
   "ceylon",
+  "clarity",
   "clean",
   "clojure",
   "clojureRepl",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -153,6 +153,7 @@ exports[`Languages 1`] = `
   "pgsql",
   "php",
   "phpTemplate",
+  "pkl",
   "plaintext",
   "pony",
   "powershell",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -23,6 +23,7 @@ exports[`Languages 1`] = `
   "axapta",
   "bash",
   "basic",
+  "bibtex",
   "bicep",
   "blade",
   "bnf",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -138,6 +138,7 @@ exports[`Languages 1`] = `
   "n1ql",
   "nestedtext",
   "nginx",
+  "nickel",
   "nim",
   "nix",
   "nodeRepl",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -153,6 +153,7 @@ exports[`Languages 1`] = `
   "processing",
   "profile",
   "prolog",
+  "promql",
   "properties",
   "protobuf",
   "puppet",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -165,6 +165,7 @@ exports[`Languages 1`] = `
   "promql",
   "properties",
   "protobuf",
+  "pug",
   "puppet",
   "purebasic",
   "python",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -28,6 +28,7 @@ exports[`Languages 1`] = `
   "bnf",
   "brainfuck",
   "c",
+  "caddy",
   "cairo",
   "cal",
   "capnproto",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -165,6 +165,7 @@ exports[`Languages 1`] = `
   "qml",
   "r",
   "reasonml",
+  "rescript",
   "rib",
   "roboconf",
   "routeros",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -43,6 +43,7 @@ exports[`Languages 1`] = `
   "csharp",
   "csp",
   "css",
+  "cypher",
   "d",
   "dart",
   "delphi",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -23,6 +23,7 @@ exports[`Languages 1`] = `
   "axapta",
   "bash",
   "basic",
+  "bicep",
   "blade",
   "bnf",
   "brainfuck",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -205,6 +205,7 @@ exports[`Languages 1`] = `
   "vim",
   "vue",
   "wasm",
+  "wgsl",
   "wren",
   "x86asm",
   "xl",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -146,6 +146,7 @@ exports[`Languages 1`] = `
   "nushell",
   "objectivec",
   "ocaml",
+  "odin",
   "openscad",
   "oxygene",
   "parser3",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -46,6 +46,7 @@ exports[`Languages 1`] = `
   "csharp",
   "csp",
   "css",
+  "cue",
   "cypher",
   "d",
   "dart",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -103,6 +103,7 @@ exports[`Languages 1`] = `
   "json",
   "json5",
   "jsonc",
+  "jsonnet",
   "julia",
   "juliaRepl",
   "kotlin",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -28,6 +28,7 @@ exports[`Languages 1`] = `
   "bnf",
   "brainfuck",
   "c",
+  "cairo",
   "cal",
   "capnproto",
   "ceylon",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -129,6 +129,7 @@ exports[`Languages 1`] = `
   "mojolicious",
   "monkey",
   "moonscript",
+  "move",
   "n1ql",
   "nestedtext",
   "nginx",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -211,6 +211,7 @@ exports[`Languages 1`] = `
   "vhdl",
   "vim",
   "vue",
+  "vyper",
   "wasm",
   "wgsl",
   "wren",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -51,6 +51,7 @@ exports[`Languages 1`] = `
   "d",
   "dart",
   "delphi",
+  "dhall",
   "diff",
   "django",
   "dns",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -50,6 +50,7 @@ exports[`Languages 1`] = `
   "cue",
   "cypher",
   "d",
+  "d2",
   "dart",
   "delphi",
   "dhall",

--- a/tests/__snapshots__/languages.test.ts.snap
+++ b/tests/__snapshots__/languages.test.ts.snap
@@ -173,6 +173,7 @@ exports[`Languages 1`] = `
   "q",
   "qml",
   "r",
+  "razor",
   "reasonml",
   "rescript",
   "rib",

--- a/tests/bibtex-language.test.ts
+++ b/tests/bibtex-language.test.ts
@@ -1,0 +1,32 @@
+import hljs from "highlight.js/lib/core";
+import bibtex from "../src/languages/bibtex";
+
+hljs.registerLanguage(bibtex.name, bibtex.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "bibtex" }).value;
+
+test("bibtex highlights entry types as keywords", () => {
+  const result = highlight("@article{key, year = 2020}");
+
+  expect(result).toContain('<span class="hljs-keyword">@article</span>');
+});
+
+test("bibtex highlights field names as attributes", () => {
+  const result = highlight("@book{key, author = {Doe}}");
+
+  expect(result).toContain('<span class="hljs-attr">author</span>');
+});
+
+test("bibtex highlights braced and quoted values", () => {
+  const result = highlight('@misc{k, title = {Hi}, note = "n"}');
+
+  expect(result).toContain('<span class="hljs-string">{Hi}</span>');
+  expect(result).toContain('<span class="hljs-string">&quot;n&quot;</span>');
+});
+
+test("bibtex highlights numeric values", () => {
+  const result = highlight("@article{k, year = 2020}");
+
+  expect(result).toContain('<span class="hljs-number">2020</span>');
+});

--- a/tests/bicep-language.test.ts
+++ b/tests/bicep-language.test.ts
@@ -1,0 +1,39 @@
+import hljs from "highlight.js/lib/core";
+import bicep from "../src/languages/bicep";
+
+hljs.registerLanguage(bicep.name, bicep.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "bicep" }).value;
+
+test("bicep highlights declaration keywords", () => {
+  const result = highlight("param location string");
+
+  expect(result).toContain('<span class="hljs-keyword">param</span>');
+  expect(result).toContain('<span class="hljs-type">string</span>');
+});
+
+test("bicep highlights single-quoted strings", () => {
+  const result = highlight("param location string = 'eastus'");
+
+  expect(result).toContain(
+    '<span class="hljs-string">&#x27;eastus&#x27;</span>',
+  );
+});
+
+test("bicep highlights decorators as meta", () => {
+  const result = highlight("@secure()\nparam pw string");
+
+  expect(result).toContain('<span class="hljs-meta">@secure</span>');
+});
+
+test("bicep highlights resource type references", () => {
+  const result = highlight(
+    "resource sa 'Microsoft.Storage/storageAccounts@2021-09-01' = {}",
+  );
+
+  expect(result).toContain('<span class="hljs-keyword">resource</span>');
+  expect(result).toContain(
+    '<span class="hljs-type">&#x27;Microsoft.Storage/storageAccounts@2021-09-01&#x27;</span>',
+  );
+});

--- a/tests/caddy-language.test.ts
+++ b/tests/caddy-language.test.ts
@@ -1,0 +1,32 @@
+import hljs from "highlight.js/lib/core";
+import caddy from "../src/languages/caddy";
+
+hljs.registerLanguage(caddy.name, caddy.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "caddy" }).value;
+
+test("caddy highlights directives", () => {
+  const result = highlight("example.com {\n\treverse_proxy localhost:8080\n}");
+
+  expect(result).toContain('<span class="hljs-keyword">reverse_proxy</span>');
+});
+
+test("caddy highlights the site address", () => {
+  const result = highlight("example.com {\n\tfile_server\n}");
+
+  expect(result).toContain('<span class="hljs-attr">example.com</span>');
+});
+
+test("caddy highlights named matchers", () => {
+  const result = highlight("@api path /api/*");
+
+  expect(result).toContain('<span class="hljs-symbol">@api</span>');
+});
+
+test("caddy highlights placeholders and comments", () => {
+  const result = highlight("# proxy\nheader X-Real-IP {remote_host}");
+
+  expect(result).toContain('<span class="hljs-comment"># proxy</span>');
+  expect(result).toContain('<span class="hljs-variable">{remote_host}</span>');
+});

--- a/tests/cairo-language.test.ts
+++ b/tests/cairo-language.test.ts
@@ -1,0 +1,32 @@
+import hljs from "highlight.js/lib/core";
+import cairo from "../src/languages/cairo";
+
+hljs.registerLanguage(cairo.name, cairo.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "cairo" }).value;
+
+test("cairo highlights fn declarations", () => {
+  const result = highlight("fn main() {}");
+
+  expect(result).toContain('<span class="hljs-keyword">fn</span>');
+  expect(result).toContain('<span class="hljs-title function_">main</span>');
+});
+
+test("cairo highlights felt252 and integer types", () => {
+  const result = highlight("let x: felt252 = 5;");
+
+  expect(result).toContain('<span class="hljs-type">felt252</span>');
+});
+
+test("cairo highlights attributes", () => {
+  const result = highlight("#[derive(Drop)]\nstruct S {}");
+
+  expect(result).toContain('<span class="hljs-meta">');
+});
+
+test("cairo highlights hex numbers", () => {
+  const result = highlight("let a = 0x1f;");
+
+  expect(result).toContain('<span class="hljs-number">0x1f</span>');
+});

--- a/tests/clarity-language.test.ts
+++ b/tests/clarity-language.test.ts
@@ -1,0 +1,33 @@
+import hljs from "highlight.js/lib/core";
+import clarity from "../src/languages/clarity";
+
+hljs.registerLanguage(clarity.name, clarity.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "clarity" }).value;
+
+test("clarity highlights hyphenated define keywords", () => {
+  const result = highlight("(define-public (go) (ok true))");
+
+  expect(result).toContain('<span class="hljs-keyword">define-public</span>');
+  expect(result).toContain('<span class="hljs-keyword">ok</span>');
+});
+
+test("clarity highlights keywords ending in punctuation", () => {
+  const result = highlight("(asserts! true (err u1))");
+
+  expect(result).toContain('<span class="hljs-keyword">asserts!</span>');
+});
+
+test("clarity highlights types and literals", () => {
+  const result = highlight("(define-data-var n uint u0)");
+
+  expect(result).toContain('<span class="hljs-type">uint</span>');
+});
+
+test("clarity highlights uint literals and comments", () => {
+  const result = highlight(";; counter\n(var-set n u5)");
+
+  expect(result).toContain('<span class="hljs-comment">;; counter</span>');
+  expect(result).toContain('<span class="hljs-number">u5</span>');
+});

--- a/tests/cue-language.test.ts
+++ b/tests/cue-language.test.ts
@@ -1,0 +1,34 @@
+import hljs from "highlight.js/lib/core";
+import cue from "../src/languages/cue";
+
+hljs.registerLanguage(cue.name, cue.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "cue" }).value;
+
+test("cue highlights package and import keywords", () => {
+  const result = highlight("package config");
+
+  expect(result).toContain('<span class="hljs-keyword">package</span>');
+});
+
+test("cue highlights definitions", () => {
+  const result = highlight("#Schema: {}");
+
+  expect(result).toContain('<span class="hljs-title class_">#Schema</span>');
+});
+
+test("cue highlights builtin types", () => {
+  const result = highlight("name: string");
+
+  expect(result).toContain('<span class="hljs-type">string</span>');
+});
+
+test("cue highlights strings and numbers", () => {
+  const result = highlight('host: "localhost"\nport: 8080');
+
+  expect(result).toContain(
+    '<span class="hljs-string">&quot;localhost&quot;</span>',
+  );
+  expect(result).toContain('<span class="hljs-number">8080</span>');
+});

--- a/tests/cypher-language.test.ts
+++ b/tests/cypher-language.test.ts
@@ -1,0 +1,34 @@
+import hljs from "highlight.js/lib/core";
+import cypher from "../src/languages/cypher";
+
+hljs.registerLanguage(cypher.name, cypher.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "cypher" }).value;
+
+test("cypher highlights clause keywords", () => {
+  const result = highlight("MATCH (n) RETURN n");
+
+  expect(result).toContain('<span class="hljs-keyword">MATCH</span>');
+  expect(result).toContain('<span class="hljs-keyword">RETURN</span>');
+});
+
+test("cypher is case-insensitive for keywords", () => {
+  const result = highlight("match (n) where n.x = 1 return n");
+
+  expect(result).toContain('<span class="hljs-keyword">match</span>');
+  expect(result).toContain('<span class="hljs-keyword">where</span>');
+});
+
+test("cypher highlights node labels", () => {
+  const result = highlight("MATCH (n:Person) RETURN n");
+
+  expect(result).toContain('<span class="hljs-type">:Person</span>');
+});
+
+test("cypher highlights parameters and strings", () => {
+  const result = highlight('MATCH (n) WHERE n.name = $name RETURN "ok"');
+
+  expect(result).toContain('<span class="hljs-variable">$name</span>');
+  expect(result).toContain('<span class="hljs-string">&quot;ok&quot;</span>');
+});

--- a/tests/d2-language.test.ts
+++ b/tests/d2-language.test.ts
@@ -1,0 +1,31 @@
+import hljs from "highlight.js/lib/core";
+import d2 from "../src/languages/d2";
+
+hljs.registerLanguage(d2.name, d2.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "d2" }).value;
+
+test("d2 highlights connection operators", () => {
+  const result = highlight("a -> b: request");
+
+  expect(result).toContain('<span class="hljs-operator">-&gt;</span>');
+});
+
+test("d2 highlights shape attributes", () => {
+  const result = highlight("server.shape: cylinder");
+
+  expect(result).toContain('<span class="hljs-keyword">.shape</span>');
+});
+
+test("d2 highlights shape values", () => {
+  const result = highlight("db.shape: cylinder");
+
+  expect(result).toContain('<span class="hljs-literal">cylinder</span>');
+});
+
+test("d2 highlights comments", () => {
+  const result = highlight("# diagram\na -> b");
+
+  expect(result).toContain('<span class="hljs-comment"># diagram</span>');
+});

--- a/tests/dhall-language.test.ts
+++ b/tests/dhall-language.test.ts
@@ -1,0 +1,32 @@
+import hljs from "highlight.js/lib/core";
+import dhall from "../src/languages/dhall";
+
+hljs.registerLanguage(dhall.name, dhall.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "dhall" }).value;
+
+test("dhall highlights let/in keywords", () => {
+  const result = highlight("let x = 1 in x");
+
+  expect(result).toContain('<span class="hljs-keyword">let</span>');
+  expect(result).toContain('<span class="hljs-keyword">in</span>');
+});
+
+test("dhall highlights builtin types", () => {
+  const result = highlight("let n : Natural = 1");
+
+  expect(result).toContain('<span class="hljs-type">Natural</span>');
+});
+
+test("dhall highlights namespaced builtins", () => {
+  const result = highlight("Natural/fold 3");
+
+  expect(result).toContain('<span class="hljs-built_in">Natural/fold</span>');
+});
+
+test("dhall highlights literals", () => {
+  const result = highlight("let b = True");
+
+  expect(result).toContain('<span class="hljs-literal">True</span>');
+});

--- a/tests/jsonnet-language.test.ts
+++ b/tests/jsonnet-language.test.ts
@@ -1,0 +1,35 @@
+import hljs from "highlight.js/lib/core";
+import jsonnet from "../src/languages/jsonnet";
+
+hljs.registerLanguage(jsonnet.name, jsonnet.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "jsonnet" }).value;
+
+test("jsonnet highlights local function declarations", () => {
+  const result = highlight("local f(x) = x;");
+
+  expect(result).toContain('<span class="hljs-keyword">local</span>');
+  expect(result).toContain('<span class="hljs-title function_">f</span>');
+});
+
+test("jsonnet highlights the std library", () => {
+  const result = highlight("{ a: std.length([]) }");
+
+  expect(result).toContain('<span class="hljs-built_in">std</span>');
+  expect(result).toContain('<span class="hljs-built_in">length</span>');
+});
+
+test("jsonnet highlights literals", () => {
+  const result = highlight("{ ok: true }");
+
+  expect(result).toContain('<span class="hljs-literal">true</span>');
+});
+
+test("jsonnet highlights strings", () => {
+  const result = highlight('{ name: "svelte" }');
+
+  expect(result).toContain(
+    '<span class="hljs-string">&quot;svelte&quot;</span>',
+  );
+});

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(227);
+  expect(languageNames.length).toEqual(228);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(231);
+  expect(languageNames.length).toEqual(232);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(215);
+  expect(languageNames.length).toEqual(216);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(213);
+  expect(languageNames.length).toEqual(214);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(216);
+  expect(languageNames.length).toEqual(217);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(217);
+  expect(languageNames.length).toEqual(218);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(224);
+  expect(languageNames.length).toEqual(225);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(230);
+  expect(languageNames.length).toEqual(231);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(219);
+  expect(languageNames.length).toEqual(220);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(223);
+  expect(languageNames.length).toEqual(224);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(228);
+  expect(languageNames.length).toEqual(229);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(211);
+  expect(languageNames.length).toEqual(212);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(229);
+  expect(languageNames.length).toEqual(230);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(212);
+  expect(languageNames.length).toEqual(213);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(214);
+  expect(languageNames.length).toEqual(215);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(225);
+  expect(languageNames.length).toEqual(226);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(218);
+  expect(languageNames.length).toEqual(219);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(222);
+  expect(languageNames.length).toEqual(223);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(226);
+  expect(languageNames.length).toEqual(227);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(220);
+  expect(languageNames.length).toEqual(221);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(221);
+  expect(languageNames.length).toEqual(222);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/languages.test.ts
+++ b/tests/languages.test.ts
@@ -6,7 +6,7 @@ test("Languages", () => {
 
   // @ts-expect-error
   expect(languages.default).toBeUndefined();
-  expect(languageNames.length).toEqual(232);
+  expect(languageNames.length).toEqual(233);
   expect(languageNames).toMatchSnapshot();
 });
 

--- a/tests/move-language.test.ts
+++ b/tests/move-language.test.ts
@@ -1,0 +1,33 @@
+import hljs from "highlight.js/lib/core";
+import move from "../src/languages/move";
+
+hljs.registerLanguage(move.name, move.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "move" }).value;
+
+test("move highlights module and fun declarations", () => {
+  const result = highlight("module addr::Coin { public fun mint() {} }");
+
+  expect(result).toContain('<span class="hljs-keyword">module</span>');
+  expect(result).toContain('<span class="hljs-keyword">fun</span>');
+  expect(result).toContain('<span class="hljs-title function_">mint</span>');
+});
+
+test("move highlights integer types", () => {
+  const result = highlight("let x: u64 = 1;");
+
+  expect(result).toContain('<span class="hljs-type">u64</span>');
+});
+
+test("move highlights address literals", () => {
+  const result = highlight("use @0x1::coin;");
+
+  expect(result).toContain('<span class="hljs-symbol">@0x1</span>');
+});
+
+test("move highlights typed number literals", () => {
+  const result = highlight("let n = 100;");
+
+  expect(result).toContain('<span class="hljs-number">100</span>');
+});

--- a/tests/nickel-language.test.ts
+++ b/tests/nickel-language.test.ts
@@ -1,0 +1,35 @@
+import hljs from "highlight.js/lib/core";
+import nickel from "../src/languages/nickel";
+
+hljs.registerLanguage(nickel.name, nickel.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "nickel" }).value;
+
+test("nickel highlights let/in keywords", () => {
+  const result = highlight("let x = 1 in x");
+
+  expect(result).toContain('<span class="hljs-keyword">let</span>');
+  expect(result).toContain('<span class="hljs-keyword">in</span>');
+});
+
+test("nickel highlights fun keyword", () => {
+  const result = highlight("let f = fun x => x in f");
+
+  expect(result).toContain('<span class="hljs-keyword">fun</span>');
+});
+
+test("nickel highlights enum tags", () => {
+  const result = highlight("let color = 'Red in color");
+
+  expect(result).toContain('<span class="hljs-symbol">&#x27;Red</span>');
+});
+
+test("nickel highlights strings and comments", () => {
+  const result = highlight('# config\nname = "svelte"');
+
+  expect(result).toContain('<span class="hljs-comment"># config</span>');
+  expect(result).toContain(
+    '<span class="hljs-string">&quot;svelte&quot;</span>',
+  );
+});

--- a/tests/odin-language.test.ts
+++ b/tests/odin-language.test.ts
@@ -1,0 +1,32 @@
+import hljs from "highlight.js/lib/core";
+import odin from "../src/languages/odin";
+
+hljs.registerLanguage(odin.name, odin.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "odin" }).value;
+
+test("odin highlights proc keyword", () => {
+  const result = highlight("main :: proc() {}");
+
+  expect(result).toContain('<span class="hljs-keyword">proc</span>');
+});
+
+test("odin highlights package and import keywords", () => {
+  const result = highlight('package main\nimport "core:fmt"');
+
+  expect(result).toContain('<span class="hljs-keyword">package</span>');
+  expect(result).toContain('<span class="hljs-keyword">import</span>');
+});
+
+test("odin highlights builtin types", () => {
+  const result = highlight("x: int = 5");
+
+  expect(result).toContain('<span class="hljs-type">int</span>');
+});
+
+test("odin highlights directives as meta", () => {
+  const result = highlight("#partial switch x {}");
+
+  expect(result).toContain('<span class="hljs-meta">#partial</span>');
+});

--- a/tests/pkl-language.test.ts
+++ b/tests/pkl-language.test.ts
@@ -1,0 +1,35 @@
+import hljs from "highlight.js/lib/core";
+import pkl from "../src/languages/pkl";
+
+hljs.registerLanguage(pkl.name, pkl.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "pkl" }).value;
+
+test("pkl highlights function declarations", () => {
+  const result = highlight("function add(x) = x");
+
+  expect(result).toContain('<span class="hljs-keyword">function</span>');
+  expect(result).toContain('<span class="hljs-title function_">add</span>');
+});
+
+test("pkl highlights structural keywords", () => {
+  const result = highlight('amends "base.pkl"');
+
+  expect(result).toContain('<span class="hljs-keyword">amends</span>');
+});
+
+test("pkl highlights builtin types", () => {
+  const result = highlight('name: String = "x"');
+
+  expect(result).toContain('<span class="hljs-type">String</span>');
+});
+
+test("pkl highlights strings and numbers", () => {
+  const result = highlight('host = "localhost"\nport = 8080');
+
+  expect(result).toContain(
+    '<span class="hljs-string">&quot;localhost&quot;</span>',
+  );
+  expect(result).toContain('<span class="hljs-number">8080</span>');
+});

--- a/tests/promql-language.test.ts
+++ b/tests/promql-language.test.ts
@@ -1,0 +1,33 @@
+import hljs from "highlight.js/lib/core";
+import promql from "../src/languages/promql";
+
+hljs.registerLanguage(promql.name, promql.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "promql" }).value;
+
+test("promql highlights functions and aggregators", () => {
+  const result = highlight("sum(rate(x[5m]))");
+
+  expect(result).toContain('<span class="hljs-built_in">sum</span>');
+  expect(result).toContain('<span class="hljs-built_in">rate</span>');
+});
+
+test("promql highlights aggregation keywords", () => {
+  const result = highlight("sum by (job) (x)");
+
+  expect(result).toContain('<span class="hljs-keyword">by</span>');
+});
+
+test("promql highlights durations as numbers", () => {
+  const result = highlight("rate(x[5m])");
+
+  expect(result).toContain('<span class="hljs-number">5m</span>');
+});
+
+test("promql highlights label matchers", () => {
+  const result = highlight('http_requests_total{code="200"}');
+
+  expect(result).toContain('<span class="hljs-attr">code</span>');
+  expect(result).toContain('<span class="hljs-string">&quot;200&quot;</span>');
+});

--- a/tests/pug-language.test.ts
+++ b/tests/pug-language.test.ts
@@ -1,0 +1,32 @@
+import hljs from "highlight.js/lib/core";
+import pug from "../src/languages/pug";
+
+hljs.registerLanguage(pug.name, pug.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "pug" }).value;
+
+test("pug highlights doctype as meta", () => {
+  const result = highlight("doctype html");
+
+  expect(result).toContain('<span class="hljs-meta">doctype html</span>');
+});
+
+test("pug highlights tags", () => {
+  const result = highlight("h1 Hello");
+
+  expect(result).toContain('<span class="hljs-selector-tag">h1</span>');
+});
+
+test("pug highlights id and class shorthand", () => {
+  const result = highlight("h1#title.big Hello");
+
+  expect(result).toContain('<span class="hljs-selector-id">#title</span>');
+  expect(result).toContain('<span class="hljs-selector-class">.big</span>');
+});
+
+test("pug highlights mixin calls", () => {
+  const result = highlight("+button('Save')");
+
+  expect(result).toContain('<span class="hljs-keyword">+button</span>');
+});

--- a/tests/razor-language.test.ts
+++ b/tests/razor-language.test.ts
@@ -1,0 +1,32 @@
+import hljs from "highlight.js/lib/core";
+import razor from "../src/languages/razor";
+
+hljs.registerLanguage(razor.name, razor.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "razor" }).value;
+
+test("razor highlights directives as meta", () => {
+  const result = highlight("@page\n@model Foo");
+
+  expect(result).toContain('<span class="hljs-meta">@page</span>');
+  expect(result).toContain('<span class="hljs-meta">@model</span>');
+});
+
+test("razor highlights inline expressions", () => {
+  const result = highlight("<div>@Name</div>");
+
+  expect(result).toContain('<span class="hljs-template-variable">@Name</span>');
+});
+
+test("razor highlights html tags", () => {
+  const result = highlight("<div></div>");
+
+  expect(result).toContain('<span class="hljs-tag">');
+});
+
+test("razor highlights razor comments", () => {
+  const result = highlight("@* a comment *@");
+
+  expect(result).toContain('<span class="hljs-comment">@* a comment *@</span>');
+});

--- a/tests/rescript-language.test.ts
+++ b/tests/rescript-language.test.ts
@@ -1,0 +1,33 @@
+import hljs from "highlight.js/lib/core";
+import rescript from "../src/languages/rescript";
+
+hljs.registerLanguage(rescript.name, rescript.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "rescript" }).value;
+
+test("rescript highlights let bindings as functions", () => {
+  const result = highlight("let greet = (name) => name");
+
+  expect(result).toContain('<span class="hljs-keyword">let</span>');
+  expect(result).toContain('<span class="hljs-title function_">greet</span>');
+});
+
+test("rescript highlights type keyword and constructors", () => {
+  const result = highlight("type color = Red");
+
+  expect(result).toContain('<span class="hljs-keyword">type</span>');
+  expect(result).toContain('<span class="hljs-type">Red</span>');
+});
+
+test("rescript highlights polymorphic variants", () => {
+  const result = highlight("let x = #Blue");
+
+  expect(result).toContain('<span class="hljs-symbol">#Blue</span>');
+});
+
+test("rescript highlights strings", () => {
+  const result = highlight('let s = "hi"');
+
+  expect(result).toContain('<span class="hljs-string">&quot;hi&quot;</span>');
+});

--- a/tests/starlark-language.test.ts
+++ b/tests/starlark-language.test.ts
@@ -1,0 +1,33 @@
+import hljs from "highlight.js/lib/core";
+import starlark from "../src/languages/starlark";
+
+hljs.registerLanguage(starlark.name, starlark.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "starlark" }).value;
+
+test("starlark highlights def declarations", () => {
+  const result = highlight("def my_rule(name):\n    pass");
+
+  expect(result).toContain('<span class="hljs-keyword">def</span>');
+  expect(result).toContain('<span class="hljs-title function_">my_rule</span>');
+});
+
+test("starlark highlights literals", () => {
+  const result = highlight("enabled = True");
+
+  expect(result).toContain('<span class="hljs-literal">True</span>');
+});
+
+test("starlark highlights build built-ins", () => {
+  const result = highlight('srcs = glob(["*.go"])');
+
+  expect(result).toContain('<span class="hljs-built_in">glob</span>');
+});
+
+test("starlark highlights hash comments and strings", () => {
+  const result = highlight('# a comment\nname = "lib"');
+
+  expect(result).toContain('<span class="hljs-comment"># a comment</span>');
+  expect(result).toContain('<span class="hljs-string">&quot;lib&quot;</span>');
+});

--- a/tests/v-language.test.ts
+++ b/tests/v-language.test.ts
@@ -1,0 +1,35 @@
+import hljs from "highlight.js/lib/core";
+import v from "../src/languages/v";
+
+hljs.registerLanguage(v.name, v.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "v" }).value;
+
+test("v highlights fn declarations", () => {
+  const result = highlight("fn main() {}");
+
+  expect(result).toContain('<span class="hljs-keyword">fn</span>');
+  expect(result).toContain('<span class="hljs-title function_">main</span>');
+});
+
+test("v highlights builtin types", () => {
+  const result = highlight("mut x := int(1)");
+
+  expect(result).toContain('<span class="hljs-keyword">mut</span>');
+  expect(result).toContain('<span class="hljs-type">int</span>');
+});
+
+test("v highlights struct types", () => {
+  const result = highlight("struct Point {}");
+
+  expect(result).toContain('<span class="hljs-keyword">struct</span>');
+  expect(result).toContain('<span class="hljs-type">Point</span>');
+});
+
+test("v highlights strings and numbers", () => {
+  const result = highlight('name := "v"\nport := 8080');
+
+  expect(result).toContain('<span class="hljs-string">&quot;v&quot;</span>');
+  expect(result).toContain('<span class="hljs-number">8080</span>');
+});

--- a/tests/vyper-language.test.ts
+++ b/tests/vyper-language.test.ts
@@ -1,0 +1,34 @@
+import hljs from "highlight.js/lib/core";
+import vyper from "../src/languages/vyper";
+
+hljs.registerLanguage(vyper.name, vyper.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "vyper" }).value;
+
+test("vyper highlights def declarations", () => {
+  const result = highlight("def transfer():\n    pass");
+
+  expect(result).toContain('<span class="hljs-keyword">def</span>');
+  expect(result).toContain(
+    '<span class="hljs-title function_">transfer</span>',
+  );
+});
+
+test("vyper highlights value types", () => {
+  const result = highlight("amount: uint256 = 0");
+
+  expect(result).toContain('<span class="hljs-type">uint256</span>');
+});
+
+test("vyper highlights decorators as meta", () => {
+  const result = highlight("@external\ndef f(): pass");
+
+  expect(result).toContain('<span class="hljs-meta">@external</span>');
+});
+
+test("vyper highlights hash comments", () => {
+  const result = highlight("# a comment\nx: uint256 = 0");
+
+  expect(result).toContain('<span class="hljs-comment"># a comment</span>');
+});

--- a/tests/wgsl-language.test.ts
+++ b/tests/wgsl-language.test.ts
@@ -1,0 +1,34 @@
+import hljs from "highlight.js/lib/core";
+import wgsl from "../src/languages/wgsl";
+
+hljs.registerLanguage(wgsl.name, wgsl.register);
+
+const highlight = (code: string) =>
+  hljs.highlight(code, { language: "wgsl" }).value;
+
+test("wgsl highlights fn declarations and keywords", () => {
+  const result = highlight("fn main() { return; }");
+
+  expect(result).toContain('<span class="hljs-keyword">fn</span>');
+  expect(result).toContain('<span class="hljs-title function_">main</span>');
+  expect(result).toContain('<span class="hljs-keyword">return</span>');
+});
+
+test("wgsl highlights builtin types", () => {
+  const result = highlight("var color: vec4<f32>;");
+
+  expect(result).toContain('<span class="hljs-type">vec4</span>');
+  expect(result).toContain('<span class="hljs-type">f32</span>');
+});
+
+test("wgsl highlights attributes as meta", () => {
+  const result = highlight("@vertex fn vs() {}");
+
+  expect(result).toContain('<span class="hljs-meta">@vertex</span>');
+});
+
+test("wgsl highlights numbers", () => {
+  const result = highlight("let x = 1.0;");
+
+  expect(result).toContain('<span class="hljs-number">1.0</span>');
+});

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { cypherPreviewSnippets } from "@www/preview/cypher-preview-snippets";
   import { dotenvPreviewSnippets } from "@www/preview/dotenv-preview-snippets";
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
   import { gleamPreviewSnippets } from "@www/preview/gleam-preview-snippets";
@@ -14,6 +15,7 @@
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
+  import cypher from "svelte-highlight/languages/cypher";
   import dotenv from "svelte-highlight/languages/dotenv";
   import fish from "svelte-highlight/languages/fish";
   import gleam from "svelte-highlight/languages/gleam";
@@ -33,7 +35,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher"} */
   export let language;
 
   const registry = {
@@ -49,6 +51,7 @@
     jsonc: { lang: jsonc, snippets: jsoncPreviewSnippets },
     dotenv: { lang: dotenv, snippets: dotenvPreviewSnippets },
     wgsl: { lang: wgsl, snippets: wgslPreviewSnippets },
+    cypher: { lang: cypher, snippets: cypherPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,5 +1,6 @@
 <script>
   import { bicepPreviewSnippets } from "@www/preview/bicep-preview-snippets";
+  import { cairoPreviewSnippets } from "@www/preview/cairo-preview-snippets";
   import { cypherPreviewSnippets } from "@www/preview/cypher-preview-snippets";
   import { dotenvPreviewSnippets } from "@www/preview/dotenv-preview-snippets";
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
@@ -21,6 +22,7 @@
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
   import bicep from "svelte-highlight/languages/bicep";
+  import cairo from "svelte-highlight/languages/cairo";
   import cypher from "svelte-highlight/languages/cypher";
   import dotenv from "svelte-highlight/languages/dotenv";
   import fish from "svelte-highlight/languages/fish";
@@ -45,7 +47,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo"} */
   export let language;
 
   const registry = {
@@ -67,6 +69,7 @@
     rescript: { lang: rescript, snippets: rescriptPreviewSnippets },
     starlark: { lang: starlark, snippets: starlarkPreviewSnippets },
     move: { lang: move, snippets: movePreviewSnippets },
+    cairo: { lang: cairo, snippets: cairoPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -15,6 +15,7 @@
   import { movePreviewSnippets } from "@www/preview/move-preview-snippets";
   import { nickelPreviewSnippets } from "@www/preview/nickel-preview-snippets";
   import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
+  import { odinPreviewSnippets } from "@www/preview/odin-preview-snippets";
   import { pklPreviewSnippets } from "@www/preview/pkl-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
@@ -47,6 +48,7 @@
   import move from "svelte-highlight/languages/move";
   import nickel from "svelte-highlight/languages/nickel";
   import nushell from "svelte-highlight/languages/nushell";
+  import odin from "svelte-highlight/languages/odin";
   import pkl from "svelte-highlight/languages/pkl";
   import prisma from "svelte-highlight/languages/prisma";
   import promql from "svelte-highlight/languages/promql";
@@ -67,7 +69,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor" | "v"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor" | "v" | "odin"} */
   export let language;
 
   const registry = {
@@ -100,6 +102,7 @@
     pug: { lang: pug, snippets: pugPreviewSnippets },
     razor: { lang: razor, snippets: razorPreviewSnippets },
     v: { lang: v, snippets: vPreviewSnippets },
+    odin: { lang: odin, snippets: odinPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -11,6 +11,7 @@
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
   import { promqlPreviewSnippets } from "@www/preview/promql-preview-snippets";
+  import { rescriptPreviewSnippets } from "@www/preview/rescript-preview-snippets";
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
   import { tomlPreviewSnippets } from "@www/preview/toml-preview-snippets";
   import { wgslPreviewSnippets } from "@www/preview/wgsl-preview-snippets";
@@ -28,6 +29,7 @@
   import nushell from "svelte-highlight/languages/nushell";
   import prisma from "svelte-highlight/languages/prisma";
   import promql from "svelte-highlight/languages/promql";
+  import rescript from "svelte-highlight/languages/rescript";
   import solidity from "svelte-highlight/languages/solidity";
   import toml from "svelte-highlight/languages/toml";
   import wgsl from "svelte-highlight/languages/wgsl";
@@ -39,7 +41,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript"} */
   export let language;
 
   const registry = {
@@ -58,6 +60,7 @@
     cypher: { lang: cypher, snippets: cypherPreviewSnippets },
     promql: { lang: promql, snippets: promqlPreviewSnippets },
     bicep: { lang: bicep, snippets: bicepPreviewSnippets },
+    rescript: { lang: rescript, snippets: rescriptPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -25,6 +25,7 @@
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
   import { starlarkPreviewSnippets } from "@www/preview/starlark-preview-snippets";
   import { tomlPreviewSnippets } from "@www/preview/toml-preview-snippets";
+  import { vPreviewSnippets } from "@www/preview/v-preview-snippets";
   import { vyperPreviewSnippets } from "@www/preview/vyper-preview-snippets";
   import { wgslPreviewSnippets } from "@www/preview/wgsl-preview-snippets";
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
@@ -55,6 +56,7 @@
   import solidity from "svelte-highlight/languages/solidity";
   import starlark from "svelte-highlight/languages/starlark";
   import toml from "svelte-highlight/languages/toml";
+  import v from "svelte-highlight/languages/v";
   import vyper from "svelte-highlight/languages/vyper";
   import wgsl from "svelte-highlight/languages/wgsl";
   import zig from "svelte-highlight/languages/zig";
@@ -65,7 +67,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor" | "v"} */
   export let language;
 
   const registry = {
@@ -97,6 +99,7 @@
     nickel: { lang: nickel, snippets: nickelPreviewSnippets },
     pug: { lang: pug, snippets: pugPreviewSnippets },
     razor: { lang: razor, snippets: razorPreviewSnippets },
+    v: { lang: v, snippets: vPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -5,6 +5,7 @@
   import { clarityPreviewSnippets } from "@www/preview/clarity-preview-snippets";
   import { cuePreviewSnippets } from "@www/preview/cue-preview-snippets";
   import { cypherPreviewSnippets } from "@www/preview/cypher-preview-snippets";
+  import { d2PreviewSnippets } from "@www/preview/d2-preview-snippets";
   import { dhallPreviewSnippets } from "@www/preview/dhall-preview-snippets";
   import { dotenvPreviewSnippets } from "@www/preview/dotenv-preview-snippets";
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
@@ -39,6 +40,7 @@
   import clarity from "svelte-highlight/languages/clarity";
   import cue from "svelte-highlight/languages/cue";
   import cypher from "svelte-highlight/languages/cypher";
+  import d2 from "svelte-highlight/languages/d2";
   import dhall from "svelte-highlight/languages/dhall";
   import dotenv from "svelte-highlight/languages/dotenv";
   import fish from "svelte-highlight/languages/fish";
@@ -71,7 +73,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor" | "v" | "odin" | "caddy"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor" | "v" | "odin" | "caddy" | "d2"} */
   export let language;
 
   const registry = {
@@ -106,6 +108,7 @@
     v: { lang: v, snippets: vPreviewSnippets },
     odin: { lang: odin, snippets: odinPreviewSnippets },
     caddy: { lang: caddy, snippets: caddyPreviewSnippets },
+    d2: { lang: d2, snippets: d2PreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -13,6 +13,7 @@
   import { promqlPreviewSnippets } from "@www/preview/promql-preview-snippets";
   import { rescriptPreviewSnippets } from "@www/preview/rescript-preview-snippets";
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
+  import { starlarkPreviewSnippets } from "@www/preview/starlark-preview-snippets";
   import { tomlPreviewSnippets } from "@www/preview/toml-preview-snippets";
   import { wgslPreviewSnippets } from "@www/preview/wgsl-preview-snippets";
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
@@ -31,6 +32,7 @@
   import promql from "svelte-highlight/languages/promql";
   import rescript from "svelte-highlight/languages/rescript";
   import solidity from "svelte-highlight/languages/solidity";
+  import starlark from "svelte-highlight/languages/starlark";
   import toml from "svelte-highlight/languages/toml";
   import wgsl from "svelte-highlight/languages/wgsl";
   import zig from "svelte-highlight/languages/zig";
@@ -41,7 +43,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark"} */
   export let language;
 
   const registry = {
@@ -61,6 +63,7 @@
     promql: { lang: promql, snippets: promqlPreviewSnippets },
     bicep: { lang: bicep, snippets: bicepPreviewSnippets },
     rescript: { lang: rescript, snippets: rescriptPreviewSnippets },
+    starlark: { lang: starlark, snippets: starlarkPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -19,6 +19,7 @@
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
   import { promqlPreviewSnippets } from "@www/preview/promql-preview-snippets";
+  import { pugPreviewSnippets } from "@www/preview/pug-preview-snippets";
   import { rescriptPreviewSnippets } from "@www/preview/rescript-preview-snippets";
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
   import { starlarkPreviewSnippets } from "@www/preview/starlark-preview-snippets";
@@ -47,6 +48,7 @@
   import pkl from "svelte-highlight/languages/pkl";
   import prisma from "svelte-highlight/languages/prisma";
   import promql from "svelte-highlight/languages/promql";
+  import pug from "svelte-highlight/languages/pug";
   import rescript from "svelte-highlight/languages/rescript";
   import solidity from "svelte-highlight/languages/solidity";
   import starlark from "svelte-highlight/languages/starlark";
@@ -61,7 +63,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug"} */
   export let language;
 
   const registry = {
@@ -91,6 +93,7 @@
     dhall: { lang: dhall, snippets: dhallPreviewSnippets },
     pkl: { lang: pkl, snippets: pklPreviewSnippets },
     nickel: { lang: nickel, snippets: nickelPreviewSnippets },
+    pug: { lang: pug, snippets: pugPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { bibtexPreviewSnippets } from "@www/preview/bibtex-preview-snippets";
   import { bicepPreviewSnippets } from "@www/preview/bicep-preview-snippets";
   import { caddyPreviewSnippets } from "@www/preview/caddy-preview-snippets";
   import { cairoPreviewSnippets } from "@www/preview/cairo-preview-snippets";
@@ -34,6 +35,7 @@
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
+  import bibtex from "svelte-highlight/languages/bibtex";
   import bicep from "svelte-highlight/languages/bicep";
   import caddy from "svelte-highlight/languages/caddy";
   import cairo from "svelte-highlight/languages/cairo";
@@ -73,7 +75,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor" | "v" | "odin" | "caddy" | "d2"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor" | "v" | "odin" | "caddy" | "d2" | "bibtex"} */
   export let language;
 
   const registry = {
@@ -109,6 +111,7 @@
     odin: { lang: odin, snippets: odinPreviewSnippets },
     caddy: { lang: caddy, snippets: caddyPreviewSnippets },
     d2: { lang: d2, snippets: d2PreviewSnippets },
+    bibtex: { lang: bibtex, snippets: bibtexPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -10,6 +10,7 @@
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
   import { json5PreviewSnippets } from "@www/preview/json5-preview-snippets";
   import { jsoncPreviewSnippets } from "@www/preview/jsonc-preview-snippets";
+  import { jsonnetPreviewSnippets } from "@www/preview/jsonnet-preview-snippets";
   import { movePreviewSnippets } from "@www/preview/move-preview-snippets";
   import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
@@ -35,6 +36,7 @@
   import hcl from "svelte-highlight/languages/hcl";
   import json5 from "svelte-highlight/languages/json5";
   import jsonc from "svelte-highlight/languages/jsonc";
+  import jsonnet from "svelte-highlight/languages/jsonnet";
   import move from "svelte-highlight/languages/move";
   import nushell from "svelte-highlight/languages/nushell";
   import prisma from "svelte-highlight/languages/prisma";
@@ -53,7 +55,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet"} */
   export let language;
 
   const registry = {
@@ -79,6 +81,7 @@
     vyper: { lang: vyper, snippets: vyperPreviewSnippets },
     clarity: { lang: clarity, snippets: clarityPreviewSnippets },
     cue: { lang: cue, snippets: cuePreviewSnippets },
+    jsonnet: { lang: jsonnet, snippets: jsonnetPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,6 +1,7 @@
 <script>
   import { bicepPreviewSnippets } from "@www/preview/bicep-preview-snippets";
   import { cairoPreviewSnippets } from "@www/preview/cairo-preview-snippets";
+  import { clarityPreviewSnippets } from "@www/preview/clarity-preview-snippets";
   import { cypherPreviewSnippets } from "@www/preview/cypher-preview-snippets";
   import { dotenvPreviewSnippets } from "@www/preview/dotenv-preview-snippets";
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
@@ -24,6 +25,7 @@
   import { Highlight } from "svelte-highlight";
   import bicep from "svelte-highlight/languages/bicep";
   import cairo from "svelte-highlight/languages/cairo";
+  import clarity from "svelte-highlight/languages/clarity";
   import cypher from "svelte-highlight/languages/cypher";
   import dotenv from "svelte-highlight/languages/dotenv";
   import fish from "svelte-highlight/languages/fish";
@@ -49,7 +51,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity"} */
   export let language;
 
   const registry = {
@@ -73,6 +75,7 @@
     move: { lang: move, snippets: movePreviewSnippets },
     cairo: { lang: cairo, snippets: cairoPreviewSnippets },
     vyper: { lang: vyper, snippets: vyperPreviewSnippets },
+    clarity: { lang: clarity, snippets: clarityPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -4,6 +4,7 @@
   import { clarityPreviewSnippets } from "@www/preview/clarity-preview-snippets";
   import { cuePreviewSnippets } from "@www/preview/cue-preview-snippets";
   import { cypherPreviewSnippets } from "@www/preview/cypher-preview-snippets";
+  import { dhallPreviewSnippets } from "@www/preview/dhall-preview-snippets";
   import { dotenvPreviewSnippets } from "@www/preview/dotenv-preview-snippets";
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
   import { gleamPreviewSnippets } from "@www/preview/gleam-preview-snippets";
@@ -30,6 +31,7 @@
   import clarity from "svelte-highlight/languages/clarity";
   import cue from "svelte-highlight/languages/cue";
   import cypher from "svelte-highlight/languages/cypher";
+  import dhall from "svelte-highlight/languages/dhall";
   import dotenv from "svelte-highlight/languages/dotenv";
   import fish from "svelte-highlight/languages/fish";
   import gleam from "svelte-highlight/languages/gleam";
@@ -55,7 +57,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall"} */
   export let language;
 
   const registry = {
@@ -82,6 +84,7 @@
     clarity: { lang: clarity, snippets: clarityPreviewSnippets },
     cue: { lang: cue, snippets: cuePreviewSnippets },
     jsonnet: { lang: jsonnet, snippets: jsonnetPreviewSnippets },
+    dhall: { lang: dhall, snippets: dhallPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -9,6 +9,7 @@
   import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
+  import { promqlPreviewSnippets } from "@www/preview/promql-preview-snippets";
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
   import { tomlPreviewSnippets } from "@www/preview/toml-preview-snippets";
   import { wgslPreviewSnippets } from "@www/preview/wgsl-preview-snippets";
@@ -24,6 +25,7 @@
   import jsonc from "svelte-highlight/languages/jsonc";
   import nushell from "svelte-highlight/languages/nushell";
   import prisma from "svelte-highlight/languages/prisma";
+  import promql from "svelte-highlight/languages/promql";
   import solidity from "svelte-highlight/languages/solidity";
   import toml from "svelte-highlight/languages/toml";
   import wgsl from "svelte-highlight/languages/wgsl";
@@ -35,7 +37,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql"} */
   export let language;
 
   const registry = {
@@ -52,6 +54,7 @@
     dotenv: { lang: dotenv, snippets: dotenvPreviewSnippets },
     wgsl: { lang: wgsl, snippets: wgslPreviewSnippets },
     cypher: { lang: cypher, snippets: cypherPreviewSnippets },
+    promql: { lang: promql, snippets: promqlPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -10,6 +10,7 @@
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
   import { tomlPreviewSnippets } from "@www/preview/toml-preview-snippets";
+  import { wgslPreviewSnippets } from "@www/preview/wgsl-preview-snippets";
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
@@ -23,6 +24,7 @@
   import prisma from "svelte-highlight/languages/prisma";
   import solidity from "svelte-highlight/languages/solidity";
   import toml from "svelte-highlight/languages/toml";
+  import wgsl from "svelte-highlight/languages/wgsl";
   import zig from "svelte-highlight/languages/zig";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
   import dracula from "svelte-highlight/styles/dracula";
@@ -31,7 +33,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl"} */
   export let language;
 
   const registry = {
@@ -46,6 +48,7 @@
     json5: { lang: json5, snippets: json5PreviewSnippets },
     jsonc: { lang: jsonc, snippets: jsoncPreviewSnippets },
     dotenv: { lang: dotenv, snippets: dotenvPreviewSnippets },
+    wgsl: { lang: wgsl, snippets: wgslPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -14,6 +14,7 @@
   import { jsonnetPreviewSnippets } from "@www/preview/jsonnet-preview-snippets";
   import { movePreviewSnippets } from "@www/preview/move-preview-snippets";
   import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
+  import { pklPreviewSnippets } from "@www/preview/pkl-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
   import { promqlPreviewSnippets } from "@www/preview/promql-preview-snippets";
@@ -41,6 +42,7 @@
   import jsonnet from "svelte-highlight/languages/jsonnet";
   import move from "svelte-highlight/languages/move";
   import nushell from "svelte-highlight/languages/nushell";
+  import pkl from "svelte-highlight/languages/pkl";
   import prisma from "svelte-highlight/languages/prisma";
   import promql from "svelte-highlight/languages/promql";
   import rescript from "svelte-highlight/languages/rescript";
@@ -57,7 +59,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl"} */
   export let language;
 
   const registry = {
@@ -85,6 +87,7 @@
     cue: { lang: cue, snippets: cuePreviewSnippets },
     jsonnet: { lang: jsonnet, snippets: jsonnetPreviewSnippets },
     dhall: { lang: dhall, snippets: dhallPreviewSnippets },
+    pkl: { lang: pkl, snippets: pklPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -17,6 +17,7 @@
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
   import { starlarkPreviewSnippets } from "@www/preview/starlark-preview-snippets";
   import { tomlPreviewSnippets } from "@www/preview/toml-preview-snippets";
+  import { vyperPreviewSnippets } from "@www/preview/vyper-preview-snippets";
   import { wgslPreviewSnippets } from "@www/preview/wgsl-preview-snippets";
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
@@ -38,6 +39,7 @@
   import solidity from "svelte-highlight/languages/solidity";
   import starlark from "svelte-highlight/languages/starlark";
   import toml from "svelte-highlight/languages/toml";
+  import vyper from "svelte-highlight/languages/vyper";
   import wgsl from "svelte-highlight/languages/wgsl";
   import zig from "svelte-highlight/languages/zig";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
@@ -47,7 +49,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper"} */
   export let language;
 
   const registry = {
@@ -70,6 +72,7 @@
     starlark: { lang: starlark, snippets: starlarkPreviewSnippets },
     move: { lang: move, snippets: movePreviewSnippets },
     cairo: { lang: cairo, snippets: cairoPreviewSnippets },
+    vyper: { lang: vyper, snippets: vyperPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -7,6 +7,7 @@
   import { hclPreviewSnippets } from "@www/preview/hcl-preview-snippets";
   import { json5PreviewSnippets } from "@www/preview/json5-preview-snippets";
   import { jsoncPreviewSnippets } from "@www/preview/jsonc-preview-snippets";
+  import { movePreviewSnippets } from "@www/preview/move-preview-snippets";
   import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
@@ -27,6 +28,7 @@
   import hcl from "svelte-highlight/languages/hcl";
   import json5 from "svelte-highlight/languages/json5";
   import jsonc from "svelte-highlight/languages/jsonc";
+  import move from "svelte-highlight/languages/move";
   import nushell from "svelte-highlight/languages/nushell";
   import prisma from "svelte-highlight/languages/prisma";
   import promql from "svelte-highlight/languages/promql";
@@ -43,7 +45,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move"} */
   export let language;
 
   const registry = {
@@ -64,6 +66,7 @@
     bicep: { lang: bicep, snippets: bicepPreviewSnippets },
     rescript: { lang: rescript, snippets: rescriptPreviewSnippets },
     starlark: { lang: starlark, snippets: starlarkPreviewSnippets },
+    move: { lang: move, snippets: movePreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,4 +1,5 @@
 <script>
+  import { bicepPreviewSnippets } from "@www/preview/bicep-preview-snippets";
   import { cypherPreviewSnippets } from "@www/preview/cypher-preview-snippets";
   import { dotenvPreviewSnippets } from "@www/preview/dotenv-preview-snippets";
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
@@ -16,6 +17,7 @@
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
+  import bicep from "svelte-highlight/languages/bicep";
   import cypher from "svelte-highlight/languages/cypher";
   import dotenv from "svelte-highlight/languages/dotenv";
   import fish from "svelte-highlight/languages/fish";
@@ -37,7 +39,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep"} */
   export let language;
 
   const registry = {
@@ -55,6 +57,7 @@
     wgsl: { lang: wgsl, snippets: wgslPreviewSnippets },
     cypher: { lang: cypher, snippets: cypherPreviewSnippets },
     promql: { lang: promql, snippets: promqlPreviewSnippets },
+    bicep: { lang: bicep, snippets: bicepPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -13,6 +13,7 @@
   import { jsoncPreviewSnippets } from "@www/preview/jsonc-preview-snippets";
   import { jsonnetPreviewSnippets } from "@www/preview/jsonnet-preview-snippets";
   import { movePreviewSnippets } from "@www/preview/move-preview-snippets";
+  import { nickelPreviewSnippets } from "@www/preview/nickel-preview-snippets";
   import { nushellPreviewSnippets } from "@www/preview/nushell-preview-snippets";
   import { pklPreviewSnippets } from "@www/preview/pkl-preview-snippets";
   import { previewThemes } from "@www/preview/preview-themes";
@@ -41,6 +42,7 @@
   import jsonc from "svelte-highlight/languages/jsonc";
   import jsonnet from "svelte-highlight/languages/jsonnet";
   import move from "svelte-highlight/languages/move";
+  import nickel from "svelte-highlight/languages/nickel";
   import nushell from "svelte-highlight/languages/nushell";
   import pkl from "svelte-highlight/languages/pkl";
   import prisma from "svelte-highlight/languages/prisma";
@@ -59,7 +61,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel"} */
   export let language;
 
   const registry = {
@@ -88,6 +90,7 @@
     jsonnet: { lang: jsonnet, snippets: jsonnetPreviewSnippets },
     dhall: { lang: dhall, snippets: dhallPreviewSnippets },
     pkl: { lang: pkl, snippets: pklPreviewSnippets },
+    nickel: { lang: nickel, snippets: nickelPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -20,6 +20,7 @@
   import { prismaPreviewSnippets } from "@www/preview/prisma-preview-snippets";
   import { promqlPreviewSnippets } from "@www/preview/promql-preview-snippets";
   import { pugPreviewSnippets } from "@www/preview/pug-preview-snippets";
+  import { razorPreviewSnippets } from "@www/preview/razor-preview-snippets";
   import { rescriptPreviewSnippets } from "@www/preview/rescript-preview-snippets";
   import { solidityPreviewSnippets } from "@www/preview/solidity-preview-snippets";
   import { starlarkPreviewSnippets } from "@www/preview/starlark-preview-snippets";
@@ -49,6 +50,7 @@
   import prisma from "svelte-highlight/languages/prisma";
   import promql from "svelte-highlight/languages/promql";
   import pug from "svelte-highlight/languages/pug";
+  import razor from "svelte-highlight/languages/razor";
   import rescript from "svelte-highlight/languages/rescript";
   import solidity from "svelte-highlight/languages/solidity";
   import starlark from "svelte-highlight/languages/starlark";
@@ -63,7 +65,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor"} */
   export let language;
 
   const registry = {
@@ -94,6 +96,7 @@
     pkl: { lang: pkl, snippets: pklPreviewSnippets },
     nickel: { lang: nickel, snippets: nickelPreviewSnippets },
     pug: { lang: pug, snippets: pugPreviewSnippets },
+    razor: { lang: razor, snippets: razorPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -2,6 +2,7 @@
   import { bicepPreviewSnippets } from "@www/preview/bicep-preview-snippets";
   import { cairoPreviewSnippets } from "@www/preview/cairo-preview-snippets";
   import { clarityPreviewSnippets } from "@www/preview/clarity-preview-snippets";
+  import { cuePreviewSnippets } from "@www/preview/cue-preview-snippets";
   import { cypherPreviewSnippets } from "@www/preview/cypher-preview-snippets";
   import { dotenvPreviewSnippets } from "@www/preview/dotenv-preview-snippets";
   import { fishPreviewSnippets } from "@www/preview/fish-preview-snippets";
@@ -26,6 +27,7 @@
   import bicep from "svelte-highlight/languages/bicep";
   import cairo from "svelte-highlight/languages/cairo";
   import clarity from "svelte-highlight/languages/clarity";
+  import cue from "svelte-highlight/languages/cue";
   import cypher from "svelte-highlight/languages/cypher";
   import dotenv from "svelte-highlight/languages/dotenv";
   import fish from "svelte-highlight/languages/fish";
@@ -51,7 +53,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue"} */
   export let language;
 
   const registry = {
@@ -76,6 +78,7 @@
     cairo: { lang: cairo, snippets: cairoPreviewSnippets },
     vyper: { lang: vyper, snippets: vyperPreviewSnippets },
     clarity: { lang: clarity, snippets: clarityPreviewSnippets },
+    cue: { lang: cue, snippets: cuePreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -1,5 +1,6 @@
 <script>
   import { bicepPreviewSnippets } from "@www/preview/bicep-preview-snippets";
+  import { caddyPreviewSnippets } from "@www/preview/caddy-preview-snippets";
   import { cairoPreviewSnippets } from "@www/preview/cairo-preview-snippets";
   import { clarityPreviewSnippets } from "@www/preview/clarity-preview-snippets";
   import { cuePreviewSnippets } from "@www/preview/cue-preview-snippets";
@@ -33,6 +34,7 @@
   import { Column, Row } from "carbon-components-svelte";
   import { Highlight } from "svelte-highlight";
   import bicep from "svelte-highlight/languages/bicep";
+  import caddy from "svelte-highlight/languages/caddy";
   import cairo from "svelte-highlight/languages/cairo";
   import clarity from "svelte-highlight/languages/clarity";
   import cue from "svelte-highlight/languages/cue";
@@ -69,7 +71,7 @@
   import horizonDark from "svelte-highlight/styles/horizon-dark";
   import nord from "svelte-highlight/styles/nord";
 
-  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor" | "v" | "odin"} */
+  /** @type {"solidity" | "hcl" | "zig" | "prisma" | "toml" | "fish" | "nushell" | "gleam" | "json5" | "jsonc" | "dotenv" | "wgsl" | "cypher" | "promql" | "bicep" | "rescript" | "starlark" | "move" | "cairo" | "vyper" | "clarity" | "cue" | "jsonnet" | "dhall" | "pkl" | "nickel" | "pug" | "razor" | "v" | "odin" | "caddy"} */
   export let language;
 
   const registry = {
@@ -103,6 +105,7 @@
     razor: { lang: razor, snippets: razorPreviewSnippets },
     v: { lang: v, snippets: vPreviewSnippets },
     odin: { lang: odin, snippets: odinPreviewSnippets },
+    caddy: { lang: caddy, snippets: caddyPreviewSnippets },
   };
 
   $: ({ lang, snippets } = registry[language]);

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -55,6 +55,7 @@
     "/preview-cairo": "Cairo language preview",
     "/preview-vyper": "Vyper language preview",
     "/preview-clarity": "Clarity language preview",
+    "/preview-cue": "CUE language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -47,6 +47,7 @@
     "/preview-dotenv": "dotenv language preview",
     "/preview-wgsl": "WGSL language preview",
     "/preview-cypher": "Cypher language preview",
+    "/preview-promql": "PromQL language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -60,6 +60,7 @@
     "/preview-dhall": "Dhall language preview",
     "/preview-pkl": "Pkl language preview",
     "/preview-nickel": "Nickel language preview",
+    "/preview-pug": "Pug language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -58,6 +58,7 @@
     "/preview-cue": "CUE language preview",
     "/preview-jsonnet": "Jsonnet language preview",
     "/preview-dhall": "Dhall language preview",
+    "/preview-pkl": "Pkl language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -62,6 +62,7 @@
     "/preview-nickel": "Nickel language preview",
     "/preview-pug": "Pug language preview",
     "/preview-razor": "Razor language preview",
+    "/preview-v": "V language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -53,6 +53,7 @@
     "/preview-starlark": "Starlark language preview",
     "/preview-move": "Move language preview",
     "/preview-cairo": "Cairo language preview",
+    "/preview-vyper": "Vyper language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -61,6 +61,7 @@
     "/preview-pkl": "Pkl language preview",
     "/preview-nickel": "Nickel language preview",
     "/preview-pug": "Pug language preview",
+    "/preview-razor": "Razor language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -45,6 +45,7 @@
     "/preview-json5": "JSON5 language preview",
     "/preview-jsonc": "JSONC language preview",
     "/preview-dotenv": "dotenv language preview",
+    "/preview-wgsl": "WGSL language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -49,6 +49,7 @@
     "/preview-cypher": "Cypher language preview",
     "/preview-promql": "PromQL language preview",
     "/preview-bicep": "Bicep language preview",
+    "/preview-rescript": "ReScript language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -59,6 +59,7 @@
     "/preview-jsonnet": "Jsonnet language preview",
     "/preview-dhall": "Dhall language preview",
     "/preview-pkl": "Pkl language preview",
+    "/preview-nickel": "Nickel language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -46,6 +46,7 @@
     "/preview-jsonc": "JSONC language preview",
     "/preview-dotenv": "dotenv language preview",
     "/preview-wgsl": "WGSL language preview",
+    "/preview-cypher": "Cypher language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -56,6 +56,7 @@
     "/preview-vyper": "Vyper language preview",
     "/preview-clarity": "Clarity language preview",
     "/preview-cue": "CUE language preview",
+    "/preview-jsonnet": "Jsonnet language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -66,6 +66,7 @@
     "/preview-odin": "Odin language preview",
     "/preview-caddy": "Caddyfile language preview",
     "/preview-d2": "D2 language preview",
+    "/preview-bibtex": "BibTeX language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -57,6 +57,7 @@
     "/preview-clarity": "Clarity language preview",
     "/preview-cue": "CUE language preview",
     "/preview-jsonnet": "Jsonnet language preview",
+    "/preview-dhall": "Dhall language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -51,6 +51,7 @@
     "/preview-bicep": "Bicep language preview",
     "/preview-rescript": "ReScript language preview",
     "/preview-starlark": "Starlark language preview",
+    "/preview-move": "Move language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -64,6 +64,7 @@
     "/preview-razor": "Razor language preview",
     "/preview-v": "V language preview",
     "/preview-odin": "Odin language preview",
+    "/preview-caddy": "Caddyfile language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -48,6 +48,7 @@
     "/preview-wgsl": "WGSL language preview",
     "/preview-cypher": "Cypher language preview",
     "/preview-promql": "PromQL language preview",
+    "/preview-bicep": "Bicep language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -63,6 +63,7 @@
     "/preview-pug": "Pug language preview",
     "/preview-razor": "Razor language preview",
     "/preview-v": "V language preview",
+    "/preview-odin": "Odin language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -65,6 +65,7 @@
     "/preview-v": "V language preview",
     "/preview-odin": "Odin language preview",
     "/preview-caddy": "Caddyfile language preview",
+    "/preview-d2": "D2 language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -54,6 +54,7 @@
     "/preview-move": "Move language preview",
     "/preview-cairo": "Cairo language preview",
     "/preview-vyper": "Vyper language preview",
+    "/preview-clarity": "Clarity language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -50,6 +50,7 @@
     "/preview-promql": "PromQL language preview",
     "/preview-bicep": "Bicep language preview",
     "/preview-rescript": "ReScript language preview",
+    "/preview-starlark": "Starlark language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -52,6 +52,7 @@
     "/preview-rescript": "ReScript language preview",
     "/preview-starlark": "Starlark language preview",
     "/preview-move": "Move language preview",
+    "/preview-cairo": "Cairo language preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/pages/preview-bibtex.astro
+++ b/www/pages/preview-bibtex.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="BibTeX language preview">
+  <LanguagePreview language="bibtex" client:idle />
+</Layout>

--- a/www/pages/preview-bicep.astro
+++ b/www/pages/preview-bicep.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Bicep language preview">
+  <LanguagePreview language="bicep" client:idle />
+</Layout>

--- a/www/pages/preview-caddy.astro
+++ b/www/pages/preview-caddy.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Caddyfile language preview">
+  <LanguagePreview language="caddy" client:idle />
+</Layout>

--- a/www/pages/preview-cairo.astro
+++ b/www/pages/preview-cairo.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Cairo language preview">
+  <LanguagePreview language="cairo" client:idle />
+</Layout>

--- a/www/pages/preview-clarity.astro
+++ b/www/pages/preview-clarity.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Clarity language preview">
+  <LanguagePreview language="clarity" client:idle />
+</Layout>

--- a/www/pages/preview-cue.astro
+++ b/www/pages/preview-cue.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="CUE language preview">
+  <LanguagePreview language="cue" client:idle />
+</Layout>

--- a/www/pages/preview-cypher.astro
+++ b/www/pages/preview-cypher.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Cypher language preview">
+  <LanguagePreview language="cypher" client:idle />
+</Layout>

--- a/www/pages/preview-d2.astro
+++ b/www/pages/preview-d2.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="D2 language preview">
+  <LanguagePreview language="d2" client:idle />
+</Layout>

--- a/www/pages/preview-dhall.astro
+++ b/www/pages/preview-dhall.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Dhall language preview">
+  <LanguagePreview language="dhall" client:idle />
+</Layout>

--- a/www/pages/preview-jsonnet.astro
+++ b/www/pages/preview-jsonnet.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Jsonnet language preview">
+  <LanguagePreview language="jsonnet" client:idle />
+</Layout>

--- a/www/pages/preview-move.astro
+++ b/www/pages/preview-move.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Move language preview">
+  <LanguagePreview language="move" client:idle />
+</Layout>

--- a/www/pages/preview-nickel.astro
+++ b/www/pages/preview-nickel.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Nickel language preview">
+  <LanguagePreview language="nickel" client:idle />
+</Layout>

--- a/www/pages/preview-odin.astro
+++ b/www/pages/preview-odin.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Odin language preview">
+  <LanguagePreview language="odin" client:idle />
+</Layout>

--- a/www/pages/preview-pkl.astro
+++ b/www/pages/preview-pkl.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Pkl language preview">
+  <LanguagePreview language="pkl" client:idle />
+</Layout>

--- a/www/pages/preview-promql.astro
+++ b/www/pages/preview-promql.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="PromQL language preview">
+  <LanguagePreview language="promql" client:idle />
+</Layout>

--- a/www/pages/preview-pug.astro
+++ b/www/pages/preview-pug.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Pug language preview">
+  <LanguagePreview language="pug" client:idle />
+</Layout>

--- a/www/pages/preview-razor.astro
+++ b/www/pages/preview-razor.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Razor language preview">
+  <LanguagePreview language="razor" client:idle />
+</Layout>

--- a/www/pages/preview-rescript.astro
+++ b/www/pages/preview-rescript.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="ReScript language preview">
+  <LanguagePreview language="rescript" client:idle />
+</Layout>

--- a/www/pages/preview-starlark.astro
+++ b/www/pages/preview-starlark.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Starlark language preview">
+  <LanguagePreview language="starlark" client:idle />
+</Layout>

--- a/www/pages/preview-v.astro
+++ b/www/pages/preview-v.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="V language preview">
+  <LanguagePreview language="v" client:idle />
+</Layout>

--- a/www/pages/preview-vyper.astro
+++ b/www/pages/preview-vyper.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Vyper language preview">
+  <LanguagePreview language="vyper" client:idle />
+</Layout>

--- a/www/pages/preview-wgsl.astro
+++ b/www/pages/preview-wgsl.astro
@@ -1,0 +1,8 @@
+---
+import LanguagePreview from "@components/LanguagePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="WGSL language preview">
+  <LanguagePreview language="wgsl" client:idle />
+</Layout>

--- a/www/preview/bibtex-preview-snippets.ts
+++ b/www/preview/bibtex-preview-snippets.ts
@@ -1,0 +1,36 @@
+export type BibtexPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const bibtexPreviewSnippets: BibtexPreviewSnippet[] = [
+  {
+    title: "Article entry",
+    description: "entry types, fields, and braced values",
+    code: `@article{shannon1948,
+  author  = {Claude E. Shannon},
+  title   = {A Mathematical Theory of Communication},
+  journal = {Bell System Technical Journal},
+  year    = 1948,
+  volume  = 27,
+  pages   = {379--423},
+}`,
+  },
+  {
+    title: "Book and proceedings",
+    description: "multiple entries and quoted values",
+    code: `@book{knuth1997,
+  author    = {Donald E. Knuth},
+  title     = "The Art of Computer Programming",
+  publisher = {Addison-Wesley},
+  year      = 1997,
+}
+
+@inproceedings{vaswani2017,
+  author = {Vaswani, Ashish and others},
+  title  = {Attention Is All You Need},
+  year   = 2017,
+}`,
+  },
+];

--- a/www/preview/bicep-preview-snippets.ts
+++ b/www/preview/bicep-preview-snippets.ts
@@ -1,0 +1,40 @@
+export type BicepPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const bicepPreviewSnippets: BicepPreviewSnippet[] = [
+  {
+    title: "Storage account",
+    description: "params, decorators, and resource declarations",
+    code: `@description('The Azure region for resources')
+param location string = resourceGroup().location
+
+@allowed(['Standard_LRS', 'Standard_GRS'])
+param skuName string = 'Standard_LRS'
+
+resource storage 'Microsoft.Storage/storageAccounts@2023-01-01' = {
+  name: 'st\${uniqueString(resourceGroup().id)}'
+  location: location
+  sku: {
+    name: skuName
+  }
+  kind: 'StorageV2'
+}
+
+output storageId string = storage.id`,
+  },
+  {
+    title: "Modules and loops",
+    description: "module references and for expressions",
+    code: `param names array = ['app', 'api', 'web']
+
+module sites 'site.bicep' = [for name in names: {
+  name: 'deploy-\${name}'
+  params: {
+    siteName: name
+  }
+}]`,
+  },
+];

--- a/www/preview/caddy-preview-snippets.ts
+++ b/www/preview/caddy-preview-snippets.ts
@@ -1,0 +1,38 @@
+export type CaddyPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const caddyPreviewSnippets: CaddyPreviewSnippet[] = [
+  {
+    title: "Reverse proxy site",
+    description: "site addresses, directives, and placeholders",
+    code: `example.com {
+	encode gzip
+	reverse_proxy localhost:8080 {
+		header_up X-Real-IP {remote_host}
+	}
+	log {
+		output file /var/log/caddy/access.log
+	}
+}`,
+  },
+  {
+    title: "Matchers and static files",
+    description: "named matchers, snippets, and file serving",
+    code: `# shared TLS config
+(tls_config) {
+	tls admin@example.com
+}
+
+static.example.com {
+	import tls_config
+	root * /srv/www
+	@assets path /static/*
+	handle @assets {
+		file_server
+	}
+}`,
+  },
+];

--- a/www/preview/cairo-preview-snippets.ts
+++ b/www/preview/cairo-preview-snippets.ts
@@ -1,0 +1,36 @@
+export type CairoPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const cairoPreviewSnippets: CairoPreviewSnippet[] = [
+  {
+    title: "Starknet contract",
+    description: "attributes, traits, and storage",
+    code: `#[starknet::contract]
+mod Counter {
+    #[storage]
+    struct Storage {
+        count: u128,
+    }
+
+    #[external(v0)]
+    fn increment(ref self: ContractState, amount: u128) {
+        let current = self.count.read();
+        self.count.write(current + amount);
+    }
+}`,
+  },
+  {
+    title: "Generic function",
+    description: "felt252, integer types, and pattern matching",
+    code: `fn fib(n: felt252) -> felt252 {
+    match n {
+        0 => 0,
+        1 => 1,
+        _ => fib(n - 1) + fib(n - 2),
+    }
+}`,
+  },
+];

--- a/www/preview/clarity-preview-snippets.ts
+++ b/www/preview/clarity-preview-snippets.ts
@@ -1,0 +1,34 @@
+export type ClarityPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const clarityPreviewSnippets: ClarityPreviewSnippet[] = [
+  {
+    title: "Counter contract",
+    description: "define forms, data vars, and responses",
+    code: `;; A simple counter
+(define-data-var counter uint u0)
+
+(define-read-only (get-counter)
+  (var-get counter))
+
+(define-public (increment (step uint))
+  (begin
+    (asserts! (> step u0) (err u100))
+    (var-set counter (+ (var-get counter) step))
+    (ok (var-get counter))))`,
+  },
+  {
+    title: "Token transfer",
+    description: "maps, principals, and assertions",
+    code: `(define-map balances principal uint)
+
+(define-public (transfer (amount uint) (recipient principal))
+  (let ((sender-balance (default-to u0 (map-get? balances tx-sender))))
+    (asserts! (>= sender-balance amount) (err u1))
+    (map-set balances tx-sender (- sender-balance amount))
+    (ok true)))`,
+  },
+];

--- a/www/preview/cue-preview-snippets.ts
+++ b/www/preview/cue-preview-snippets.ts
@@ -1,0 +1,39 @@
+export type CuePreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const cuePreviewSnippets: CuePreviewSnippet[] = [
+  {
+    title: "Schema and constraints",
+    description: "definitions, types, and field constraints",
+    code: `package config
+
+#Server: {
+	host:    string
+	port:    int & >0 & <65536
+	tls:     bool | *false
+	timeout: string | *"30s"
+}
+
+production: #Server & {
+	host: "example.com"
+	port: 443
+	tls:  true
+}`,
+  },
+  {
+    title: "Comprehensions",
+    description: "for expressions and string interpolation",
+    code: `names: ["app", "api", "web"]
+
+services: {
+	for name in names {
+		"\\(name)": {
+			image: "registry/\\(name):latest"
+		}
+	}
+}`,
+  },
+];

--- a/www/preview/cypher-preview-snippets.ts
+++ b/www/preview/cypher-preview-snippets.ts
@@ -1,0 +1,25 @@
+export type CypherPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const cypherPreviewSnippets: CypherPreviewSnippet[] = [
+  {
+    title: "Pattern match",
+    description: "nodes, labels, and relationships",
+    code: `MATCH (person:Person)-[:ACTED_IN]->(movie:Movie)
+WHERE movie.released > 2000
+RETURN person.name AS actor, movie.title AS title
+ORDER BY movie.released DESC
+LIMIT 10`,
+  },
+  {
+    title: "Create and merge",
+    description: "parameters and property maps",
+    code: `MERGE (u:User {id: $userId})
+ON CREATE SET u.created = timestamp()
+CREATE (u)-[:POSTED]->(p:Post {title: "Hello", likes: 0})
+RETURN u, p`,
+  },
+];

--- a/www/preview/d2-preview-snippets.ts
+++ b/www/preview/d2-preview-snippets.ts
@@ -1,0 +1,32 @@
+export type D2PreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const d2PreviewSnippets: D2PreviewSnippet[] = [
+  {
+    title: "System diagram",
+    description: "shapes, connections, and labels",
+    code: `# request flow
+client -> server: HTTP request
+server -> db: query
+
+server.shape: rectangle
+db.shape: cylinder
+client.shape: person`,
+  },
+  {
+    title: "Containers and styles",
+    description: "nested objects and style attributes",
+    code: `network: {
+  web -> api: REST
+  api -> cache: read
+
+  cache.shape: cylinder
+  api.style.fill: "#f5f5f5"
+}
+
+network.web -> network.api: internal`,
+  },
+];

--- a/www/preview/dhall-preview-snippets.ts
+++ b/www/preview/dhall-preview-snippets.ts
@@ -1,0 +1,31 @@
+export type DhallPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const dhallPreviewSnippets: DhallPreviewSnippet[] = [
+  {
+    title: "Typed config",
+    description: "let bindings, records, and builtin types",
+    code: `let Port : Type = Natural
+
+let Server =
+  { host : Text, port : Port, tls : Bool }
+
+let defaults : Server =
+  { host = "localhost", port = 8080, tls = False }
+
+in  defaults // { tls = True }`,
+  },
+  {
+    title: "Functions and lists",
+    description: "lambdas, List/map, and string interpolation",
+    code: `let makeUrl =
+  \\(host : Text) -> \\(port : Natural) -> "https://\${host}:\${Natural/show port}"
+
+let hosts = [ "a.example.com", "b.example.com" ]
+
+in  List/map Text Text (\\(h : Text) -> makeUrl h 443) hosts`,
+  },
+];

--- a/www/preview/jsonnet-preview-snippets.ts
+++ b/www/preview/jsonnet-preview-snippets.ts
@@ -1,0 +1,43 @@
+export type JsonnetPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const jsonnetPreviewSnippets: JsonnetPreviewSnippet[] = [
+  {
+    title: "Config templating",
+    description: "locals, functions, and the std library",
+    code: `local name = "frontend";
+local replicas = 3;
+
+{
+  apiVersion: "apps/v1",
+  kind: "Deployment",
+  metadata: {
+    name: name,
+    labels: { app: name },
+  },
+  spec: {
+    replicas: replicas,
+    template: {
+      spec: {
+        containers: [
+          { name: name, image: "registry/" + name + ":latest" },
+        ],
+      },
+    },
+  },
+}`,
+  },
+  {
+    title: "Functions and comprehensions",
+    description: "object construction and std.map",
+    code: `local mkPort(p) = { containerPort: p, protocol: "TCP" };
+
+{
+  ports: std.map(mkPort, [80, 443, 8080]),
+  count: std.length(self.ports),
+}`,
+  },
+];

--- a/www/preview/move-preview-snippets.ts
+++ b/www/preview/move-preview-snippets.ts
@@ -1,0 +1,37 @@
+export type MovePreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const movePreviewSnippets: MovePreviewSnippet[] = [
+  {
+    title: "Coin module",
+    description: "modules, abilities, and resources",
+    code: `module 0x1::Coin {
+    struct Coin has key, store {
+        value: u64,
+    }
+
+    public fun mint(value: u64): Coin {
+        Coin { value }
+    }
+
+    public fun value(coin: &Coin): u64 {
+        coin.value
+    }
+}`,
+  },
+  {
+    title: "Entry function",
+    description: "signer, address literals, and acquires",
+    code: `module addr::Bank {
+    use std::signer;
+
+    public entry fun deposit(account: &signer, amount: u64) acquires Coin {
+        let addr = signer::address_of(account);
+        assert!(amount > 0, 1);
+    }
+}`,
+  },
+];

--- a/www/preview/nickel-preview-snippets.ts
+++ b/www/preview/nickel-preview-snippets.ts
@@ -1,0 +1,33 @@
+export type NickelPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const nickelPreviewSnippets: NickelPreviewSnippet[] = [
+  {
+    title: "Contracts and records",
+    description: "let bindings, annotations, and merging",
+    code: `let Port = std.contract.from_predicate (fun p =>
+  std.is_number p && p > 0 && p < 65536) in
+
+{
+  host | String = "localhost",
+  port | Port = 8080,
+  url = "http://%{host}:%{std.to_string port}",
+}`,
+  },
+  {
+    title: "Functions and enums",
+    description: "fun expressions and enum tags",
+    code: `let classify = fun n =>
+  if n > 0 then 'Positive
+  else if n < 0 then 'Negative
+  else 'Zero in
+
+{
+  result = classify 42,
+  values = std.array.map (fun x => x * 2) [1, 2, 3],
+}`,
+  },
+];

--- a/www/preview/odin-preview-snippets.ts
+++ b/www/preview/odin-preview-snippets.ts
@@ -1,0 +1,46 @@
+export type OdinPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const odinPreviewSnippets: OdinPreviewSnippet[] = [
+  {
+    title: "Procedures and structs",
+    description: "proc declarations, types, and directives",
+    code: `package main
+
+import "core:fmt"
+
+Vector2 :: struct {
+	x, y: f32,
+}
+
+length :: proc(v: Vector2) -> f32 {
+	return v.x * v.x + v.y * v.y
+}
+
+main :: proc() {
+	v := Vector2{3, 4}
+	fmt.println("length:", length(v))
+}`,
+  },
+  {
+    title: "Enums and switches",
+    description: "enums, #partial switch, and literals",
+    code: `Direction :: enum {
+	North,
+	East,
+	South,
+	West,
+}
+
+describe :: proc(d: Direction) -> string {
+	#partial switch d {
+	case .North: return "up"
+	case .South: return "down"
+	case: return "sideways"
+	}
+}`,
+  },
+];

--- a/www/preview/pkl-preview-snippets.ts
+++ b/www/preview/pkl-preview-snippets.ts
@@ -1,0 +1,43 @@
+export type PklPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const pklPreviewSnippets: PklPreviewSnippet[] = [
+  {
+    title: "Application config",
+    description: "properties, types, and string interpolation",
+    code: `name = "svelte-highlight"
+version = "8.0.0"
+
+server {
+  host = "0.0.0.0"
+  port = 8080
+  url = "http://\\(host):\\(port)"
+}
+
+environments = new Listing {
+  "development"
+  "staging"
+  "production"
+}`,
+  },
+  {
+    title: "Classes and functions",
+    description: "class declarations and typed functions",
+    code: `class Endpoint {
+  path: String
+  method: String = "GET"
+}
+
+function route(path: String): Endpoint = new Endpoint {
+  path = path
+}
+
+routes {
+  ["health"] = route("/health")
+  ["users"] = route("/api/users")
+}`,
+  },
+];

--- a/www/preview/promql-preview-snippets.ts
+++ b/www/preview/promql-preview-snippets.ts
@@ -1,0 +1,24 @@
+export type PromqlPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const promqlPreviewSnippets: PromqlPreviewSnippet[] = [
+  {
+    title: "Request rate",
+    description: "functions, label matchers, and durations",
+    code: `sum by (job) (
+  rate(http_requests_total{status="200", env="prod"}[5m])
+)`,
+  },
+  {
+    title: "Latency and alerts",
+    description: "aggregation and comparison operators",
+    code: `histogram_quantile(
+  0.95,
+  sum by (le) (rate(request_duration_seconds_bucket[5m]))
+)
+> 0.5`,
+  },
+];

--- a/www/preview/pug-preview-snippets.ts
+++ b/www/preview/pug-preview-snippets.ts
@@ -1,0 +1,32 @@
+export type PugPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const pugPreviewSnippets: PugPreviewSnippet[] = [
+  {
+    title: "HTML template",
+    description: "tags, id/class shorthand, and attributes",
+    code: `doctype html
+html(lang="en")
+  head
+    title My Page
+  body
+    h1#headline.title Welcome
+    nav.menu
+      a(href="/") Home
+      a(href="/about") About`,
+  },
+  {
+    title: "Mixins and interpolation",
+    description: "mixin calls and #{} interpolation",
+    code: `mixin card(title)
+  .card
+    h2.card-title= title
+    block
+
++card("Hello")
+  p Posted by #{author} on #{date}`,
+  },
+];

--- a/www/preview/razor-preview-snippets.ts
+++ b/www/preview/razor-preview-snippets.ts
@@ -1,0 +1,35 @@
+export type RazorPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const razorPreviewSnippets: RazorPreviewSnippet[] = [
+  {
+    title: "Razor page",
+    description: "directives, expressions, and markup",
+    code: `@page "/products"
+@model ProductsModel
+
+<h1>@Model.Title</h1>
+
+<ul>
+    @foreach (var product in Model.Products)
+    {
+        <li>@product.Name — @product.Price</li>
+    }
+</ul>`,
+  },
+  {
+    title: "Code blocks and comments",
+    description: "@{ } blocks and @* *@ comments",
+    code: `@* product summary section *@
+@{
+    var total = Model.Items.Count;
+    var label = total == 1 ? "item" : "items";
+}
+
+<p>You have @total @label in your cart.</p>
+<a href="/checkout">Checkout</a>`,
+  },
+];

--- a/www/preview/rescript-preview-snippets.ts
+++ b/www/preview/rescript-preview-snippets.ts
@@ -1,0 +1,31 @@
+export type RescriptPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const rescriptPreviewSnippets: RescriptPreviewSnippet[] = [
+  {
+    title: "Types and pattern matching",
+    description: "variants, records, and switch",
+    code: `type shape =
+  | Circle(float)
+  | Rectangle(float, float)
+
+let area = shape =>
+  switch shape {
+  | Circle(r) => 3.14 *. r *. r
+  | Rectangle(w, h) => w *. h
+  }`,
+  },
+  {
+    title: "Bindings and polymorphic variants",
+    description: "let bindings, decorators, and JSX-friendly syntax",
+    code: `@react.component
+let make = (~name) => {
+  let color = #Blue
+  let greeting = "Hello, " ++ name
+  <div className="greeting"> {React.string(greeting)} </div>
+}`,
+  },
+];

--- a/www/preview/starlark-preview-snippets.ts
+++ b/www/preview/starlark-preview-snippets.ts
@@ -1,0 +1,35 @@
+export type StarlarkPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const starlarkPreviewSnippets: StarlarkPreviewSnippet[] = [
+  {
+    title: "BUILD target",
+    description: "rules, globs, and select",
+    code: `# Build the server binary
+go_binary(
+    name = "server",
+    srcs = glob(["*.go"]),
+    deps = [
+        "//internal/api",
+        "//internal/db",
+    ],
+    visibility = ["//visibility:public"],
+)`,
+  },
+  {
+    title: "Custom rule",
+    description: "function definitions and providers",
+    code: `def _impl(ctx):
+    out = ctx.actions.declare_file(ctx.label.name + ".txt")
+    ctx.actions.write(output = out, content = "generated")
+    return [DefaultInfo(files = depset([out]))]
+
+my_rule = rule(
+    implementation = _impl,
+    attrs = {"value": attr.string(default = "hello")},
+)`,
+  },
+];

--- a/www/preview/v-preview-snippets.ts
+++ b/www/preview/v-preview-snippets.ts
@@ -1,0 +1,45 @@
+export type VlangPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const vPreviewSnippets: VlangPreviewSnippet[] = [
+  {
+    title: "Structs and methods",
+    description: "structs, functions, and string interpolation",
+    code: `module main
+
+struct Point {
+mut:
+	x f64
+	y f64
+}
+
+fn (p Point) distance() f64 {
+	return p.x * p.x + p.y * p.y
+}
+
+fn main() {
+	p := Point{x: 3.0, y: 4.0}
+	println("distance = \${p.distance()}")
+}`,
+  },
+  {
+    title: "Options and matching",
+    description: "option types, match, and enums",
+    code: `enum Color {
+	red
+	green
+	blue
+}
+
+fn parse(s string) ?Color {
+	return match s {
+		"red" { Color.red }
+		"green" { Color.green }
+		else { none }
+	}
+}`,
+  },
+];

--- a/www/preview/vyper-preview-snippets.ts
+++ b/www/preview/vyper-preview-snippets.ts
@@ -1,0 +1,43 @@
+export type VyperPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const vyperPreviewSnippets: VyperPreviewSnippet[] = [
+  {
+    title: "Token contract",
+    description: "decorators, types, and events",
+    code: `# @version 0.3.10
+
+balances: public(HashMap[address, uint256])
+
+event Transfer:
+    sender: indexed(address)
+    receiver: indexed(address)
+    amount: uint256
+
+@external
+def transfer(to: address, amount: uint256) -> bool:
+    assert self.balances[msg.sender] >= amount, "insufficient balance"
+    self.balances[msg.sender] -= amount
+    self.balances[to] += amount
+    log Transfer(msg.sender, to, amount)
+    return True`,
+  },
+  {
+    title: "View functions",
+    description: "constants, immutables, and internal helpers",
+    code: `MAX_SUPPLY: constant(uint256) = 1_000_000
+owner: immutable(address)
+
+@deploy
+def __init__():
+    owner = msg.sender
+
+@view
+@external
+def is_owner(account: address) -> bool:
+    return account == owner`,
+  },
+];

--- a/www/preview/wgsl-preview-snippets.ts
+++ b/www/preview/wgsl-preview-snippets.ts
@@ -1,0 +1,35 @@
+export type WgslPreviewSnippet = {
+  title: string;
+  description?: string;
+  code: string;
+};
+
+export const wgslPreviewSnippets: WgslPreviewSnippet[] = [
+  {
+    title: "Vertex shader",
+    description: "entry points, attributes, and builtin types",
+    code: `struct VertexOutput {
+  @builtin(position) position: vec4<f32>,
+  @location(0) color: vec3<f32>,
+}
+
+@vertex
+fn vs_main(@location(0) pos: vec2<f32>) -> VertexOutput {
+  var out: VertexOutput;
+  out.position = vec4<f32>(pos, 0.0, 1.0);
+  out.color = vec3<f32>(1.0, 0.5, 0.25);
+  return out;
+}`,
+  },
+  {
+    title: "Compute shader",
+    description: "bindings and workgroups",
+    code: `@group(0) @binding(0) var<storage, read_write> data: array<f32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) id: vec3<u32>) {
+  let i = id.x;
+  data[i] = data[i] * 2.0;
+}`,
+  },
+];


### PR DESCRIPTION
Adds another batch of custom grammars that are not shipped by highlight.js OOTB, following the same approach as #417.


- WGSL (WebGPU shading language)
- Cypher (Neo4j graph queries)
- PromQL (Prometheus)
- Bicep (Azure IaC)
- ReScript
- Starlark (Bazel `BUILD` / `.bzl`)
- Move, Cairo, Vyper, Clarity (web3 — alongside the existing `solidity`)
- CUE, Jsonnet, Dhall, Pkl, Nickel (config languages)
- Pug, Razor (templating)
- V, Odin (systems languages)
- Caddyfile (server config)
- D2 (diagrams)
- BibTeX
