### PR TITLE
feat: add HighlightEditable component

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,80 @@ When using a language tag alongside `CopyButton`, offset `--langtag-top` and `--
 </div>
 ```
 
+## Editable
+
+`HighlightEditable` is a `contenteditable` code block. It re-highlights on every edit and keeps the caret where you left it.
+
+Use `bind:code` to keep your state in sync.
+
+```svelte
+<script>
+  import { HighlightEditable } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  let code = "const add = (a: number, b: number) => a + b";
+</script>
+
+<svelte:head>
+  {@html atomOneDark}
+</svelte:head>
+
+<HighlightEditable language={typescript} bind:code />
+```
+
+### Keyboard Behavior
+
+- **Enter** inserts a newline.
+- **Tab** / **Shift+Tab** indent or dedent the selected lines (or insert one indent at the caret). Set the indent size with the `tabSize` prop (default `2`).
+- **Cmd/Ctrl+Z** undo and **Shift+Cmd/Ctrl+Z** (or **Ctrl+Y**) redo. Typing bursts collapse into a single undo step; cap the retained history with the `historyLimit` prop (default `200`).
+
+### Dispatched Events
+
+`HighlightEditable` dispatches `change` (on every edit), `blur`, and `history` (whenever the undo/redo stack changes).
+
+```svelte
+<HighlightEditable
+  language={typescript}
+  bind:code
+  on:change={(e) => console.log(e.detail.code)}
+  on:blur={(e) => console.log(e.detail.code)}
+  on:history={(e) => console.log(e.detail.canUndo, e.detail.canRedo)}
+/>
+```
+
+### Imperative API
+
+Use `bind:this` to call methods on the instance.
+
+```svelte
+<script>
+  let editor;
+</script>
+
+<HighlightEditable bind:this={editor} language={typescript} bind:code />
+
+<button on:click={() => editor.undo()}>Undo</button>
+<button on:click={() => editor.redo()}>Redo</button>
+<button on:click={() => editor.indent()}>Indent</button>
+<button on:click={() => editor.clear()}>Clear</button>
+```
+
+Available methods: `undo`, `redo`, `focus`, `selectAll`, `insert`, `indent`, `outdent`, `setCode`, `clear`, `getCode`, `canUndo`, and `canRedo`.
+
+### Custom Styles
+
+Customize the focus outline with the `--outline-color`, `--outline-width`, and `--outline-offset` style props.
+
+```svelte
+<HighlightEditable
+  language={typescript}
+  bind:code
+  --outline-color="#42be65"
+  --outline-width="2px"
+/>
+```
+
 ## Language Targeting
 
 All `Highlight` components apply a `data-language` attribute on the codeblock containing the language name.
@@ -890,6 +964,40 @@ import type { LanguageName } from "svelte-highlight";
      */
     console.log(e.detail.language);
   }}
+/>
+```
+
+### `HighlightEditable`
+
+#### Props
+
+| Name         | Type                                           | Default value  |
+| :----------- | :--------------------------------------------- | :------------- |
+| code         | `string`                                       | `""`           |
+| language     | { name: `string`; register: hljs => `object` } | N/A (required) |
+| tabSize      | `number`                                       | `2`            |
+| historyLimit | `number`                                       | `200`          |
+
+`$$restProps` are forwarded to the top-level `pre` element.
+
+`code` supports two-way binding (`bind:code`).
+
+#### Methods
+
+Use `bind:this`, then call `undo()`, `redo()`, `focus()`, `selectAll()`, `insert(text)`, `indent()`, `outdent()`, `setCode(value)`, `clear()`, `getCode()`, `canUndo()`, or `canRedo()`.
+
+#### Dispatched Events
+
+- **on:change**: fired on every edit, with `{ code }`
+- **on:blur**: fired when the editor loses focus, with `{ code }`
+- **on:history**: fired when the undo/redo stack changes, with `{ entries, index, canUndo, canRedo }`
+
+```svelte
+<HighlightEditable
+  language={typescript}
+  bind:code
+  on:change={(e) => console.log(e.detail.code)}
+  on:history={(e) => console.log(e.detail.canUndo, e.detail.canRedo)}
 />
 ```
 

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -1,0 +1,381 @@
+<script>
+  /** @type {import("./languages").LanguageType<string>} */
+  export let language;
+
+  /** @type {string} */
+  export let code = "";
+
+  /** @type {number} Number of spaces inserted by the Tab key. */
+  export let tabSize = 2;
+
+  /** @type {number} Maximum number of undo snapshots retained. */
+  export let historyLimit = 200;
+
+  import hljs from "highlight.js/lib/core";
+  import { createEventDispatcher, onMount } from "svelte";
+
+  const dispatch = createEventDispatcher();
+  const TRAILING_NEWLINE = /\n$/;
+
+  /** @type {HTMLElement} */
+  let editor;
+
+  // Skip re-highlighting mid-composition; it would destroy IME input.
+  let composing = false;
+  let mounted = false;
+  let restoringSelection = false;
+
+  // Mirror of `code` so external (parent) reassignments can be told apart from
+  // our own edits and trigger a repaint.
+  let internalCode = code;
+
+  $: hljs.registerLanguage(language.name, language.register);
+  $: indentUnit = " ".repeat(tabSize);
+  $: if (mounted && code !== internalCode) syncExternal();
+
+  function getSelectionRange() {
+    const selection = window.getSelection();
+    if (!selection || selection.rangeCount === 0) return null;
+    const range = selection.getRangeAt(0);
+    if (!editor.contains(range.commonAncestorContainer)) return null;
+    const pre = range.cloneRange();
+    pre.selectNodeContents(editor);
+    pre.setEnd(range.startContainer, range.startOffset);
+    const start = pre.toString().length;
+    return { start, end: start + range.toString().length };
+  }
+
+  function getCaretOffset() {
+    const sel = getSelectionRange();
+    return sel ? sel.end : null;
+  }
+
+  function nodeAtOffset(offset) {
+    const walker = document.createTreeWalker(
+      editor,
+      NodeFilter.SHOW_TEXT,
+      null,
+    );
+    let count = 0;
+    for (let node = walker.nextNode(); node; node = walker.nextNode()) {
+      const next = count + node.textContent.length;
+      if (offset <= next) return { node, offset: offset - count };
+      count = next;
+    }
+    return null;
+  }
+
+  function setSelection(start, end) {
+    const from = nodeAtOffset(start);
+    if (!from) return;
+    const range = document.createRange();
+    range.setStart(from.node, from.offset);
+    const to = end != null && end !== start ? nodeAtOffset(end) : null;
+    if (to) range.setEnd(to.node, to.offset);
+    else range.collapse(true);
+    const selection = window.getSelection();
+    selection.removeAllRanges();
+    selection.addRange(range);
+  }
+
+  function paint() {
+    const html = hljs.highlight(code, { language: language.name }).value;
+    // contenteditable can't place a caret on a trailing empty line, so render a
+    // phantom newline there (stripped again when reading `innerText`).
+    editor.innerHTML = code === "" || code.endsWith("\n") ? `${html}\n` : html;
+  }
+
+  function renderAt(start, end) {
+    paint();
+    if (start == null) return;
+    restoringSelection = true;
+    setSelection(start, end);
+    restoringSelection = false;
+  }
+
+  function syncCaretToHistory() {
+    if (restoringSelection || composing || undoStack.length === 0) return;
+    const sel = getSelectionRange();
+    if (!sel) return;
+    const top = undoStack[undoStack.length - 1];
+    if (top.code !== code) return;
+    undoStack[undoStack.length - 1] = {
+      code: top.code,
+      start: sel.start,
+      end: sel.end,
+    };
+  }
+
+  /** @type {Array<{ code: string; start: number; end: number }>} */
+  let undoStack = [];
+  /** @type {Array<{ code: string; start: number; end: number }>} */
+  let redoStack = [];
+  let lastRecord = 0;
+
+  function emitHistory() {
+    const future = redoStack.slice().reverse();
+    dispatch("history", {
+      entries: [...undoStack, ...future].map((snap) => ({
+        size: snap.code.length,
+      })),
+      index: undoStack.length - 1,
+      canUndo: undoStack.length > 1,
+      canRedo: redoStack.length > 0,
+    });
+  }
+
+  // Coalesce records within 250ms into one undo step so a burst of typing is
+  // undone at once; structural edits (Enter/Tab/paste) pass coalesce=false.
+  function pushHistory(snap, coalesce) {
+    redoStack = [];
+    const now = Date.now();
+    if (coalesce && undoStack.length > 1 && now - lastRecord < 250) {
+      undoStack[undoStack.length - 1] = snap;
+    } else {
+      undoStack.push(snap);
+      const limit = Math.max(1, historyLimit);
+      if (undoStack.length > limit) {
+        undoStack.splice(0, undoStack.length - limit);
+      }
+    }
+    lastRecord = coalesce ? now : 0;
+    emitHistory();
+  }
+
+  function applySnapshot(snap) {
+    code = snap.code;
+    internalCode = snap.code;
+    dispatch("change", { code });
+    emitHistory();
+    renderAt(snap.start, snap.end);
+  }
+
+  function commit(value, start, end, coalesce) {
+    code = value;
+    internalCode = value;
+    dispatch("change", { code });
+    pushHistory({ code: value, start, end }, coalesce);
+    renderAt(start, end);
+  }
+
+  function syncExternal() {
+    internalCode = code;
+    pushHistory({ code, start: code.length, end: code.length }, false);
+    paint();
+  }
+
+  function insertText(text) {
+    const sel = getSelectionRange();
+    if (!sel) return;
+    const value = code.slice(0, sel.start) + text + code.slice(sel.end);
+    commit(value, sel.start + text.length, undefined, false);
+  }
+
+  // Indent or dedent every line the selection touches, keeping the lines
+  // selected so the action repeats. Blank lines are skipped when indenting.
+  function shiftIndent(outdent) {
+    const sel = getSelectionRange();
+    if (!sel) return;
+    const blockStart = code.lastIndexOf("\n", sel.start - 1) + 1;
+    const lines = code.slice(blockStart, sel.end).split("\n");
+
+    let firstDelta = 0;
+    let totalDelta = 0;
+    const next = lines
+      .map((line, index) => {
+        if (outdent) {
+          const leading = line.length - line.trimStart().length;
+          const remove = Math.min(tabSize, leading);
+          if (index === 0) firstDelta = -remove;
+          totalDelta -= remove;
+          return line.slice(remove);
+        }
+        if (line.length === 0) return line;
+        if (index === 0) firstDelta = tabSize;
+        totalDelta += tabSize;
+        return indentUnit + line;
+      })
+      .join("\n");
+
+    if (totalDelta === 0) return;
+    const value = code.slice(0, blockStart) + next + code.slice(sel.end);
+    const start = Math.max(blockStart, sel.start + firstDelta);
+    commit(value, start, sel.end + totalDelta, false);
+  }
+
+  function indentCommand() {
+    const sel = getSelectionRange();
+    if (sel && code.slice(sel.start, sel.end).includes("\n"))
+      shiftIndent(false);
+    else insertText(indentUnit);
+  }
+
+  function ensureFocus() {
+    if (document.activeElement === editor) return;
+    // Capture any selection that persisted from before blurring; focusing would
+    // otherwise reset the caret to the start. Fall back to the end of the code.
+    const prior = getSelectionRange();
+    editor.focus();
+    if (prior) setSelection(prior.start, prior.end);
+    else setSelection(code.length);
+    syncCaretToHistory();
+  }
+
+  export function undo() {
+    if (undoStack.length <= 1) return;
+    redoStack.push(undoStack.pop());
+    applySnapshot(undoStack[undoStack.length - 1]);
+  }
+
+  export function redo() {
+    if (redoStack.length === 0) return;
+    const snap = redoStack.pop();
+    undoStack.push(snap);
+    applySnapshot(snap);
+  }
+
+  export function focus() {
+    editor.focus();
+  }
+
+  export function selectAll() {
+    editor.focus();
+    setSelection(0, code.length);
+  }
+
+  export function insert(text) {
+    ensureFocus();
+    insertText(text);
+  }
+
+  export function indent() {
+    ensureFocus();
+    indentCommand();
+  }
+
+  export function outdent() {
+    ensureFocus();
+    shiftIndent(true);
+  }
+
+  export function setCode(value) {
+    if (value === code) return;
+    internalCode = value;
+    code = value;
+    dispatch("change", { code });
+    pushHistory({ code: value, start: value.length, end: value.length }, false);
+    paint();
+  }
+
+  export function clear() {
+    setCode("");
+  }
+
+  export function getCode() {
+    return code;
+  }
+
+  export function canUndo() {
+    return undoStack.length > 1;
+  }
+
+  export function canRedo() {
+    return redoStack.length > 0;
+  }
+
+  function onInput() {
+    if (composing) return;
+    // innerText (not textContent) preserves contenteditable line breaks.
+    code = editor.innerText.replace(TRAILING_NEWLINE, "");
+    internalCode = code;
+    const caret = getCaretOffset() ?? code.length;
+    dispatch("change", { code });
+    pushHistory({ code, start: caret, end: caret }, true);
+    renderAt(caret);
+  }
+
+  function onKeydown(event) {
+    const mod = event.metaKey || event.ctrlKey;
+
+    if (mod && event.key === "z" && !event.shiftKey) {
+      event.preventDefault();
+      undo();
+      return;
+    }
+    if (mod && (event.key === "y" || (event.key === "z" && event.shiftKey))) {
+      event.preventDefault();
+      redo();
+      return;
+    }
+    if (event.key === "Enter") {
+      event.preventDefault();
+      insertText("\n");
+      return;
+    }
+    if (event.key === "Tab") {
+      event.preventDefault();
+      if (event.shiftKey) shiftIndent(true);
+      else indentCommand();
+    }
+  }
+
+  function onPaste(event) {
+    event.preventDefault();
+    insertText(event.clipboardData?.getData("text/plain") ?? "");
+  }
+
+  onMount(() => {
+    paint();
+    undoStack = [{ code, start: 0, end: 0 }];
+    mounted = true;
+    emitHistory();
+
+    editor.addEventListener("input", onInput);
+    editor.addEventListener("keydown", onKeydown);
+    editor.addEventListener("paste", onPaste);
+    editor.addEventListener("mouseup", syncCaretToHistory);
+    editor.addEventListener("keyup", syncCaretToHistory);
+    document.addEventListener("selectionchange", syncCaretToHistory);
+    editor.addEventListener("blur", () =>
+      dispatch("blur", { code: getCode() }),
+    );
+    editor.addEventListener("compositionstart", () => {
+      composing = true;
+    });
+    editor.addEventListener("compositionend", () => {
+      composing = false;
+      onInput();
+    });
+
+    return () => {
+      editor.removeEventListener("input", onInput);
+      editor.removeEventListener("keydown", onKeydown);
+      editor.removeEventListener("paste", onPaste);
+      editor.removeEventListener("mouseup", syncCaretToHistory);
+      editor.removeEventListener("keyup", syncCaretToHistory);
+      document.removeEventListener("selectionchange", syncCaretToHistory);
+    };
+  });
+</script>
+
+<pre
+  style:overflow-x="var(--overflow-x, auto)"
+  style:border-radius="var(--border-radius, 0)"
+  {...$$restProps}
+><code
+    bind:this={editor}
+    class:hljs={true}
+    contenteditable="true"
+    spellcheck="false"
+></code></pre>
+
+<style>
+  code {
+    outline: none;
+  }
+
+  code:focus {
+    outline: var(--outline-width, 2px) solid var(--outline-color, #4589ff);
+    outline-offset: var(--outline-offset, -2px);
+  }
+</style>

--- a/src/HighlightEditable.svelte.d.ts
+++ b/src/HighlightEditable.svelte.d.ts
@@ -1,0 +1,115 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+import type { LanguageType } from "./languages";
+
+export type HighlightEditableProps = HTMLAttributes<HTMLPreElement> & {
+  /**
+   * Specify the editable code. Supports two-way binding (`bind:code`).
+   */
+  code?: string;
+
+  /**
+   * Provide the language grammar used to highlight the code.
+   * Import languages from `svelte-highlight/languages/*`.
+   * @example
+   * import typescript from "svelte-highlight/languages/typescript";
+   */
+  language: LanguageType<string>;
+
+  /**
+   * Number of spaces inserted by the Tab key.
+   * @default 2
+   */
+  tabSize?: number;
+
+  /**
+   * Maximum number of undo snapshots retained. Older snapshots are dropped
+   * once the limit is exceeded.
+   * @default 200
+   */
+  historyLimit?: number;
+
+  /**
+   * Color of the focus outline.
+   * @default "#4589ff"
+   */
+  "--outline-color"?: string;
+
+  /**
+   * Width of the focus outline.
+   * @default "2px"
+   */
+  "--outline-width"?: string | number;
+
+  /**
+   * Offset of the focus outline.
+   * @default "-2px"
+   */
+  "--outline-offset"?: string | number;
+};
+
+export type HighlightEditableEvents = {
+  /**
+   * Fired on every edit with the current plain-text code.
+   */
+  change: CustomEvent<{ code: string }>;
+
+  /**
+   * Fired when the editor loses focus with the current plain-text code.
+   */
+  blur: CustomEvent<{ code: string }>;
+
+  /**
+   * Fired whenever the undo/redo history changes. `entries` is the linear
+   * timeline (oldest to newest, including redoable future states) and `index`
+   * points at the current state within it.
+   */
+  history: CustomEvent<{
+    entries: { size: number }[];
+    index: number;
+    canUndo: boolean;
+    canRedo: boolean;
+  }>;
+};
+
+export default class HighlightEditable extends SvelteComponentTyped<
+  HighlightEditableProps,
+  HighlightEditableEvents,
+  Record<string, never>
+> {
+  /** Undo to the previous history snapshot. */
+  undo(): void;
+
+  /** Redo the last undone history snapshot. */
+  redo(): void;
+
+  /** Focus the editor. */
+  focus(): void;
+
+  /** Select the entire document. */
+  selectAll(): void;
+
+  /** Insert text at the caret (replacing any selection). */
+  insert(text: string): void;
+
+  /** Indent the selected lines (or insert one indent at the caret). */
+  indent(): void;
+
+  /** Dedent the selected lines. */
+  outdent(): void;
+
+  /** Replace the entire document, recording it as an undo step. */
+  setCode(value: string): void;
+
+  /** Empty the document. */
+  clear(): void;
+
+  /** Read the current code. */
+  getCode(): string;
+
+  /** Whether an undo step is available. */
+  canUndo(): boolean;
+
+  /** Whether a redo step is available. */
+  canRedo(): boolean;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,7 @@ export { highlight } from "./action";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { default as Highlight, default } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
+export { default as HighlightEditable } from "./HighlightEditable.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ export { highlight } from "./action.js";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { default, default as Highlight } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
+export { default as HighlightEditable } from "./HighlightEditable.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";

--- a/tests/e2e/HighlightEditable.binding.test.svelte
+++ b/tests/e2e/HighlightEditable.binding.test.svelte
@@ -1,0 +1,25 @@
+<script>
+  import { HighlightEditable } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  let first;
+  let code = "ab";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<div data-testid="first">
+  <HighlightEditable bind:this={first} language={typescript} bind:code />
+</div>
+<div data-testid="second">
+  <HighlightEditable language={typescript} bind:code />
+</div>
+
+<button
+  type="button"
+  data-testid="insert-first"
+  on:click={() => first.insert("X")}
+>
+  insert into first
+</button>

--- a/tests/e2e/HighlightEditable.test.svelte
+++ b/tests/e2e/HighlightEditable.test.svelte
@@ -1,0 +1,63 @@
+<script>
+  import { HighlightEditable } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  export let initialCode = "const a = 1;";
+
+  let editor;
+  let code = initialCode;
+  let changes = 0;
+  let historyState = { entries: [], index: 0, canUndo: false, canRedo: false };
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<HighlightEditable
+  bind:this={editor}
+  language={typescript}
+  bind:code
+  tabSize={2}
+  --outline-color="rgb(255, 0, 0)"
+  on:change={() => (changes += 1)}
+  on:history={(e) => (historyState = e.detail)}
+/>
+
+<div data-testid="code" data-value={code}></div>
+<div data-testid="changes" data-value={changes}></div>
+<div data-testid="can-undo" data-value={historyState.canUndo}></div>
+<div data-testid="can-redo" data-value={historyState.canRedo}></div>
+<div data-testid="entries" data-value={historyState.entries.length}></div>
+
+<button type="button" data-testid="undo" on:click={() => editor.undo()}>
+  undo
+</button>
+<button type="button" data-testid="redo" on:click={() => editor.redo()}>
+  redo
+</button>
+<button
+  type="button"
+  data-testid="select-all"
+  on:click={() => editor.selectAll()}
+>
+  select all
+</button>
+<button type="button" data-testid="indent" on:click={() => editor.indent()}>
+  indent
+</button>
+<button type="button" data-testid="outdent" on:click={() => editor.outdent()}>
+  outdent
+</button>
+<button type="button" data-testid="insert" on:click={() => editor.insert("X")}>
+  insert
+</button>
+<button
+  type="button"
+  data-testid="set-code"
+  on:click={() => editor.setCode("xyz")}
+>
+  set code
+</button>
+<button type="button" data-testid="clear" on:click={() => editor.clear()}>
+  clear
+</button>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -6,6 +6,8 @@ import Highlight from "./Highlight.test.svelte";
 import HighlightAction from "./HighlightAction.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
+import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
+import HighlightEditable from "./HighlightEditable.test.svelte";
 import LangTag from "./LangTag.test.svelte";
 import LineNumbersCssVariables from "./LineNumbers.cssVariables.test.svelte";
 import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test.svelte";
@@ -338,4 +340,207 @@ test("CopyButton - dedupes clicks while an async copy is in flight", async ({
   await expect(button).toHaveAttribute("aria-label", "Copy", {
     timeout: 3_000,
   });
+});
+
+test("HighlightEditable - renders an editable, highlighted block", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable);
+
+  await expect(page.locator("[contenteditable='true']")).toBeVisible();
+  await expect(page.locator(".hljs-keyword").first()).toHaveText("const");
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "const a = 1;",
+  );
+  await expect(page.getByTestId("entries")).toHaveAttribute("data-value", "1");
+  await expect(page.getByTestId("can-undo")).toHaveAttribute(
+    "data-value",
+    "false",
+  );
+});
+
+test("HighlightEditable - typing updates the bound code and fires change", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable);
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowRight"); // collapse caret to end
+  await page.keyboard.type(" // ok");
+
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "const a = 1; // ok",
+  );
+  await expect(page.getByTestId("changes")).not.toHaveAttribute(
+    "data-value",
+    "0",
+  );
+});
+
+test("HighlightEditable - preserves caret position across re-highlight", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable, { props: { initialCode: "abcd" } });
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowLeft"); // collapse caret to start
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("ArrowRight"); // caret after "ab"
+  await page.keyboard.type("XY");
+
+  // Inserted at the caret (not at the start), proving the caret survives the
+  // re-highlight that runs on each keystroke.
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "abXYcd",
+  );
+});
+
+test("HighlightEditable - Enter inserts a newline and Tab inserts indent", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable, { props: { initialCode: "a" } });
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowRight"); // caret to end
+  await page.keyboard.press("Enter");
+  await page.keyboard.type("b");
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "a\nb");
+
+  await page.keyboard.press("Tab");
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "a\nb  ",
+  );
+});
+
+test("HighlightEditable - Tab and Shift+Tab indent/dedent selected lines", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable, { props: { initialCode: "a\nb" } });
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Tab");
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "  a\n  b",
+  );
+
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("Shift+Tab");
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "a\nb");
+});
+
+test("HighlightEditable - undo and redo walk the history", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable);
+
+  await page.getByTestId("insert").click();
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "const a = 1;X",
+  );
+  await expect(page.getByTestId("can-undo")).toHaveAttribute(
+    "data-value",
+    "true",
+  );
+
+  await page.getByTestId("undo").click();
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "const a = 1;",
+  );
+  await expect(page.getByTestId("can-redo")).toHaveAttribute(
+    "data-value",
+    "true",
+  );
+
+  await page.getByTestId("redo").click();
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "const a = 1;X",
+  );
+});
+
+test("HighlightEditable - undo preserves caret position", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable, { props: { initialCode: "abcd" } });
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowLeft");
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.type("XY");
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "abXYcd",
+  );
+
+  await page.keyboard.press("ControlOrMeta+z");
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "abcd");
+
+  await page.keyboard.type("Q");
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "abQcd");
+});
+
+test("HighlightEditable - setCode and clear replace the document", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable);
+
+  await page.getByTestId("set-code").click();
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "xyz");
+  await expect(page.getByTestId("can-undo")).toHaveAttribute(
+    "data-value",
+    "true",
+  );
+
+  await page.getByTestId("clear").click();
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "");
+});
+
+test("HighlightEditable - focus outline uses the --outline-color variable", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable);
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await expect(editor).toHaveCSS("outline-color", "rgb(255, 0, 0)");
+});
+
+test("HighlightEditable - two instances share the same bound code", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditableBinding);
+
+  const second = page.getByTestId("second").locator("[contenteditable='true']");
+  await expect(second).toHaveText("ab");
+
+  await page.getByTestId("insert-first").click();
+  await expect(second).toHaveText("abX");
 });

--- a/www/components/EditablePreview.svelte
+++ b/www/components/EditablePreview.svelte
@@ -1,0 +1,269 @@
+<script>
+  import { Button, Column, Row, Slider } from "carbon-components-svelte";
+  import {
+    Highlight,
+    HighlightEditable,
+    HighlightStyle,
+    LineNumbers,
+  } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+  import githubDark from "svelte-highlight/styles/github-dark";
+  import nord from "svelte-highlight/styles/nord";
+
+  let code = `interface User {
+  id: number;
+  name: string;
+}
+
+const greet = (user: User): string => {
+  return \`Hello, \${user.name}!\`;
+};`;
+
+  let lastEvent = "none";
+  let outlineColor = "#42be65";
+  let outlineWidth = 2;
+
+  /** @type {import("svelte-highlight").HighlightEditable} */
+  let editor;
+
+  /** @type {{ entries: { size: number }[]; index: number; canUndo: boolean; canRedo: boolean }} */
+  let historyState = { entries: [], index: 0, canUndo: false, canRedo: false };
+
+  const sideThemes = [
+    { name: "atom-one-dark", theme: atomOneDark },
+    { name: "nord", theme: nord },
+  ];
+
+  // Mutate `code` from the outside to demonstrate external-change repaint.
+  function sortLines() {
+    code = code.split("\n").sort().join("\n");
+  }
+</script>
+
+<Row class="mb-9">
+  <Column xlg={10} lg={10} md={12} class="mb-5">
+    <div class="label-01 mb-3">
+      Enter inserts newlines. Tab and Shift+Tab indent selected lines.
+      Cmd/Ctrl+Z undoes, Shift+Z or Ctrl+Y redoes. The caret and selection
+      survive re-highlight.
+    </div>
+
+    <div class="toolbar">
+      <Button
+        size="small"
+        kind="tertiary"
+        disabled={!historyState.canUndo}
+        on:click={() => editor.undo()}
+        >Undo</Button
+      >
+      <Button
+        size="small"
+        kind="tertiary"
+        disabled={!historyState.canRedo}
+        on:click={() => editor.redo()}
+        >Redo</Button
+      >
+      <Button size="small" kind="ghost" on:click={() => editor.indent()}>
+        Indent
+      </Button>
+      <Button size="small" kind="ghost" on:click={() => editor.outdent()}>
+        Outdent
+      </Button>
+      <Button size="small" kind="ghost" on:click={() => editor.selectAll()}>
+        Select all
+      </Button>
+      <Button
+        size="small"
+        kind="ghost"
+        on:click={() => editor.insert("// TODO\n")}
+        >Insert</Button
+      >
+      <Button size="small" kind="ghost" on:click={sortLines}>
+        Sort lines (external)
+      </Button>
+      <Button
+        size="small"
+        kind="danger-tertiary"
+        on:click={() => editor.clear()}
+        >Clear</Button
+      >
+    </div>
+
+    <div class="controls">
+      <label class="control">
+        <span class="label-01">Outline color</span>
+        <input type="color" bind:value={outlineColor}>
+      </label>
+      <div class="control slider">
+        <Slider
+          labelText="Outline width (px)"
+          min={0}
+          max={6}
+          step={1}
+          maxLabel="6"
+          bind:value={outlineWidth}
+        />
+      </div>
+    </div>
+
+    <HighlightStyle theme={githubDark}>
+      <HighlightEditable
+        bind:this={editor}
+        language={typescript}
+        bind:code
+        --outline-color={outlineColor}
+        --outline-width={`${outlineWidth}px`}
+        on:change={(e) => (lastEvent = `change: ${e.detail.code.length} chars`)}
+        on:blur={(e) => (lastEvent = `blur: ${e.detail.code.length} chars`)}
+        on:history={(e) => (historyState = e.detail)}
+      />
+    </HighlightStyle>
+  </Column>
+
+  <Column xlg={10} lg={10} md={12} class="mb-5">
+    <div class="label-01 mb-3">
+      History stack ({historyState.entries.length}
+      snapshots, at #{historyState.index})
+    </div>
+    <div class="history">
+      {#each historyState.entries as entry, i}
+        <div
+          class="cell"
+          class:current={i === historyState.index}
+          class:future={i > historyState.index}
+          title={`#${i} · ${entry.size} chars`}
+        >
+          <div class="bar" style:height={`${Math.min(100, entry.size)}%`}></div>
+          <span class="num">{i}</span>
+        </div>
+      {/each}
+    </div>
+
+    <div class="label-01 mb-3" style="margin-top: 1.5rem">
+      Live bound value (bind:code)
+    </div>
+    <pre class="bound">{code}</pre>
+
+    <div class="label-01 mb-3" style="margin-top: 1rem">Last event</div>
+    <code>{lastEvent}</code>
+  </Column>
+</Row>
+
+<h3 class="mb-3">
+  Same <code>bind:code</code> in other themes. Edits in one block show up in all
+  of them.
+</h3>
+<Row class="mb-9">
+  {#each sideThemes as { name, theme }}
+    <Column xlg={10} lg={10} md={12} class="mb-5">
+      <div class="label-01 mb-3">{name}</div>
+      <HighlightStyle {theme}>
+        <HighlightEditable
+          language={typescript}
+          bind:code
+          --outline-color={outlineColor}
+          --outline-width={`${outlineWidth}px`}
+        />
+      </HighlightStyle>
+    </Column>
+  {/each}
+</Row>
+
+<h3 class="mb-3">Rendered with LineNumbers</h3>
+<Row class="mb-9">
+  <Column xlg={12} class="mb-5">
+    <HighlightStyle theme={githubDark}>
+      <Highlight language={typescript} {code} let:highlighted let:languageName>
+        <LineNumbers {highlighted} {languageName} />
+      </Highlight>
+    </HighlightStyle>
+  </Column>
+</Row>
+
+<style>
+  .toolbar {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1.5rem;
+    margin-bottom: 1rem;
+  }
+
+  .control {
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+  }
+
+  .control input[type="color"] {
+    width: 48px;
+    height: 28px;
+    padding: 0;
+    border: none;
+    background: none;
+    cursor: pointer;
+  }
+
+  .history {
+    display: flex;
+    align-items: flex-end;
+    gap: 3px;
+    height: 120px;
+    padding: 0.5rem;
+    background: #161616;
+    border-radius: 4px;
+    overflow-x: auto;
+  }
+
+  .cell {
+    position: relative;
+    display: flex;
+    flex-direction: column;
+    justify-content: flex-end;
+    align-items: center;
+    min-width: 16px;
+    height: 100%;
+  }
+
+  .bar {
+    width: 14px;
+    min-height: 2px;
+    background: #4589ff;
+    border-radius: 2px;
+  }
+
+  .cell.future .bar {
+    background: #525252;
+  }
+
+  .cell.current .bar {
+    background: #42be65;
+    box-shadow: 0 0 0 2px #42be6566;
+  }
+
+  .num {
+    margin-top: 2px;
+    font-size: 9px;
+    color: #8d8d8d;
+  }
+
+  .cell.current .num {
+    color: #42be65;
+  }
+
+  .bound {
+    padding: 1rem;
+    background: #161616;
+    color: #f4f4f4;
+    border-radius: 4px;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+</style>

--- a/www/components/HighlightEditable/Basic.svelte
+++ b/www/components/HighlightEditable/Basic.svelte
@@ -1,0 +1,13 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { HighlightEditable } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  let code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<HighlightEditable language={typescript} bind:code class={THEME_MODULE_NAME} />
+
+<p class="label-01" style="margin-top: 0.75rem">
+  bind:code: <code class="code">{code}</code>
+</p>

--- a/www/components/HighlightEditable/Commands.svelte
+++ b/www/components/HighlightEditable/Commands.svelte
@@ -1,0 +1,47 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import { HighlightEditable } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  let editor;
+  let code = "const add = (a, b) => a + b;";
+  let historyState = { canUndo: false, canRedo: false };
+</script>
+
+<HighlightEditable
+  bind:this={editor}
+  language={typescript}
+  bind:code
+  class={THEME_MODULE_NAME}
+  on:history={(e) => (historyState = e.detail)}
+/>
+
+<div style="display: flex; flex-wrap: wrap; gap: 0.5rem; margin-top: 0.5rem">
+  <Button
+    size="small"
+    kind="tertiary"
+    disabled={!historyState.canUndo}
+    on:click={() => editor.undo()}
+    >Undo</Button
+  >
+  <Button
+    size="small"
+    kind="tertiary"
+    disabled={!historyState.canRedo}
+    on:click={() => editor.redo()}
+    >Redo</Button
+  >
+  <Button size="small" kind="ghost" on:click={() => editor.indent()}>
+    Indent
+  </Button>
+  <Button size="small" kind="ghost" on:click={() => editor.outdent()}>
+    Outdent
+  </Button>
+  <Button size="small" kind="ghost" on:click={() => editor.insert("// TODO\n")}>
+    Insert
+  </Button>
+  <Button size="small" kind="danger-tertiary" on:click={() => editor.clear()}>
+    Clear
+  </Button>
+</div>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -6,6 +6,8 @@
   import CopyButtonLineNumbers from "@components/CopyButton/LineNumbers.svelte";
   import CopyButtonSlot from "@components/CopyButton/Slot.svelte";
   import CopyButtonStyleProps from "@components/CopyButton/StyleProps.svelte";
+  import EditableBasic from "@components/HighlightEditable/Basic.svelte";
+  import EditableCommands from "@components/HighlightEditable/Commands.svelte";
   import Basic from "@components/LineNumbers/Basic.svelte";
   import ContainerStyle from "@components/LineNumbers/ContainerStyle.svelte";
   import FocusLines from "@components/LineNumbers/FocusLines.svelte";
@@ -437,6 +439,57 @@
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <CopyButtonLangtag /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Editable</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">HighlightEditable</code>
+      is a
+      <code class="code">contenteditable</code>
+      code block. It re-highlights on every edit and keeps the caret where you
+      left it.
+    </p>
+    <p class="mb-5">
+      <code class="code">bind:code</code>
+      keeps your state in sync. Try typing in the block below.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <EditableBasic /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">Enter</code>
+      inserts a newline,
+      <code class="code">Tab</code>/<code class="code">Shift+Tab</code>
+      indent the selected lines, and <code class="code">Cmd/Ctrl+Z</code> /
+      <code class="code">Shift+Z</code>
+      undo and redo. Set <code class="code">tabSize</code> and
+      <code class="code">historyLimit</code>
+      to customize.
+    </p>
+    <p class="mb-5">
+      <code class="code">bind:this</code>
+      exposes
+      <code class="code">undo()</code>, <code class="code">redo()</code>,
+      <code class="code">indent()</code>, <code class="code">insert()</code>,
+      <code class="code">setCode()</code>, and
+      <code class="code">clear()</code>.
+      <code class="code">on:history</code>
+      reports
+      <code class="code">canUndo</code>
+      and <code class="code">canRedo</code>.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <EditableCommands /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Customize the focus outline with
+      <code class="code">--outline-color</code>,
+      <code class="code">--outline-width</code>, and
+      <code class="code">--outline-offset</code>.
+    </p>
+  </Column>
 </Row>
 
 <Row class="mb-9">

--- a/www/pages/preview-editable.astro
+++ b/www/pages/preview-editable.astro
@@ -1,0 +1,8 @@
+---
+import EditablePreview from "@components/EditablePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Editable highlight preview">
+  <EditablePreview client:idle />
+</Layout>


### PR DESCRIPTION
Adds `HighlightEditable`, a contenteditable code block that re-highlights on every edit while keeping the caret in place. It supports `bind:code`, undo/redo, Tab indent, and an imperative API via `bind:this`. Docs cover the README section, home page examples, and an unlisted `/preview-editable` page.

```svelte
<script>
  import { HighlightEditable } from "svelte-highlight";
  import typescript from "svelte-highlight/languages/typescript";
  import atomOneDark from "svelte-highlight/styles/atom-one-dark";

  let code = "const add = (a: number, b: number) => a + b";
</script>

<svelte:head>{@html atomOneDark}</svelte:head>

<HighlightEditable language={typescript} bind:code />
```

| | contenteditable (`HighlightEditable`) | ProseMirror |
| --- | --- | --- |
| Bundle size | Small. Reuses highlight.js and native editing. | Large. Full document model, schema, and plugin system. |
| Setup | Drop in with a language and theme. | Define a schema, plugins, and keymaps for code editing. |
| Syntax fidelity | Plain text in, HTML tokens out. Caret survives re-highlight. | Rich document tree. Syntax is one plugin among many. |
| Editing features | Undo/redo, indent, paste as plain text. No AST or multi-cursor. | Extensible commands, collaborative editing, decorations, custom node types. |
| Best for | Read-only blocks that need light inline editing. | Full code editors, notebooks, or structured documents. |

## Test plan

- [x] `bun lint`
- [x] e2e tests for typing, caret preservation, undo/redo, indent, bind:code
- [ ] Manual check on `/preview-editable` and home page Editable section