### PR TITLE
feat: add CodeWindow chrome wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,6 +257,29 @@ These apply when `langtag` is set to `true`.
 | --langtag-border-radius | Border radius of the langtag    | `0`           |
 | --langtag-padding       | Padding of the langtag          | `1em`         |
 
+### `CodeWindow` variables
+
+| Variable              | Description                              | Default value                       |
+| :-------------------- | :--------------------------------------- | :---------------------------------- |
+| --window-background   | Background color of the window body      | `#1e1e1e`                           |
+| --window-border       | Border of the window                     | `1px solid rgba(255, 255, 255, 0.1)`|
+| --window-radius       | Corner radius of the window              | `0`                                 |
+| --titlebar-gap        | Gap between items in the title bar       | `0.5em`                             |
+| --titlebar-padding    | Padding of the title bar                 | `0.65em 1em`                        |
+| --titlebar-background | Background color of the title bar        | `#2d2d2d`                           |
+| --titlebar-border     | Bottom border of the title bar           | `1px solid rgba(255, 255, 255, 0.1)`|
+| --titlebar-color      | Text color of the title bar              | `rgba(255, 255, 255, 0.6)`          |
+| --titlebar-font-family| Font family of the title bar             | `system-ui, -apple-system, sans-serif`|
+| --titlebar-font-size  | Font size of the title bar               | `0.8125em`                          |
+| --dot-gap             | Gap between the macOS traffic-light dots | `0.5em`                             |
+| --dot-size            | Diameter of the macOS traffic-light dots | `0.75em`                            |
+| --dot-close           | Color of the "close" traffic-light dot   | `#ff5f56`                           |
+| --dot-minimize        | Color of the "minimize" traffic-light dot| `#ffbd2e`                           |
+| --dot-maximize        | Color of the "maximize" traffic-light dot| `#27c93f`                           |
+| --prompt-font-family  | Font family of the terminal prompt       | `ui-monospace, monospace`           |
+| --prompt-font-weight  | Font weight of the terminal prompt       | `700`                               |
+| --prompt-color        | Color of the terminal prompt             | `inherit`                           |
+
 ## Svelte Syntax Highlighting
 
 Use the `HighlightSvelte` component for Svelte syntax highlighting.
@@ -823,6 +846,131 @@ Omit `code` to highlight the element's existing contents:
 ></pre>
 ```
 
+## Code Window
+
+Wrap a code block in `CodeWindow` to frame it with window chrome. It's purely cosmetic; the default slot renders your content unchanged.
+
+Use the `variant` prop to choose the chrome style: `"macos"` (default) renders traffic-light dots, `"terminal"` renders a prompt, and `"plain"` renders just the title bar. The optional `title` is shown in the title bar.
+
+```svelte
+<script>
+  import Highlight, { CodeWindow } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<CodeWindow variant="macos" title="example.ts">
+  <Highlight language={typescript} {code} />
+</CodeWindow>
+```
+
+### Terminal output
+
+Pair `variant="terminal"` with a shell language to frame command-line output:
+
+```svelte
+<script>
+  import Highlight, { CodeWindow } from "svelte-highlight";
+  import bash from "svelte-highlight/languages/bash";
+  import nord from "svelte-highlight/styles/nord";
+
+  const code = `$ npm install svelte-highlight
+
+added 1 package in 1.2s`;
+</script>
+
+<svelte:head>
+  {@html nord}
+</svelte:head>
+
+<CodeWindow variant="terminal" title="bash">
+  <Highlight language={bash} {code} />
+</CodeWindow>
+```
+
+### Theming the chrome
+
+Every part of the chrome is driven by CSS variables (see [`CodeWindow` variables](#codewindow-variables)). Pass them as style props to restyle the window without `:global` overrides. For example, give the default square window rounded corners with `--window-radius`:
+
+```svelte
+<CodeWindow
+  variant="macos"
+  title="example.ts"
+  --window-radius="12px"
+  --window-background="#0d1117"
+  --window-border="1px solid #30363d"
+  --titlebar-background="#161b22"
+  --titlebar-color="#8b949e"
+>
+  <Highlight language={typescript} {code} />
+</CodeWindow>
+```
+
+The macOS traffic-light dots are themable too. Recolor them, or mute them to a single neutral color:
+
+```svelte
+<CodeWindow
+  variant="macos"
+  title="example.ts"
+  --dot-close="#888"
+  --dot-minimize="#888"
+  --dot-maximize="#888"
+>
+  <Highlight language={typescript} {code} />
+</CodeWindow>
+```
+
+The `plain` variant drops the dots and prompt for a minimal titled bar:
+
+```svelte
+<CodeWindow variant="plain" title="example.ts">
+  <Highlight language={typescript} {code} />
+</CodeWindow>
+```
+
+### Composing with other components
+
+`CodeWindow` only frames its slot, so it composes with the rest of the library. Add `LineNumbers` inside it:
+
+```svelte
+<script>
+  import Highlight, { CodeWindow, LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const code = `const add = (a, b) => a + b;
+const sub = (a, b) => a - b;`;
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<CodeWindow variant="macos" title="math.ts">
+  <Highlight language={typescript} {code} let:highlighted>
+    <LineNumbers {highlighted} hideBorder />
+  </Highlight>
+</CodeWindow>
+```
+
+Or layer a `CopyButton` over it by wrapping both in a relatively-positioned container:
+
+```svelte
+<div style="position: relative">
+  <CodeWindow variant="macos" title="example.ts">
+    <Highlight language={typescript} {code} />
+  </CodeWindow>
+  <!-- Offset the button so it clears the title bar. -->
+  <CopyButton {code} --copy-top="3em" />
+</div>
+```
+
 ## Component API
 
 ### `Highlight`
@@ -897,6 +1045,17 @@ Omit `code` to highlight the element's existing contents:
   on:error={(e) => console.error(e.detail.error)}
 />
 ```
+
+### `CodeWindow`
+
+#### Props
+
+| Name    | Type                               | Default value |
+| :------ | :--------------------------------- | :------------ |
+| variant | `"macos" \| "terminal" \| "plain"` | `"macos"`     |
+| title   | `string`                           | `""`          |
+
+`$$restProps` are forwarded to the top-level `div` element.
 
 ### `HighlightSvelte`
 

--- a/src/CodeWindow.svelte
+++ b/src/CodeWindow.svelte
@@ -1,0 +1,111 @@
+<script>
+  /** @type {"macos" | "terminal" | "plain"} */
+  export let variant = "macos";
+
+  /** @type {string} */
+  export let title = "";
+</script>
+
+<div class="code-window {variant}" {...$$restProps}>
+  <div class="titlebar">
+    {#if variant === "macos"}
+      <span class="dots" aria-hidden="true">
+        <span class="dot close"></span>
+        <span class="dot minimize"></span>
+        <span class="dot maximize"></span>
+      </span>
+    {:else if variant === "terminal"}
+      <span class="prompt" aria-hidden="true">&gt;_</span>
+    {/if}
+
+    {#if title}
+      <span class="title">{title}</span>
+    {/if}
+  </div>
+
+  <div class="content">
+    <slot />
+  </div>
+</div>
+
+<style>
+  .code-window {
+    overflow: hidden;
+    background: var(--window-background, #1e1e1e);
+    border: var(--window-border, 1px solid rgba(255, 255, 255, 0.1));
+    border-radius: var(--window-radius, 0);
+  }
+
+  .titlebar {
+    position: relative;
+    display: flex;
+    align-items: center;
+    gap: var(--titlebar-gap, 0.5em);
+    padding: var(--titlebar-padding, 0.65em 1em);
+    background: var(--titlebar-background, #2d2d2d);
+    border-bottom: var(--titlebar-border, 1px solid rgba(255, 255, 255, 0.1));
+    color: var(--titlebar-color, rgba(255, 255, 255, 0.6));
+    font-family: var(
+      --titlebar-font-family,
+      system-ui,
+      -apple-system,
+      sans-serif
+    );
+    font-size: var(--titlebar-font-size, 0.8125em);
+  }
+
+  .dots {
+    display: flex;
+    align-items: center;
+    gap: var(--dot-gap, 0.5em);
+  }
+
+  .dot {
+    width: var(--dot-size, 0.75em);
+    height: var(--dot-size, 0.75em);
+    border-radius: 50%;
+  }
+
+  .dot.close {
+    background: var(--dot-close, #ff5f56);
+  }
+
+  .dot.minimize {
+    background: var(--dot-minimize, #ffbd2e);
+  }
+
+  .dot.maximize {
+    background: var(--dot-maximize, #27c93f);
+  }
+
+  .prompt {
+    font-family: var(--prompt-font-family, ui-monospace, monospace);
+    font-weight: var(--prompt-font-weight, 700);
+    color: var(--prompt-color, inherit);
+  }
+
+  .title {
+    /* Center the title across the full titlebar width, independent of the
+       leading dots/prompt, mirroring native window chrome. */
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
+    max-width: 70%;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+    pointer-events: none;
+  }
+
+  .plain .title {
+    /* No leading chrome, so left-align the title flush with the padding. */
+    position: static;
+    left: auto;
+    transform: none;
+    max-width: 100%;
+  }
+
+  .content {
+    overflow: auto;
+  }
+</style>

--- a/src/CodeWindow.svelte.d.ts
+++ b/src/CodeWindow.svelte.d.ts
@@ -1,0 +1,136 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+
+export type CodeWindowProps = HTMLAttributes<HTMLDivElement> & {
+  /**
+   * Specify the window chrome style.
+   * @default "macos"
+   */
+  variant?: "macos" | "terminal" | "plain";
+
+  /**
+   * Specify the title shown in the title bar.
+   * @default ""
+   */
+  title?: string;
+
+  /**
+   * Customize the background color of the window body.
+   * @default "#1e1e1e"
+   */
+  "--window-background"?: string;
+
+  /**
+   * Customize the border of the window.
+   * @default "1px solid rgba(255, 255, 255, 0.1)"
+   */
+  "--window-border"?: string;
+
+  /**
+   * Customize the corner radius of the window.
+   * @default "0"
+   */
+  "--window-radius"?: string;
+
+  /**
+   * Customize the gap between items in the title bar.
+   * @default "0.5em"
+   */
+  "--titlebar-gap"?: string;
+
+  /**
+   * Customize the padding of the title bar.
+   * @default "0.65em 1em"
+   */
+  "--titlebar-padding"?: string;
+
+  /**
+   * Customize the background color of the title bar.
+   * @default "#2d2d2d"
+   */
+  "--titlebar-background"?: string;
+
+  /**
+   * Customize the bottom border of the title bar.
+   * @default "1px solid rgba(255, 255, 255, 0.1)"
+   */
+  "--titlebar-border"?: string;
+
+  /**
+   * Customize the text color of the title bar.
+   * @default "rgba(255, 255, 255, 0.6)"
+   */
+  "--titlebar-color"?: string;
+
+  /**
+   * Customize the font family of the title bar.
+   * @default "system-ui, -apple-system, sans-serif"
+   */
+  "--titlebar-font-family"?: string;
+
+  /**
+   * Customize the font size of the title bar.
+   * @default "0.8125em"
+   */
+  "--titlebar-font-size"?: string;
+
+  /**
+   * Customize the gap between the macOS traffic-light dots.
+   * @default "0.5em"
+   */
+  "--dot-gap"?: string;
+
+  /**
+   * Customize the diameter of the macOS traffic-light dots.
+   * @default "0.75em"
+   */
+  "--dot-size"?: string;
+
+  /**
+   * Customize the color of the "close" traffic-light dot.
+   * @default "#ff5f56"
+   */
+  "--dot-close"?: string;
+
+  /**
+   * Customize the color of the "minimize" traffic-light dot.
+   * @default "#ffbd2e"
+   */
+  "--dot-minimize"?: string;
+
+  /**
+   * Customize the color of the "maximize" traffic-light dot.
+   * @default "#27c93f"
+   */
+  "--dot-maximize"?: string;
+
+  /**
+   * Customize the font family of the terminal prompt.
+   * @default "ui-monospace, monospace"
+   */
+  "--prompt-font-family"?: string;
+
+  /**
+   * Customize the font weight of the terminal prompt.
+   * @default 700
+   */
+  "--prompt-font-weight"?: string | number;
+
+  /**
+   * Customize the color of the terminal prompt.
+   * @default "inherit"
+   */
+  "--prompt-color"?: string;
+};
+
+export type CodeWindowEvents = {};
+
+export type CodeWindowSlots = {
+  default: {};
+};
+
+export default class CodeWindow extends SvelteComponentTyped<
+  CodeWindowProps,
+  CodeWindowEvents,
+  CodeWindowSlots
+> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,6 @@
 export type { HighlightActionParameters } from "./action";
 export { highlight } from "./action";
+export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { default as Highlight, default } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
 export { highlight } from "./action.js";
+export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { default, default as Highlight } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";

--- a/tests/e2e/CodeWindow.test.svelte
+++ b/tests/e2e/CodeWindow.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Highlight, { CodeWindow } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<CodeWindow variant="macos" title="example.ts" data-testid="macos">
+  <Highlight language={typescript} {code} />
+</CodeWindow>
+
+<CodeWindow variant="terminal" title="bash" data-testid="terminal">
+  <Highlight language={typescript} {code} />
+</CodeWindow>
+
+<CodeWindow variant="plain" title="plain.ts" data-testid="plain">
+  <Highlight language={typescript} {code} />
+</CodeWindow>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1,4 +1,5 @@
 import { expect, test } from "@playwright/experimental-ct-svelte";
+import CodeWindow from "./CodeWindow.test.svelte";
 import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
 import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
 import CopyButton from "./CopyButton.test.svelte";
@@ -36,6 +37,37 @@ test("Scoped styles - two themes coexist without bleed", async ({
   // a11y-dark keyword is #dcc6e0; github keyword is #d73a49.
   await expect(keywordA).toHaveCSS("color", "rgb(220, 198, 224)");
   await expect(keywordB).toHaveCSS("color", "rgb(215, 58, 73)");
+});
+
+test("CodeWindow - renders each variant wrapping a Highlight", async ({
+  mount,
+  page,
+}) => {
+  await mount(CodeWindow);
+
+  const macos = page.getByTestId("macos");
+  const terminal = page.getByTestId("terminal");
+  const plain = page.getByTestId("plain");
+
+  // The slotted code block is rendered inside each window.
+  await expect(macos.locator(".hljs-title")).toHaveText("add");
+  await expect(terminal.locator(".hljs-title")).toHaveText("add");
+  await expect(plain.locator(".hljs-title")).toHaveText("add");
+
+  // Titles are shown in every variant's title bar.
+  await expect(macos.locator(".title")).toHaveText("example.ts");
+  await expect(terminal.locator(".title")).toHaveText("bash");
+  await expect(plain.locator(".title")).toHaveText("plain.ts");
+
+  // macOS shows three traffic-light dots; other variants do not.
+  await expect(macos.locator(".dot")).toHaveCount(3);
+  await expect(terminal.locator(".dot")).toHaveCount(0);
+  await expect(plain.locator(".dot")).toHaveCount(0);
+
+  // Terminal shows a prompt; macOS and plain do not.
+  await expect(terminal.locator(".prompt")).toBeVisible();
+  await expect(macos.locator(".prompt")).toHaveCount(0);
+  await expect(plain.locator(".prompt")).toHaveCount(0);
 });
 
 test("Highlight", async ({ mount, page }) => {

--- a/www/components/CodeWindowPreview.svelte
+++ b/www/components/CodeWindowPreview.svelte
@@ -1,0 +1,126 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import Highlight, {
+    CodeWindow,
+    HighlightStyle,
+    HighlightSvelte,
+  } from "svelte-highlight";
+  import bash from "svelte-highlight/languages/bash";
+  import json from "svelte-highlight/languages/json";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+  import githubDark from "svelte-highlight/styles/github-dark";
+  import nord from "svelte-highlight/styles/nord";
+
+  const jsonCode = `{
+  "name": "svelte-highlight",
+  "version": "7.12.0",
+  "type": "module"
+}`;
+
+  const bashCode = `$ npm install svelte-highlight
+
+added 1 package in 1.2s
+$ npm run build`;
+
+  const tsCode = "const add = (a: number, b: number) => a + b;";
+
+  const snippet = `<script>
+  import Highlight, { CodeWindow } from "svelte-highlight";
+  import json from "svelte-highlight/languages/json";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = '{ "name": "svelte-highlight" }';
+<\/script>
+
+<svelte:head>
+  {@html atomOneDark}
+<\/svelte:head>
+
+<CodeWindow variant="macos" title="package.json">
+  <Highlight language={json} {code} />
+</CodeWindow>`;
+
+  const customSnippet = `<CodeWindow
+  variant="macos"
+  title="example.ts"
+  --window-radius="12px"
+  --window-background="#0d1117"
+  --titlebar-background="#161b22"
+  --titlebar-color="#8b949e"
+>
+  <Highlight language={typescript} {code} />
+</CodeWindow>`;
+
+  // Each example pairs a variant with its own language and theme. Distinct
+  // themes mean distinct scope classes, so each HighlightStyle injects its
+  // own stylesheet.
+  const examples = [
+    {
+      variant: "macos",
+      title: "package.json",
+      language: json,
+      code: jsonCode,
+      theme: atomOneDark,
+    },
+    {
+      variant: "terminal",
+      title: "bash",
+      language: bash,
+      code: bashCode,
+      theme: nord,
+    },
+    {
+      variant: "plain",
+      title: "example.ts",
+      language: typescript,
+      code: tsCode,
+      theme: githubDark,
+    },
+  ];
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+<p class="mb-5">
+  Switch the <code class="code">variant</code> prop between
+  <code class="code">"macos"</code>, <code class="code">"terminal"</code>, and
+  <code class="code">"plain"</code>. Each block below also pairs it with a
+  different language and theme:
+</p>
+
+{#each examples as { variant, title, language, code, theme }}
+  <div class="mb-5">
+    <HighlightStyle {theme}>
+      <CodeWindow {variant} {title}>
+        <Highlight {language} {code} />
+      </CodeWindow>
+    </HighlightStyle>
+  </div>
+{/each}
+
+<p class="mb-5">
+  Every part of the chrome is themable with style props. The window is square by
+  default; give it rounded corners with
+  <code class="code">--window-radius</code>
+  and recolor the body and title bar:
+</p>
+
+<div class="mb-5">
+  <HighlightSvelte code={customSnippet} class={THEME_MODULE_NAME} />
+</div>
+
+<HighlightStyle theme={githubDark}>
+  <CodeWindow
+    variant="macos"
+    title="example.ts"
+    --window-radius="12px"
+    --window-background="#0d1117"
+    --titlebar-background="#161b22"
+    --titlebar-color="#8b949e"
+  >
+    <Highlight language={typescript} code={tsCode} />
+  </CodeWindow>
+</HighlightStyle>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -1,5 +1,6 @@
 <script>
   import CodeSnippet from "@components/CodeSnippet.svelte";
+  import CodeWindowPreview from "@components/CodeWindowPreview.svelte";
   import CopyButtonBasic from "@components/CopyButton/Basic.svelte";
   import CopyButtonCustomFunction from "@components/CopyButton/CustomFunction.svelte";
   import CopyButtonLangtag from "@components/CopyButton/Langtag.svelte";
@@ -439,6 +440,33 @@
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <CopyButtonLangtag /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Code Window</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Wrap a code block in the <code class="code">CodeWindow</code> component to
+      frame it with window chrome. It is purely cosmetic—the default slot
+      renders your content unchanged.
+    </p>
+    <p class="mb-5">
+      Use the <code class="code">variant</code> prop to choose the chrome style:
+      <code class="code">"macos"</code>
+      (default) renders traffic-light dots,
+      <code class="code">"terminal"</code>
+      renders a prompt, and <code class="code">"plain"</code> renders just the
+      title bar. The optional <code class="code">title</code> is shown in the
+      title bar.
+    </p>
+    <p class="mb-5">
+      The chrome is themable with <code class="code">--window-*</code>,
+      <code class="code">--titlebar-*</code>, and
+      <code class="code">--dot-*</code>
+      style props.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CodeWindowPreview /> </Column>
 </Row>
 
 <Row class="mb-9">


### PR DESCRIPTION
Adds a cosmetic `CodeWindow` component that frames a slotted code block with window chrome. The `variant` prop switches between macOS traffic-light dots, a terminal prompt, and a plain title bar, and the chrome is themable via CSS variables. The change is fully additive and backwards compatible.

## Usage

```svelte
<script>
  import Highlight, { CodeWindow } from "svelte-highlight";
  import json from "svelte-highlight/languages/json";
  import atomOneDark from "svelte-highlight/styles/atom-one-dark";

  const code = '{ "name": "svelte-highlight" }';
</script>

<svelte:head>
  {@html atomOneDark}
</svelte:head>

<CodeWindow variant="macos" title="package.json">
  <Highlight language={json} {code} />
</CodeWindow>
```

The `variant` prop also supports `"terminal"` and `"plain"`:

```svelte
<CodeWindow variant="terminal" title="bash">
  <Highlight language={bash} code={"$ npm install svelte-highlight"} />
</CodeWindow>
```

Theme the chrome with CSS variables:

```svelte
<CodeWindow
  variant="macos"
  title="example.ts"
  style="--window-background: #000; --titlebar-background: #111; --window-radius: 8px;"
>
  <Highlight language={typescript} {code} />
</CodeWindow>
```

## Props

| Name    | Type                               | Default   |
| :------ | :--------------------------------- | :-------- |
| variant | `"macos" \| "terminal" \| "plain"` | `"macos"` |
| title   | `string`                           | `""`      |
