### PR TITLE
feat: add loadLanguage dynamic loader helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -816,6 +816,47 @@ In the example below, the `HighlightAuto` component and injected styles are dyna
 />
 ```
 
+### Loading a language by name
+
+The example above imports a specific language as a static string, which lets the bundler split out only the grammars you reference. When the language is known only at **runtime** — a Markdown fence (` ```ts `), an API field, or a user-selected value — use the `loadLanguage` helper to import a grammar by name:
+
+```svelte
+<script>
+  import { Highlight, loadLanguage } from "svelte-highlight";
+  import github from "svelte-highlight/styles/github";
+
+  // The language name is not known until runtime.
+  export let language = "typescript";
+  export let code = "const add = (a, b) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+{#await loadLanguage(language) then grammar}
+  <Highlight {code} language={grammar} />
+{:catch}
+  <pre>{code}</pre>
+{/await}
+```
+
+`loadLanguage` accepts a [supported language name](SUPPORTED_LANGUAGES.md), dynamically imports its grammar, and resolves with the language object. It rejects with an `Unknown language` error for an unrecognized name, so handle the `{:catch}` block (or `.catch`) when the name comes from untrusted input.
+
+> **Note:** Because the imported name is dynamic, the bundler cannot prune unused grammars and will emit a chunk for every language. Prefer a static `import` when the language is known ahead of time, and reach for `loadLanguage` only when it is not.
+
+A practical case is rendering Markdown, where each fenced block declares its own language:
+
+```js
+import { loadLanguage } from "svelte-highlight";
+
+// e.g. from a Markdown fence: ```ts → "typescript"
+async function highlightFence(fenceLang, code) {
+  const grammar = await loadLanguage(fenceLang);
+  return { code, language: grammar };
+}
+```
+
 ## Action
 
 Use the `highlight` action to highlight existing `<pre><code>` markup in place. This is useful for progressively enhancing server-rendered content (e.g. markdown) without swapping in a component.

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,3 +9,4 @@ export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export type { LanguageName, LanguageType } from "./languages";
+export { loadLanguage } from "./load-language";

--- a/src/index.js
+++ b/src/index.js
@@ -7,3 +7,4 @@ export { default as HighlightEditable } from "./HighlightEditable.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
+export { loadLanguage } from "./load-language.js";

--- a/src/load-language.d.ts
+++ b/src/load-language.d.ts
@@ -1,0 +1,11 @@
+import type { LanguageName, LanguageType } from "./languages";
+
+/**
+ * Dynamically load a single highlight.js grammar by name.
+ *
+ * Use when the language is only known at runtime. When it is known at author
+ * time, prefer a static import so the bundler can prune unused grammars.
+ */
+export declare function loadLanguage(
+  name: LanguageName,
+): Promise<LanguageType<string>>;

--- a/src/load-language.js
+++ b/src/load-language.js
@@ -1,0 +1,21 @@
+/**
+ * Dynamically load a single highlight.js grammar by name.
+ *
+ * Ergonomic, name-keyed wrapper over the per-language dynamic imports the
+ * package already supports (`import("svelte-highlight/languages/<name>")`).
+ * Use this when the language is only known at runtime (e.g. from a markdown
+ * fence, an API field, or a user selection). When the language is known at
+ * author time, prefer a static `import`/`await import` so the bundler can ship
+ * only the grammars you reference.
+ *
+ * @param {import("./languages").LanguageName} name
+ * @returns {Promise<import("./languages").LanguageType<string>>}
+ */
+export async function loadLanguage(name) {
+  try {
+    const module = await import(`./languages/${name}.js`);
+    return module.default;
+  } catch (cause) {
+    throw new Error(`Unknown language: "${name}"`, { cause });
+  }
+}

--- a/tests/load-language.test.ts
+++ b/tests/load-language.test.ts
@@ -1,0 +1,16 @@
+import { loadLanguage } from "../src/load-language.js";
+
+describe("loadLanguage", () => {
+  it("loads a known language", async () => {
+    const language = await loadLanguage("typescript");
+    expect(language.name).toBe("typescript");
+    expect(typeof language.register).toBe("function");
+  });
+
+  it("rejects an unknown language", async () => {
+    // @ts-expect-error — intentionally invalid name
+    await expect(loadLanguage("not-a-language")).rejects.toThrow(
+      /Unknown language/,
+    );
+  });
+});

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -610,6 +610,54 @@
   </Column>
 </Row>
 
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Loading a Language by Name</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Import a language as a static string when you know it ahead of time—the
+      bundler can then split out only the grammars you reference.
+    </p>
+    <p class="mb-5">
+      When the language is known only at <strong>runtime</strong>—a Markdown
+      fence, an API field, or a user-selected value—use the
+      <code class="code">loadLanguage</code>
+      helper to import a grammar by name. It resolves with the language object
+      and rejects with an <code class="code">Unknown language</code> error for
+      an unrecognized name.
+    </p>
+    <InlineNotification
+      lowContrast
+      hideCloseButton
+      kind="info"
+      title="Note:"
+      subtitle="Because the imported name is dynamic, the bundler emits a chunk for every language. Prefer a static import when the language is known ahead of time."
+    />
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <HighlightSvelte
+      code={`<script>
+  import { Highlight, loadLanguage } from "svelte-highlight";
+  import github from "svelte-highlight/styles/github";
+
+  // The language name is not known until runtime.
+  export let language = "typescript";
+  export let code = "const add = (a, b) => a + b;";
+<\/script>
+
+<svelte:head>
+  {@html github}
+<\/svelte:head>
+
+{#await loadLanguage(language) then grammar}
+  <Highlight {code} language={grammar} \/>
+{:catch}
+  <pre>{code}<\/pre>
+{/await}`}
+      class={THEME_MODULE_NAME}
+    />
+  </Column>
+</Row>
+
 <Row>
   <Column xlg={12}><h3>Examples</h3></Column>
   <Column xlg={6} lg={6} md={12}>


### PR DESCRIPTION
Adds a `loadLanguage(name)` helper that dynamically imports a single highlight.js grammar by name and resolves with the language object, rejecting with an `Unknown language` error for an unrecognized name. This fills a gap the existing static-import code-splitting pattern cannot: loading a grammar whose name is only known at runtime, such as a Markdown fence, an API field, or a user selection. Note that because the imported name is dynamic, the bundler emits a chunk per language, so a static import is still preferable when the language is known ahead of time. Includes unit tests plus README and docs-site sections.

```svelte
<script>
  import { Highlight, loadLanguage } from "svelte-highlight";
  import github from "svelte-highlight/styles/github";

  export let language = "typescript";
  export let code = "const add = (a, b) => a + b;";
</script>

<svelte:head>
  {@html github}
</svelte:head>

{#await loadLanguage(language) then grammar}
  <Highlight {code} language={grammar} />
{:catch}
  <pre>{code}</pre>
{/await}
```
