### PR TITLE
Add Typewriter component for typing animations

### DIFF
--- a/README.md
+++ b/README.md
@@ -1012,6 +1012,45 @@ Or layer a `CopyButton` over it by wrapping both in a relatively-positioned cont
 </div>
 ```
 
+## Animation
+
+Use `Typewriter` inside `Highlight`'s default slot with the `highlighted` prop. It prints the code one character at a time, syntax highlighting included. A blinking caret marks the end of the typed text and hides when typing stops.
+
+Unrevealed text stays in the layout but invisible, so the block is full height from the start. Content below won't jump as characters appear. You don't need a `min-height` hack.
+
+```svelte
+<script>
+  import Highlight, { Typewriter } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<Highlight language={typescript} {code} let:highlighted>
+  <Typewriter {highlighted} />
+</Highlight>
+```
+
+Set `speed` (milliseconds per character) and pause with `play`. Turn `play` back on to pick up where you left off. A new `highlighted` value starts over from the first character. Fire `on:done` when the last character is visible.
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <Typewriter
+    {highlighted}
+    speed={50}
+    {play}
+    on:done={() => console.log("revealed")}
+  />
+</Highlight>
+```
+
+With `prefers-reduced-motion`, the full block shows immediately and `on:done` runs right away. Customize the caret with `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink`.
+
 ## Component API
 
 ### `Highlight`
@@ -1199,6 +1238,28 @@ Use `bind:this`, then call `undo()`, `redo()`, `focus()`, `selectAll()`, `insert
   on:change={(e) => console.log(e.detail.code)}
   on:history={(e) => console.log(e.detail.canUndo, e.detail.canRedo)}
 />
+```
+
+### `Typewriter`
+
+#### Props
+
+| Name        | Type      | Default value |
+| :---------- | :-------- | :------------ |
+| highlighted | `string`  | `""`          |
+| speed       | `number`  | `30`          |
+| play        | `boolean` | `true`        |
+
+`$$restProps` are forwarded to the top-level `pre` element.
+
+#### Dispatched Events
+
+- **on:done**: fires when typing finishes, or immediately when reduced motion is on
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <Typewriter {highlighted} on:done={() => console.log("revealed")} />
+</Highlight>
 ```
 
 ## [Supported Languages](SUPPORTED_LANGUAGES.md)

--- a/src/CodeWindow.svelte
+++ b/src/CodeWindow.svelte
@@ -86,7 +86,7 @@
 
   .title {
     /* Center the title across the full titlebar width, independent of the
-       leading dots/prompt, mirroring native window chrome. */
+         leading dots/prompt, mirroring native window chrome. */
     position: absolute;
     left: 50%;
     transform: translateX(-50%);

--- a/src/Typewriter.svelte
+++ b/src/Typewriter.svelte
@@ -1,0 +1,250 @@
+<script>
+  /**
+   * Highlighted HTML from `Highlight`'s `highlighted` slot prop.
+   * @type {string}
+   */
+  export let highlighted = "";
+
+  /**
+   * Milliseconds between characters.
+   * @type {number}
+   */
+  export let speed = 30;
+
+  /**
+   * Pause with `false`; resume picks up where it left off.
+   * @type {boolean}
+   */
+  export let play = true;
+
+  import { createEventDispatcher, onMount } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  /** Captures the tag name from an opening or closing tag. */
+  const TAG_NAME = /^<\/?\s*([a-zA-Z0-9-]+)/;
+
+  /** @type {boolean} */
+  let mounted = false;
+
+  /** @type {boolean} */
+  let reducedMotion = false;
+
+  /** @type {boolean} */
+  let doneFired = false;
+
+  /** Number of visible characters currently revealed. @type {number} */
+  let revealed = 0;
+
+  /** @type {ReturnType<typeof setInterval> | undefined} */
+  let timerId;
+
+  /** @type {string | undefined} */
+  let prevHighlighted;
+
+  /**
+   * Split highlighted HTML into renderable units. Tag units carry no visible
+   * weight; each text character or HTML entity counts as a single visible unit
+   * so typing advances one visible character at a time without splitting markup.
+   * @param {string} html
+   */
+  function tokenize(html) {
+    /** @type {{ raw: string; visible: number; kind?: string; name?: string }[]} */
+    const units = [];
+    const n = html.length;
+    let i = 0;
+
+    while (i < n) {
+      const ch = html[i];
+
+      if (ch === "<") {
+        const end = html.indexOf(">", i);
+        if (end === -1) {
+          // Malformed tail. Treat as plain text.
+          units.push({ raw: html.slice(i), visible: 1 });
+          break;
+        }
+        const raw = html.slice(i, end + 1);
+        const kind =
+          raw[1] === "/"
+            ? "close"
+            : raw[raw.length - 2] === "/"
+              ? "self"
+              : "open";
+        const match = TAG_NAME.exec(raw);
+        units.push({ raw, visible: 0, kind, name: match ? match[1] : "" });
+        i = end + 1;
+      } else if (ch === "&") {
+        // Treat an entity (e.g. `&lt;`) as one visible character.
+        const end = html.indexOf(";", i);
+        if (end !== -1 && end - i <= 10) {
+          units.push({ raw: html.slice(i, end + 1), visible: 1 });
+          i = end + 1;
+        } else {
+          units.push({ raw: ch, visible: 1 });
+          i += 1;
+        }
+      } else {
+        units.push({ raw: ch, visible: 1 });
+        i += 1;
+      }
+    }
+
+    return units;
+  }
+
+  /**
+   * Split at the first `count` visible characters. `head` is what's shown;
+   * `tail` is the rest. Open tags at the cut get closed in `head` and reopened
+   * in `tail`. `tail` renders hidden but still takes up space, so layout
+   * doesn't shift as characters appear.
+   * @param {ReturnType<typeof tokenize>} list
+   * @param {number} count
+   */
+  function split(list, count) {
+    let head = "";
+    let shown = 0;
+    /** @type {{ raw: string; name: string }[]} */
+    const open = [];
+    let i = 0;
+
+    for (; i < list.length; i++) {
+      const unit = list[i];
+      if (shown >= count) break;
+      head += unit.raw;
+      if (unit.visible === 0) {
+        if (unit.kind === "open")
+          open.push({ raw: unit.raw, name: unit.name ?? "" });
+        else if (unit.kind === "close") open.pop();
+      } else {
+        shown += unit.visible;
+      }
+    }
+
+    // Close the still-open tags so `head` is well-formed...
+    let headClose = "";
+    for (let k = open.length - 1; k >= 0; k--)
+      headClose += `</${open[k].name}>`;
+
+    // ...and reopen the same tags at the start of `tail` so it is too.
+    let tail = "";
+    for (const tag of open) tail += tag.raw;
+    for (; i < list.length; i++) tail += list[i].raw;
+
+    return { head: head + headClose, tail };
+  }
+
+  function clearTimer() {
+    clearInterval(timerId);
+    timerId = undefined;
+  }
+
+  function fireDone() {
+    if (!doneFired && total > 0 && revealed >= total) {
+      doneFired = true;
+      dispatch("done");
+    }
+  }
+
+  function tick() {
+    if (revealed < total) revealed += 1;
+    if (revealed >= total) {
+      clearTimer();
+      fireDone();
+    }
+  }
+
+  /** Start, stop, or retime the typing interval from current inputs. */
+  function sync() {
+    clearTimer();
+    if (!mounted) return;
+
+    if (reducedMotion) {
+      // With reduced motion, show everything at once.
+      if (revealed !== total) revealed = total;
+      fireDone();
+      return;
+    }
+
+    if (play && revealed < total) {
+      timerId = setInterval(tick, Math.max(0, speed));
+    } else if (revealed >= total) {
+      fireDone();
+    }
+  }
+
+  $: units = tokenize(highlighted);
+  $: total = units.reduce((sum, unit) => sum + unit.visible, 0);
+
+  // Restart typing when the source content changes.
+  $: if (highlighted !== prevHighlighted) {
+    prevHighlighted = highlighted;
+    doneFired = false;
+    revealed = reducedMotion ? total : 0;
+    sync();
+  }
+
+  // Reconfigure (but never restart per-tick) when playback inputs change.
+  // The array makes the dependencies explicit without the comma operator.
+  $: {
+    void [play, speed, mounted, reducedMotion, total];
+    sync();
+  }
+
+  // Before mount (incl. SSR) render the full content so it is visible without
+  // JS; once mounted, type out character by character from `revealed`.
+  $: parts = mounted ? split(units, revealed) : { head: highlighted, tail: "" };
+  $: showCaret = mounted && !reducedMotion && revealed < total;
+
+  onMount(() => {
+    mounted = true;
+
+    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
+    reducedMotion = query.matches;
+    const onChange = (event) => {
+      reducedMotion = event.matches;
+    };
+    query.addEventListener?.("change", onChange);
+
+    return () => {
+      query.removeEventListener?.("change", onChange);
+      clearTimer();
+    };
+  });
+</script>
+
+<pre
+  {...$$restProps}
+><code class:hljs={true}>{@html parts.head}{#if showCaret}<span
+      class="typewriter-caret"
+      aria-hidden="true"
+    ></span>{/if}<span class="typewriter-rest" aria-hidden="true"
+    >{@html parts.tail}</span></code></pre>
+
+<style>
+  .typewriter-rest {
+    visibility: hidden;
+  }
+
+  .typewriter-caret {
+    display: inline-block;
+    width: var(--caret-width, 0.6em);
+    height: var(--caret-height, 1.1em);
+    margin-left: var(--caret-gap, 1px);
+    vertical-align: text-bottom;
+    background: var(--caret-color, currentColor);
+    animation: typewriter-blink var(--caret-blink, 1s) step-end infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .typewriter-caret {
+      animation: none;
+    }
+  }
+
+  @keyframes typewriter-blink {
+    50% {
+      opacity: 0;
+    }
+  }
+</style>

--- a/src/Typewriter.svelte.d.ts
+++ b/src/Typewriter.svelte.d.ts
@@ -1,0 +1,65 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+
+export type TypewriterProps = HTMLAttributes<HTMLPreElement> & {
+  /**
+   * Highlighted HTML from `Highlight`'s `highlighted` slot prop.
+   * @default ""
+   */
+  highlighted?: string;
+
+  /**
+   * Milliseconds between characters.
+   * @default 30
+   */
+  speed?: number;
+
+  /**
+   * Pause with `false`; resume picks up where it left off.
+   * @default true
+   */
+  play?: boolean;
+
+  /**
+   * Width of the blinking caret.
+   * @default "0.6em"
+   */
+  "--caret-width"?: string;
+
+  /**
+   * Height of the blinking caret.
+   * @default "1.1em"
+   */
+  "--caret-height"?: string;
+
+  /**
+   * Gap between typed text and the caret.
+   * @default "1px"
+   */
+  "--caret-gap"?: string;
+
+  /**
+   * Color of the blinking caret.
+   * @default "currentColor"
+   */
+  "--caret-color"?: string;
+
+  /**
+   * Duration of one caret blink cycle.
+   * @default "1s"
+   */
+  "--caret-blink"?: string;
+};
+
+export type TypewriterEvents = {
+  /**
+   * Fires when typing finishes, or immediately when reduced motion is on.
+   */
+  done: CustomEvent<null>;
+};
+
+export default class Typewriter extends SvelteComponentTyped<
+  TypewriterProps,
+  TypewriterEvents,
+  Record<string, never>
+> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,3 +10,4 @@ export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export type { LanguageName, LanguageType } from "./languages";
 export { loadLanguage } from "./load-language";
+export { default as Typewriter } from "./Typewriter.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -8,3 +8,4 @@ export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export { loadLanguage } from "./load-language.js";
+export { default as Typewriter } from "./Typewriter.svelte";

--- a/tests/e2e/Typewriter.test.svelte
+++ b/tests/e2e/Typewriter.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import Highlight, { Typewriter } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  export let speed = 1;
+
+  const code = "const add = (a: number, b: number) => a + b;";
+
+  let done = 0;
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<Highlight language={typescript} {code} let:highlighted>
+  <Typewriter
+    {highlighted}
+    {speed}
+    data-testid="tw"
+    on:done={() => (done += 1)}
+  />
+</Highlight>
+
+<span data-testid="done">{done}</span>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -19,6 +19,7 @@ import LineNumbers from "./LineNumbers.test.svelte";
 import LineNumbersWrapLines from "./LineNumbers.wrapLines.test.svelte";
 import ScopedStyle from "./ScopedStyle.test.svelte";
 import SvelteHighlight from "./SvelteHighlight.test.svelte";
+import Typewriter from "./Typewriter.test.svelte";
 
 test.use({ viewport: { width: 1200, height: 600 } });
 
@@ -562,6 +563,40 @@ test("HighlightEditable - focus outline uses the --outline-color variable", asyn
   const editor = page.locator("[contenteditable='true']");
   await editor.click();
   await expect(editor).toHaveCSS("outline-color", "rgb(255, 0, 0)");
+});
+
+test("Typewriter - animates then settles to the full highlighted content", async ({
+  mount,
+  page,
+}) => {
+  await mount(Typewriter);
+
+  const tw = page.getByTestId("tw");
+
+  // Mid-animation, partial splits can duplicate open tags (e.g. `add` → `a` + `dd`).
+  // Wait for `done` before asserting final highlighted structure.
+  await expect(page.getByTestId("done")).toHaveText("1");
+
+  await expect(tw.locator(".hljs-keyword").first()).toHaveText("const");
+  await expect(tw.locator(".hljs-title.function_")).toHaveText("add");
+  await expect(tw).toContainText(
+    "const add = (a: number, b: number) => a + b;",
+  );
+});
+
+test("Typewriter - reduced motion renders instantly", async ({
+  mount,
+  page,
+}) => {
+  await page.emulateMedia({ reducedMotion: "reduce" });
+
+  // At speed 1000, typing would take ~44s without reduced motion. With reduced
+  // motion the full content (and `done`) must appear immediately.
+  await mount(Typewriter, { props: { speed: 1000 } });
+
+  const tw = page.getByTestId("tw");
+  await expect(page.getByTestId("done")).toHaveText("1");
+  await expect(tw.locator(".hljs-title.function_")).toHaveText("add");
 });
 
 test("HighlightEditable - two instances share the same bound code", async ({

--- a/www/components/Typewriter/Basic.svelte
+++ b/www/components/Typewriter/Basic.svelte
@@ -1,0 +1,48 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import Highlight, { HighlightSvelte, Typewriter } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code = `const greet = (name) => {
+  return \`Hello, \${name}!\`;
+};`;
+
+  const snippet = `<script>
+  import Highlight, { Typewriter } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const code = "const add = (a, b) => a + b;";
+<\/script>
+
+<svelte:head>
+  {@html github}
+<\/svelte:head>
+
+<Highlight language={typescript} {code} let:highlighted>
+  <Typewriter {highlighted} />
+</Highlight>`;
+
+  // Bump to remount and replay typing.
+  let runId = 0;
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+{#key runId}
+  <Highlight language={typescript} {code} let:highlighted>
+    <Typewriter {highlighted} class={THEME_MODULE_NAME} />
+  </Highlight>
+{/key}
+
+<Button
+  size="small"
+  kind="tertiary"
+  style="margin-top: 0.75rem"
+  on:click={() => (runId += 1)}
+>
+  Replay
+</Button>

--- a/www/components/Typewriter/Controls.svelte
+++ b/www/components/Typewriter/Controls.svelte
@@ -1,0 +1,60 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button, Slider, Toggle } from "carbon-components-svelte";
+  import Highlight, { CodeWindow, Typewriter } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code = `async function load(url) {
+  const res = await fetch(url);
+  return res.json();
+}`;
+
+  let speed = 40;
+  let play = true;
+  let done = false;
+  let runId = 0;
+
+  function replay() {
+    done = false;
+    play = true;
+    runId += 1;
+  }
+</script>
+
+{#key runId}
+  <CodeWindow variant="macos" title="load.ts">
+    <Highlight language={typescript} {code} let:highlighted>
+      <Typewriter
+        {highlighted}
+        {speed}
+        {play}
+        class={THEME_MODULE_NAME}
+        --caret-color="#2996cf"
+        --caret-width="2px"
+        on:done={() => (done = true)}
+      />
+    </Highlight>
+  </CodeWindow>
+{/key}
+
+<div
+  style="display: flex; flex-wrap: wrap; align-items: flex-end; gap: 1.5rem; margin-top: 1rem"
+>
+  <Slider
+    bind:value={speed}
+    min={10}
+    max={120}
+    step={5}
+    labelText="Speed (ms / character)"
+  />
+  <Toggle
+    bind:toggled={play}
+    labelText="Playback"
+    labelA="Paused"
+    labelB="Playing"
+  />
+  <Button size="small" kind="tertiary" on:click={replay}>Replay</Button>
+  <p class="label-01" style="margin-bottom: 0.5rem">
+    Status: <code class="code">{done ? "done" : "revealing…"}</code>
+  </p>
+</div>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -24,6 +24,8 @@
   import ScopedStyleSvelte from "@components/ScopedStyleSvelte.svelte";
   import ScopedThemes from "@components/ScopedThemes.svelte";
   import ScopedThemesDark from "@components/ScopedThemesDark.svelte";
+  import TypewriterBasic from "@components/Typewriter/Basic.svelte";
+  import TypewriterControls from "@components/Typewriter/Controls.svelte";
   import { PKG_NAME, THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
   import {
     Column,
@@ -37,9 +39,9 @@
   import css from "svelte-highlight/languages/css";
 
   const svelteHeadCdn = `<link
-  rel="stylesheet"
-  href="https://unpkg.com/svelte-highlight/styles/github.css"
-/>\n`;
+    rel="stylesheet"
+    href="https://unpkg.com/svelte-highlight/styles/github.css"
+  />\n`;
 </script>
 
 <Row>
@@ -467,6 +469,51 @@
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <CodeWindowPreview /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Animation</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Use <code class="code">Typewriter</code> inside
+      <code class="code">Highlight</code>'s default slot with the
+      <code class="code">highlighted</code>
+      prop. It prints the code one character at a time, syntax highlighting
+      included. A blinking caret marks the end of the typed text and hides when
+      typing stops.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <TypewriterBasic /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Set <code class="code">speed</code> (milliseconds per character) and pause
+      with <code class="code">play</code>. Turn
+      <code class="code">play</code>
+      back on to pick up where you left off. A new
+      <code class="code">highlighted</code>
+      value starts over from the first character. Fire
+      <code class="code">on:done</code>
+      when the last character is visible.
+    </p>
+    <p class="mb-5">
+      Customize the caret with <code class="code">--caret-width</code>,
+      <code class="code">--caret-height</code>,
+      <code class="code">--caret-gap</code>,
+      <code class="code">--caret-color</code>, and
+      <code class="code">--caret-blink</code>. The demo below puts
+      <code class="code">Typewriter</code>
+      inside a
+      <code class="code">CodeWindow</code>.
+    </p>
+    <InlineNotification
+      lowContrast
+      hideCloseButton
+      kind="info"
+      title="Reduced motion"
+      subtitle="With prefers-reduced-motion, the full block shows immediately and on:done runs right away."
+    />
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <TypewriterControls /> </Column>
 </Row>
 
 <Row class="mb-9">


### PR DESCRIPTION
## Summary

Adds `Typewriter`, a component that types highlighted code one character at a time inside `Highlight`'s default slot. Unrevealed text stays hidden in the layout so the block keeps its full height and nothing below jumps during the animation. Supports `speed`, `play`, customizable caret CSS variables, `prefers-reduced-motion`, and an `on:done` event.

### Basic usage

```svelte
<script>
  import Highlight, { Typewriter } from "svelte-highlight";
  import typescript from "svelte-highlight/languages/typescript";
  import github from "svelte-highlight/styles/github";

  const code = "const add = (a: number, b: number) => a + b;";
</script>

<svelte:head>{@html github}</svelte:head>

<Highlight language={typescript} {code} let:highlighted>
  <Typewriter {highlighted} />
</Highlight>
```

### Speed, pause, and completion callback

```svelte
<script>
  let play = true;
</script>

<Highlight language={typescript} {code} let:highlighted>
  <Typewriter
    {highlighted}
    speed={50}
    {play}
    on:done={() => console.log("done")}
  />
</Highlight>
```

### Inside a CodeWindow with a styled caret

```svelte
<CodeWindow variant="macos" title="load.ts">
  <Highlight language={typescript} {code} let:highlighted>
    <Typewriter
      {highlighted}
      speed={40}
      --caret-color="#2996cf"
      --caret-width="2px"
    />
  </Highlight>
</CodeWindow>
```

### Restart on content change

```svelte
<script>
  let code = "const x = 1;";
</script>

<Highlight language={typescript} {code} let:highlighted>
  <Typewriter {highlighted} />
</Highlight>

<button on:click={() => (code = "const y = 2;")}>Change code</button>
```

## Test plan

- [x] E2E: animation completes with full highlighted content and fires `on:done` once
- [x] E2E: `prefers-reduced-motion` renders instantly and fires `on:done` immediately
- [ ] Verify docs site Animation section demos (basic + controls)
- [ ] Confirm caret CSS variables apply as expected