### PR TITLE
feat(action): add use:highlight Svelte action

### DIFF
--- a/README.md
+++ b/README.md
@@ -686,6 +686,36 @@ In the example below, the `HighlightAuto` component and injected styles are dyna
 />
 ```
 
+## Action
+
+Use the `highlight` action to highlight existing `<pre><code>` markup in place. This is useful for progressively enhancing server-rendered content (e.g. markdown) without swapping in a component.
+
+The action accepts the same `language` prop as the components. When `code` is omitted, the element's existing `textContent` is highlighted. Updating `code` re-highlights the element.
+
+```svelte
+<script>
+  import { highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<pre><code use:highlight={{ language: typescript, code }}></code></pre>
+```
+
+Omit `code` to highlight the element's existing contents:
+
+```svelte
+<pre><code use:highlight={{ language: typescript }}
+  >const add = (a, b) => a + b;</code
+></pre>
+```
+
 ## Component API
 
 ### `Highlight`

--- a/src/action.d.ts
+++ b/src/action.d.ts
@@ -1,0 +1,22 @@
+import type { Action } from "svelte/action";
+import type { LanguageType } from "./languages";
+
+export type HighlightActionParameters = {
+  /**
+   * Language used to highlight the element's contents.
+   */
+  language: LanguageType<string>;
+
+  /**
+   * Code to highlight. When omitted, the element's
+   * current `textContent` is highlighted.
+   */
+  code?: string;
+};
+
+/**
+ * Svelte action that highlights an element's contents in place using
+ * highlight.js. Useful for progressively enhancing existing `<pre><code>`
+ * markup (e.g. server-rendered markdown).
+ */
+export declare const highlight: Action<HTMLElement, HighlightActionParameters>;

--- a/src/action.js
+++ b/src/action.js
@@ -1,0 +1,26 @@
+import hljs from "highlight.js/lib/core";
+
+/**
+ * Svelte action that highlights an element's contents in place using
+ * highlight.js. Useful for progressively enhancing existing `<pre><code>`
+ * markup (e.g. server-rendered markdown) without swapping in a component.
+ *
+ * When `code` is omitted, the element's current `textContent` is highlighted.
+ *
+ * @type {import("svelte/action").Action<HTMLElement, { language: import("./languages").LanguageType<string>; code?: string }>}
+ */
+export function highlight(node, parameters) {
+  /** @param {{ language: import("./languages").LanguageType<string>; code?: string }} params */
+  function apply({ language, code }) {
+    hljs.registerLanguage(language.name, language.register);
+    const source = code ?? node.textContent ?? "";
+    node.innerHTML = hljs.highlight(source, { language: language.name }).value;
+    node.classList.add("hljs");
+  }
+
+  apply(parameters);
+
+  return {
+    update: apply,
+  };
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,3 +1,5 @@
+export type { HighlightActionParameters } from "./action";
+export { highlight } from "./action";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { default as Highlight, default } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,3 +1,4 @@
+export { highlight } from "./action.js";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { default, default as Highlight } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";

--- a/tests/e2e/HighlightAction.test.svelte
+++ b/tests/e2e/HighlightAction.test.svelte
@@ -1,0 +1,18 @@
+<script>
+  import { highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  let code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<button
+  type="button"
+  on:click={() => (code = "function hello(name: string) {}")}
+>
+  Update
+</button>
+
+<pre><code use:highlight={{ language: typescript, code }}></code></pre>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -3,6 +3,7 @@ import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
 import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
 import CopyButton from "./CopyButton.test.svelte";
 import Highlight from "./Highlight.test.svelte";
+import HighlightAction from "./HighlightAction.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
 import LangTag from "./LangTag.test.svelte";
@@ -66,6 +67,21 @@ test("Highlight - astro language", async ({ mount, page }) => {
     page.locator(".language-typescript .hljs-keyword").first(),
   ).toHaveText("export");
   await expect(page.locator(".hljs-attr")).toHaveText("client:load");
+});
+
+test("highlight action", async ({ mount, page }) => {
+  await mount(HighlightAction);
+
+  // The action highlights the element's contents in place.
+  const code = page.locator("pre code.hljs");
+  await expect(code).toBeVisible();
+  await expect(code.locator(".hljs-keyword").first()).toHaveText("const");
+  await expect(code.locator(".hljs-title").first()).toHaveText("add");
+
+  // Updating `code` re-highlights in place.
+  await page.getByRole("button", { name: "Update" }).click();
+  await expect(code.locator(".hljs-keyword").first()).toHaveText("function");
+  await expect(code.locator(".hljs-title").first()).toHaveText("hello");
 });
 
 test("HighlightAuto", async ({ mount, page }) => {

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -206,6 +206,43 @@
 </Row>
 
 <Row class="mb-9">
+  <Column xlg={12}> <h3>Action</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Use the <code class="code">highlight</code> action to highlight existing
+      <code class="code">{"<pre><code>"}</code>
+      markup in place. This is useful for progressively enhancing
+      server-rendered content like Markdown without swapping in a component.
+    </p>
+    <p class="mb-5">
+      The action accepts the same <code class="code">language</code> prop as the
+      components. When <code class="code">code</code> is omitted, the element's
+      existing <code class="code">textContent</code> is highlighted. Updating
+      <code class="code">code</code>
+      re-highlights the element.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <HighlightSvelte
+      code={`<script>
+  import { highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const code = "const add = (a, b) => a + b;";
+<\/script>
+
+<svelte:head>
+  {@html github}
+<\/svelte:head>
+
+<pre><code use:highlight={{ language: typescript, code }}><\/code><\/pre>`}
+      class={THEME_MODULE_NAME}
+    />
+  </Column>
+</Row>
+
+<Row class="mb-9">
   <Column xlg={12}> <h3>Line Numbers</h3> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">


### PR DESCRIPTION
Adds a `highlight` Svelte action so existing `<pre><code>` markup can be syntax highlighted in place, which is handy for progressively enhancing server-rendered content like Markdown without swapping in a component. It takes the same `language` prop as the components, and when `code` is omitted it highlights the element's existing `textContent`. Updating `code` re-highlights the element. The export is registered in both `index.js` and `index.d.ts`, with an e2e test plus README and docs-site coverage. Fully backwards compatible since it is a new opt-in export.

Sample usage:

```svelte
<script>
  import { highlight } from "svelte-highlight";
  import typescript from "svelte-highlight/languages/typescript";
  import github from "svelte-highlight/styles/github";

  const code = "const add = (a, b) => a + b;";
</script>

<svelte:head>
  {@html github}
</svelte:head>

<pre><code use:highlight={{ language: typescript, code }}></code></pre>
```
