### PR TITLE
feat(styles): dual light/dark HighlightStyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,6 +156,39 @@ The component prefixes each selector with a scope class on the wrapper, so the t
 
 For a page-wide theme, use `{@html theme}` as shown above.
 
+### Dark mode
+
+`HighlightStyle` can emit a light and a dark theme together and switch between them. Pass `light` and `dark` instead of `theme`:
+
+```svelte
+<script>
+  import { Highlight, HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+  import githubDark from "svelte-highlight/styles/github-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<HighlightStyle light={github} dark={githubDark}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>
+```
+
+The `mode` prop controls how the two themes are switched (default `"auto"`):
+
+- `"auto"` — wrap each theme in a `@media (prefers-color-scheme: …)` query so the OS/browser preference decides.
+- `"light"` / `"dark"` — emit only that single theme.
+- any other string — treated as a CSS selector that gates the dark block while light stays the default. Use this to drive theming from a class or attribute on an ancestor, e.g. a manual theme toggle:
+
+```svelte
+<HighlightStyle light={github} dark={githubDark} mode={'[data-theme="dark"]'}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>
+```
+
+Both themes are scoped to the wrapper, so different blocks can use different theme pairs on the same page. When `light` and `dark` are both set they take precedence over `theme`; passing only `theme` keeps the existing single-theme behavior unchanged.
+
 ## Styling with CSS variables
 
 Every `Highlight` variant forwards `$$restProps` to its top-level element, so you can style the component using CSS variables without resorting to `:global` overrides or `!important`.

--- a/src/HighlightStyle.svelte
+++ b/src/HighlightStyle.svelte
@@ -1,5 +1,5 @@
 <script>
-  import { scopeClassFor, scopeStyle } from "./scoped.js";
+  import { dualStyle, scopeClassFor, scopeStyle } from "./scoped.js";
 
   /**
    * Theme CSS from `svelte-highlight/styles/<theme>`.
@@ -7,15 +7,41 @@
    * import a11yDark from "svelte-highlight/styles/a11y-dark";
    * @type {string}
    */
-  export let theme;
+  export let theme = undefined;
+
+  /**
+   * Light theme CSS; pair with `dark` to emit both stylesheets and switch
+   * automatically. Takes precedence over `theme` when both `light` and `dark`
+   * are provided.
+   * @type {string | undefined}
+   */
+  export let light = undefined;
+
+  /**
+   * Dark theme CSS; pair with `light` to emit both stylesheets.
+   * @type {string | undefined}
+   */
+  export let dark = undefined;
+
+  /**
+   * How to switch between `light` and `dark`:
+   * `"auto"` uses `prefers-color-scheme` media queries, `"light"`/`"dark"`
+   * force a single theme, and any other string is a CSS selector that gates
+   * the dark block (e.g. `[data-theme="dark"]`).
+   * @type {"auto" | "light" | "dark" | string}
+   */
+  export let mode = "auto";
 
   /**
    * Wrapper class the scoped selectors target.
    * @type {string}
    */
-  export let scopeClass = scopeClassFor(theme);
+  export let scopeClass = scopeClassFor(theme ?? `${light}${dark}`);
 
-  $: style = scopeStyle(theme, scopeClass);
+  $: style =
+    light !== undefined && dark !== undefined
+      ? dualStyle(light, dark, scopeClass, mode)
+      : scopeStyle(theme, scopeClass);
 </script>
 
 <svelte:head> {@html style} </svelte:head>

--- a/src/HighlightStyle.svelte.d.ts
+++ b/src/HighlightStyle.svelte.d.ts
@@ -7,7 +7,28 @@ export type HighlightStyleProps = HTMLAttributes<HTMLDivElement> & {
    * @example
    * import a11yDark from "svelte-highlight/styles/a11y-dark";
    */
-  theme: string;
+  theme?: string;
+
+  /**
+   * Light theme CSS; pair with `dark` to emit both stylesheets and switch
+   * automatically. Takes precedence over `theme` when both `light` and `dark`
+   * are provided.
+   */
+  light?: string;
+
+  /**
+   * Dark theme CSS; pair with `light` to emit both stylesheets.
+   */
+  dark?: string;
+
+  /**
+   * How to switch between `light` and `dark`:
+   * `"auto"` uses `prefers-color-scheme` media queries, `"light"`/`"dark"`
+   * force a single theme, and any other string is a CSS selector that gates
+   * the dark block (e.g. `[data-theme="dark"]`).
+   * @default "auto"
+   */
+  mode?: "auto" | "light" | "dark" | (string & {});
 
   /**
    * Wrapper class the scoped selectors target.

--- a/src/scoped.d.ts
+++ b/src/scoped.d.ts
@@ -7,5 +7,17 @@ export declare function scopeSelectors(
   transform: (selector: string) => string,
 ): string;
 
+/**
+ * Build a combined light/dark stylesheet scoped under `.scope`. `mode` is
+ * `"auto"` (prefers-color-scheme media queries), `"light"`/`"dark"` (single
+ * theme), or any CSS selector that gates the dark block.
+ */
+export declare function dualStyle(
+  light: string,
+  dark: string,
+  scope: string,
+  mode?: string,
+): string;
+
 /** Hash of the theme string. Same theme gives the same class (SSR-safe). */
 export declare function scopeClassFor(theme: string, prefix?: string): string;

--- a/src/scoped.js
+++ b/src/scoped.js
@@ -261,6 +261,55 @@ export function scopeStyle(style, scope) {
 }
 
 /**
+ * Scope `style` under `.scope`, optionally prefixing every selector with an
+ * extra `prefix` (e.g. a mode selector), and return the bare CSS with any
+ * `<style>` wrapper removed so callers can recombine it.
+ *
+ * @param {string} style Theme CSS (optionally `<style>`-wrapped).
+ * @param {string} scope Scope class name without a leading `.`.
+ * @param {string} [prefix] Selector prepended ahead of the scope class.
+ * @returns {string}
+ */
+function scopedBody(style, scope, prefix = "") {
+  const scopeSelector = prefix ? `${prefix} .${scope}` : `.${scope}`;
+  /** @type {(selector: string) => string} */
+  const transform = (selector) => `${scopeSelector} ${selector}`;
+  const match = STYLE_TAG.exec(style);
+  const css = match ? (match[2] ?? "") : style;
+  return scopeSelectors(css, transform);
+}
+
+/**
+ * Build a combined light/dark stylesheet scoped under `.scope`.
+ *
+ * - `"auto"` wraps each theme in `@media (prefers-color-scheme: …)`.
+ * - `"light"` / `"dark"` emit only that single theme.
+ * - any other string is treated as a CSS selector that gates the dark block
+ *   (light stays the default), e.g. `[data-theme="dark"]`.
+ *
+ * @param {string} light Light theme CSS (optionally `<style>`-wrapped).
+ * @param {string} dark Dark theme CSS (optionally `<style>`-wrapped).
+ * @param {string} scope Scope class name without a leading `.`.
+ * @param {string} [mode] `"auto"` | `"light"` | `"dark"` | a CSS selector.
+ * @returns {string}
+ */
+export function dualStyle(light, dark, scope, mode = "auto") {
+  let css;
+  if (mode === "light") {
+    css = scopedBody(light, scope);
+  } else if (mode === "dark") {
+    css = scopedBody(dark, scope);
+  } else if (mode === "auto") {
+    css =
+      `@media (prefers-color-scheme: light){${scopedBody(light, scope)}}` +
+      `@media (prefers-color-scheme: dark){${scopedBody(dark, scope)}}`;
+  } else {
+    css = scopedBody(light, scope) + scopedBody(dark, scope, mode);
+  }
+  return `<style>${css}</style>`;
+}
+
+/**
  * Hash of the theme string. Same theme gives the same class (SSR-safe).
  *
  * @param {string} theme

--- a/tests/highlight-style-dual.test.ts
+++ b/tests/highlight-style-dual.test.ts
@@ -1,0 +1,88 @@
+import { dualStyle, scopeStyle } from "../src/scoped.js";
+
+const light = "<style>.hljs{color:black;background:white}</style>";
+const dark = "<style>.hljs{color:white;background:black}</style>";
+
+describe("dualStyle", () => {
+  it("wraps both themes in prefers-color-scheme media queries for auto", () => {
+    const out = dualStyle(light, dark, "scope", "auto");
+    expect(out).toBe(
+      "<style>" +
+        "@media (prefers-color-scheme: light){.scope .hljs{color:black;background:white}}" +
+        "@media (prefers-color-scheme: dark){.scope .hljs{color:white;background:black}}" +
+        "</style>",
+    );
+  });
+
+  it("defaults to auto when no mode is given", () => {
+    expect(dualStyle(light, dark, "scope")).toBe(
+      dualStyle(light, dark, "scope", "auto"),
+    );
+  });
+
+  it("contains both scoped themes in auto mode", () => {
+    const out = dualStyle(light, dark, "scope", "auto");
+    expect(out).toContain(".scope .hljs{color:black;background:white}");
+    expect(out).toContain(".scope .hljs{color:white;background:black}");
+  });
+
+  it("emits only the light theme for mode=light", () => {
+    const out = dualStyle(light, dark, "scope", "light");
+    expect(out).toBe(
+      "<style>.scope .hljs{color:black;background:white}</style>",
+    );
+    expect(out).not.toContain("color:white");
+    expect(out).not.toContain("prefers-color-scheme");
+  });
+
+  it("emits only the dark theme for mode=dark", () => {
+    const out = dualStyle(light, dark, "scope", "dark");
+    expect(out).toBe(
+      "<style>.scope .hljs{color:white;background:black}</style>",
+    );
+    expect(out).not.toContain("color:black");
+    expect(out).not.toContain("prefers-color-scheme");
+  });
+
+  it("treats any other mode string as a selector gating the dark block", () => {
+    const out = dualStyle(light, dark, "scope", '[data-theme="dark"]');
+    expect(out).toBe(
+      "<style>" +
+        ".scope .hljs{color:black;background:white}" +
+        '[data-theme="dark"] .scope .hljs{color:white;background:black}' +
+        "</style>",
+    );
+  });
+
+  it("scopes every selector of a multi-rule theme", () => {
+    const multi =
+      "<style>.hljs{color:black}.hljs-keyword,\n.hljs-type{color:red}</style>";
+    const out = dualStyle(multi, multi, "scope", "light");
+    expect(out).toBe(
+      "<style>.scope .hljs{color:black}.scope .hljs-keyword,\n.scope .hljs-type{color:red}</style>",
+    );
+  });
+
+  it("handles themes without a <style> wrapper", () => {
+    const out = dualStyle(
+      ".hljs{color:black}",
+      ".hljs{color:white}",
+      "scope",
+      "auto",
+    );
+    expect(out).toBe(
+      "<style>" +
+        "@media (prefers-color-scheme: light){.scope .hljs{color:black}}" +
+        "@media (prefers-color-scheme: dark){.scope .hljs{color:white}}" +
+        "</style>",
+    );
+  });
+});
+
+describe("single-theme HighlightStyle output is unchanged", () => {
+  it("scopeStyle still preserves a <style> wrapper and scopes selectors", () => {
+    expect(scopeStyle(light, "scope")).toBe(
+      "<style>.scope .hljs{color:black;background:white}</style>",
+    );
+  });
+});

--- a/www/components/DualThemePreview.svelte
+++ b/www/components/DualThemePreview.svelte
@@ -1,0 +1,133 @@
+<script>
+  import Highlight, { HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+  import githubDark from "svelte-highlight/styles/github-dark";
+
+  const code = `interface User {
+  id: number;
+  name: string;
+}
+
+const greet = (user: User): string => {
+  return \`Hello, \${user.name}!\`;
+};`;
+
+  const modes = ["auto", "light", "dark", "selector"];
+
+  /** @type {"auto" | "light" | "dark" | "selector"} */
+  let mode = "auto";
+
+  // For "selector" mode the dark block is gated behind `[data-theme="dark"]`.
+  let darkSelectorOn = false;
+
+  const selector = '[data-theme="dark"]';
+
+  $: resolvedMode = mode === "selector" ? selector : mode;
+  $: dataTheme = mode === "selector" && darkSelectorOn ? "dark" : undefined;
+</script>
+
+<div class="controls">
+  <fieldset>
+    <legend>mode</legend>
+    {#each modes as value}
+      <button
+        type="button"
+        class="mode-button"
+        class:selected={mode === value}
+        on:click={() => (mode = value)}
+      >
+        {value}
+      </button>
+    {/each}
+  </fieldset>
+
+  {#if mode === "selector"}
+    <label class="toggle">
+      <input type="checkbox" bind:checked={darkSelectorOn}>
+      apply <code>{selector}</code>
+    </label>
+  {/if}
+</div>
+
+<p class="hint">
+  {#if mode === "auto"}
+    Following your OS / browser <code>prefers-color-scheme</code>. Switch your
+    system theme to see it flip.
+  {:else if mode === "light" || mode === "dark"}
+    Forcing the <strong>{mode}</strong> theme.
+  {:else}
+    Dark block is gated behind <code>{selector}</code> on an ancestor — toggle
+    the checkbox above.
+  {/if}
+</p>
+
+<div data-theme={dataTheme}>
+  <HighlightStyle light={github} dark={githubDark} mode={resolvedMode}>
+    <Highlight language={typescript} {code} />
+  </HighlightStyle>
+</div>
+
+<style>
+  .controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  fieldset {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    border: 1px solid var(--cds-ui-04, #8d8d8d);
+    border-radius: 4px;
+    padding: 0.25rem 0.75rem;
+  }
+
+  legend {
+    padding: 0 0.25rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  label {
+    display: inline-flex;
+    gap: 0.25rem;
+    align-items: center;
+    cursor: pointer;
+  }
+
+  .mode-button {
+    cursor: pointer;
+    border: 1px solid var(--cds-ui-04, #8d8d8d);
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    padding: 0.25rem 0.625rem;
+    font: inherit;
+    font-size: 0.875rem;
+  }
+
+  .mode-button.selected {
+    background: var(--cds-interactive-01, #0f62fe);
+    border-color: var(--cds-interactive-01, #0f62fe);
+    color: var(--cds-text-04, #ffffff);
+  }
+
+  .toggle {
+    font-size: 0.875rem;
+  }
+
+  .hint {
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+    opacity: 0.8;
+  }
+
+  code {
+    font-family: var(--cds-code-02-font-family, monospace);
+  }
+</style>

--- a/www/components/ScopedThemesDark.svelte
+++ b/www/components/ScopedThemesDark.svelte
@@ -1,0 +1,46 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import Highlight, { HighlightStyle, HighlightSvelte } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+  import githubDark from "svelte-highlight/styles/github-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+
+  const snippet = `<script>
+  import { Highlight, HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+  import githubDark from "svelte-highlight/styles/github-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+<\/script>
+
+<HighlightStyle light={github} dark={githubDark}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>`;
+
+  const selectorSnippet = `<HighlightStyle light={github} dark={githubDark} mode={'[data-theme="dark"]'}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>`;
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+<p class="mb-5">
+  Renders following your system <code class="code">prefers-color-scheme</code>:
+</p>
+
+<div class="mb-5">
+  <HighlightStyle light={github} dark={githubDark}>
+    <Highlight language={typescript} {code} />
+  </HighlightStyle>
+</div>
+
+<p class="mb-5">
+  Or gate the dark block behind a CSS selector for a manual toggle:
+</p>
+
+<HighlightSvelte code={selectorSnippet} class={THEME_MODULE_NAME} />

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -20,6 +20,7 @@
   import ScopedStyleAuto from "@components/ScopedStyleAuto.svelte";
   import ScopedStyleSvelte from "@components/ScopedStyleSvelte.svelte";
   import ScopedThemes from "@components/ScopedThemes.svelte";
+  import ScopedThemesDark from "@components/ScopedThemesDark.svelte";
   import { PKG_NAME, THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
   import {
     Column,
@@ -144,6 +145,53 @@
   </Column>
   <Column xlg={10} lg={10} md={12}>
     <ScopedThemes />
+  </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Dark mode</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">HighlightStyle</code>
+      can emit a light and a dark theme together and switch between them. Pass
+      <code class="code">light</code>
+      and
+      <code class="code">dark</code>
+      instead of <code class="code">theme</code>.
+    </p>
+    <p class="mb-5">
+      The <code class="code">mode</code> prop controls how the two themes are
+      switched (default <code class="code">"auto"</code>):
+    </p>
+    <UnorderedList class="mb-5">
+      <ListItem>
+        <code class="code">"auto"</code>: wrap each theme in a
+        <code class="code">@media (prefers-color-scheme)</code>
+        query so the OS or browser preference decides.
+      </ListItem>
+      <ListItem>
+        <code class="code">"light"</code>
+        / <code class="code">"dark"</code>: emit only that single theme.
+      </ListItem>
+      <ListItem>
+        any other string: treated as a CSS selector that gates the dark block
+        while light stays the default—e.g.
+        <code class="code">[data-theme="dark"]</code>
+        to drive theming from a manual toggle.
+      </ListItem>
+    </UnorderedList>
+    <p class="mb-5">
+      Both themes are scoped to the wrapper, so different blocks can use
+      different theme pairs on the same page. When
+      <code class="code">light</code>
+      and <code class="code">dark</code> are both set they take precedence over
+      <code class="code">theme</code>; passing only
+      <code class="code">theme</code>
+      keeps the existing single-theme behavior unchanged.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <ScopedThemesDark />
   </Column>
 </Row>
 

--- a/www/pages/preview-dual-theme.astro
+++ b/www/pages/preview-dual-theme.astro
@@ -1,0 +1,9 @@
+---
+import DualThemePreview from "@components/DualThemePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Dual light/dark HighlightStyle preview">
+  <h1 class="mb-5">Dual light/dark HighlightStyle</h1>
+  <DualThemePreview client:idle />
+</Layout>


### PR DESCRIPTION
Adds optional `light`, `dark`, and `mode` props to `HighlightStyle` so a single block can emit both a light and dark theme and switch between them, where `mode="auto"` uses `prefers-color-scheme` media queries, `"light"`/`"dark"` force one theme, and any other string is treated as a CSS selector that gates the dark block. The dual-theme path only activates when both `light` and `dark` are passed, so existing `theme`-only usage is byte-for-byte unchanged. The only API change is that `theme` is now optional, which is backwards compatible. Docs are updated in the README and on the home page, plus an unlisted `/preview-dual-theme` route with a mode toggle for manual testing.

No breaking changes.
