### PR TITLE
feat(components): add `AnsiOutput` terminal renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -1051,6 +1051,71 @@ Set `speed` (milliseconds per character) and pause with `play`. Turn `play` back
 
 With `prefers-reduced-motion`, the full block shows immediately and `on:done` runs right away. Customize the caret with `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink`.
 
+## Terminal Output
+
+Use `AnsiOutput` to render terminal output that still contains ANSI [SGR](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters) escape codes. Colors, bold, dim, italic, and underline become styled HTML. The parser is separate from highlight.js, so reach for it with build logs, CLI output, and test runners.
+
+```svelte
+<script>
+  import { AnsiOutput } from "svelte-highlight";
+
+  // Raw program output, escape codes included.
+  const text = "\x1b[32m✓\x1b[0m build succeeded \x1b[2m(1.2s)\x1b[0m";
+</script>
+
+<AnsiOutput {text} />
+```
+
+Malformed or unsupported escape sequences are dropped. Nothing throws.
+
+### Theming the palette
+
+Pass `--ansi-*` style props to recolor the output. The 16 base colors, default foreground and background, and bold/dim weight and opacity all come from CSS variables with hex fallbacks:
+
+```svelte
+<AnsiOutput
+  {text}
+  --ansi-background="#0d1117"
+  --ansi-red="#ff7b72"
+  --ansi-green="#3fb950"
+/>
+```
+
+256-color and 24-bit truecolor codes resolve to RGB.
+
+### Readable colors
+
+With `autoContrast` on (the default), spans that set a background get a readable foreground. If the chosen text color would disappear on that background (white on white, for example), it flips to black or white, whichever reads better. Only spans with a background are adjusted. Set `autoContrast={false}` to keep the ANSI colors as-is.
+
+```svelte
+<AnsiOutput {text} autoContrast={false} />
+```
+
+### Pairing with `CodeWindow`
+
+Put `AnsiOutput` inside `CodeWindow variant="terminal"` for the prompt and title bar:
+
+```svelte
+<script>
+  import { AnsiOutput, CodeWindow } from "svelte-highlight";
+
+  const text = "\x1b[1;32m$\x1b[0m npm run build";
+</script>
+
+<CodeWindow variant="terminal" title="bash">
+  <AnsiOutput {text} />
+</CodeWindow>
+```
+
+Call `parseAnsi` directly if you need the segments yourself:
+
+```js
+import { parseAnsi } from "svelte-highlight";
+
+parseAnsi("\x1b[31merror\x1b[0m");
+// => [{ text: "error", fg: { name: "red" } }]
+```
+
 ## Component API
 
 ### `Highlight`
@@ -1136,6 +1201,17 @@ With `prefers-reduced-motion`, the full block shows immediately and `on:done` ru
 | title   | `string`                           | `""`          |
 
 `$$restProps` are forwarded to the top-level `div` element.
+
+### `AnsiOutput`
+
+#### Props
+
+| Name         | Type      | Default value  |
+| :----------- | :-------- | :------------- |
+| text         | `string`  | N/A (required) |
+| autoContrast | `boolean` | `true`         |
+
+`$$restProps` are forwarded to the top-level `pre` element.
 
 ### `HighlightSvelte`
 

--- a/src/AnsiOutput.svelte
+++ b/src/AnsiOutput.svelte
@@ -1,0 +1,224 @@
+<script>
+  /** @type {string} */
+  export let text;
+
+  /**
+   * Whether to flip a span's foreground to black or white when it wouldn't read
+   * on its background (e.g. white text on a white background). Only spans that
+   * set a background are adjusted.
+   * @type {boolean}
+   */
+  export let autoContrast = true;
+
+  import { parseAnsi } from "./ansi.js";
+
+  // The default foreground (matches `--ansi-foreground`) and the minimum
+  // contrast ratio a span's text must meet against its background.
+  const FOREGROUND_FALLBACK = "#d4d4d4";
+  const CONTRAST_TARGET = 4.5;
+
+  // Default hex values for the 16 base colors (xterm palette). Each is exposed
+  // as a `--ansi-<name>` CSS variable so the palette is fully themable.
+  const DEFAULTS = {
+    black: "#000000",
+    red: "#cd0000",
+    green: "#00cd00",
+    yellow: "#cdcd00",
+    blue: "#0000ee",
+    magenta: "#cd00cd",
+    cyan: "#00cdcd",
+    white: "#e5e5e5",
+    "bright-black": "#7f7f7f",
+    "bright-red": "#ff0000",
+    "bright-green": "#00ff00",
+    "bright-yellow": "#ffff00",
+    "bright-blue": "#5c5cff",
+    "bright-magenta": "#ff00ff",
+    "bright-cyan": "#00ffff",
+    "bright-white": "#ffffff",
+  };
+
+  // The six steps used by the 6×6×6 color cube of the 256-color palette.
+  const CUBE = [0, 95, 135, 175, 215, 255];
+
+  /**
+   * Resolve a 256-color palette index (16-255) to a hex string.
+   * @param {number} index
+   */
+  function indexedHex(index) {
+    if (index >= 232) {
+      const value = (index - 232) * 10 + 8;
+      const hex = value.toString(16).padStart(2, "0");
+      return `#${hex}${hex}${hex}`;
+    }
+    const n = index - 16;
+    const r = CUBE[Math.floor(n / 36) % 6];
+    const g = CUBE[Math.floor(n / 6) % 6];
+    const b = CUBE[n % 6];
+    return `#${[r, g, b].map((c) => c.toString(16).padStart(2, "0")).join("")}`;
+  }
+
+  /**
+   * Convert a parsed color into a CSS color string. Named colors reference a
+   * themable CSS variable with a hex fallback.
+   * @param {import("./ansi").AnsiColor} color
+   */
+  function cssColor(color) {
+    if ("name" in color) {
+      return `var(--ansi-${color.name}, ${DEFAULTS[color.name]})`;
+    }
+    if ("rgb" in color) {
+      return `rgb(${color.rgb[0]}, ${color.rgb[1]}, ${color.rgb[2]})`;
+    }
+    return color.index < 16
+      ? `var(--ansi-${color.index}, ${indexedHex(color.index)})`
+      : indexedHex(color.index);
+  }
+
+  /**
+   * @param {string} hex A `#rrggbb` string.
+   * @returns {[number, number, number]}
+   */
+  function hexToRgb(hex) {
+    const value = hex.replace("#", "");
+    return [
+      Number.parseInt(value.slice(0, 2), 16),
+      Number.parseInt(value.slice(2, 4), 16),
+      Number.parseInt(value.slice(4, 6), 16),
+    ];
+  }
+
+  /**
+   * Resolve a parsed color to its RGB value (using the default palette for
+   * named colors, since user theme overrides aren't known at this point).
+   * @param {import("./ansi").AnsiColor} color
+   * @returns {[number, number, number]}
+   */
+  function colorToRgb(color) {
+    if ("name" in color) return hexToRgb(DEFAULTS[color.name] ?? "#000000");
+    if ("rgb" in color) return color.rgb;
+    return hexToRgb(indexedHex(color.index));
+  }
+
+  /**
+   * Relative luminance per WCAG.
+   * @param {[number, number, number]} rgb
+   */
+  function luminance([r, g, b]) {
+    const channels = [r, g, b].map((c) => {
+      const v = c / 255;
+      return v <= 0.03928 ? v / 12.92 : ((v + 0.055) / 1.055) ** 2.4;
+    });
+    return 0.2126 * channels[0] + 0.7152 * channels[1] + 0.0722 * channels[2];
+  }
+
+  /**
+   * WCAG contrast ratio between two colors.
+   * @param {[number, number, number]} a
+   * @param {[number, number, number]} b
+   */
+  function contrastRatio(a, b) {
+    const la = luminance(a);
+    const lb = luminance(b);
+    return (Math.max(la, lb) + 0.05) / (Math.min(la, lb) + 0.05);
+  }
+
+  /**
+   * Pick black or white, whichever reads better against `bg`.
+   * @param {[number, number, number]} bg
+   */
+  function readableForeground(bg) {
+    const black = /** @type {[number, number, number]} */ ([0, 0, 0]);
+    const white = /** @type {[number, number, number]} */ ([255, 255, 255]);
+    return contrastRatio(black, bg) >= contrastRatio(white, bg)
+      ? "#000000"
+      : "#ffffff";
+  }
+
+  /**
+   * Resolve a segment's foreground CSS, substituting a readable color when
+   * auto-contrast is on and the span's text would be hard to read on its
+   * background.
+   * @param {import("./ansi").AnsiSegment} segment
+   */
+  function foregroundCss(segment) {
+    if (autoContrast && segment.bg) {
+      const bg = colorToRgb(segment.bg);
+      const fg = segment.fg
+        ? colorToRgb(segment.fg)
+        : hexToRgb(FOREGROUND_FALLBACK);
+      if (contrastRatio(fg, bg) < CONTRAST_TARGET)
+        return readableForeground(bg);
+    }
+    return segment.fg ? cssColor(segment.fg) : undefined;
+  }
+
+  /** @param {import("./ansi").AnsiSegment} segment */
+  function classNames(segment) {
+    const names = [];
+    if (segment.bold) names.push("bold");
+    if (segment.dim) names.push("dim");
+    if (segment.italic) names.push("italic");
+    if (segment.underline) names.push("underline");
+    return names.length ? names.join(" ") : undefined;
+  }
+
+  /** @param {import("./ansi").AnsiSegment} segment */
+  function inlineStyle(segment) {
+    let style = "";
+    if (segment.bg) style += `background-color:${cssColor(segment.bg)};`;
+    const fg = foregroundCss(segment);
+    if (fg) style += `color:${fg};`;
+    return style || undefined;
+  }
+
+  // Resolve each segment to its rendered class/style up front so the helpers
+  // are referenced from the script (and the markup stays declarative).
+  $: segments = parseAnsi(text).map((segment) => ({
+    text: segment.text,
+    class: classNames(segment),
+    style: inlineStyle(segment),
+  }));
+</script>
+
+<pre class="ansi" {...$$restProps}><code
+    >{#each segments as segment}<span class={segment.class} style={segment.style}
+        >{segment.text}</span
+      >{/each}</code
+  ></pre>
+
+<style>
+  .ansi {
+    margin: 0;
+    overflow: auto;
+    padding: var(--ansi-padding, 1em);
+    background: var(--ansi-background, #1e1e1e);
+    color: var(--ansi-foreground, #d4d4d4);
+    font-family: var(
+      --ansi-font-family,
+      ui-monospace,
+      "SFMono-Regular",
+      "Menlo",
+      monospace
+    );
+    font-size: var(--ansi-font-size, 0.875em);
+    line-height: var(--ansi-line-height, 1.5);
+    tab-size: var(--ansi-tab-size, 4);
+  }
+
+  .bold {
+    font-weight: var(--ansi-bold-weight, 700);
+  }
+
+  .dim {
+    opacity: var(--ansi-dim-opacity, 0.5);
+  }
+
+  .italic {
+    font-style: italic;
+  }
+
+  .underline {
+    text-decoration: underline;
+  }
+</style>

--- a/src/AnsiOutput.svelte.d.ts
+++ b/src/AnsiOutput.svelte.d.ts
@@ -1,0 +1,114 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+
+export type AnsiOutputProps = HTMLAttributes<HTMLPreElement> & {
+  /**
+   * Specify the terminal output to render. May contain ANSI SGR escape codes.
+   */
+  text: string;
+
+  /**
+   * Keep spans with a background readable by flipping the foreground to black or
+   * white when it wouldn't read on that background (e.g. white text on a white
+   * background). Only spans that set a background are adjusted.
+   * @default true
+   */
+  autoContrast?: boolean;
+
+  /**
+   * Customize the padding of the output block.
+   * @default "1em"
+   */
+  "--ansi-padding"?: string;
+
+  /**
+   * Customize the background color of the output block.
+   * @default "#1e1e1e"
+   */
+  "--ansi-background"?: string;
+
+  /**
+   * Customize the default (un-colored) text color.
+   * @default "#d4d4d4"
+   */
+  "--ansi-foreground"?: string;
+
+  /**
+   * Customize the monospace font family.
+   * @default "ui-monospace, SFMono-Regular, Menlo, monospace"
+   */
+  "--ansi-font-family"?: string;
+
+  /**
+   * Customize the font size.
+   * @default "0.875em"
+   */
+  "--ansi-font-size"?: string;
+
+  /**
+   * Customize the line height.
+   * @default 1.5
+   */
+  "--ansi-line-height"?: string | number;
+
+  /**
+   * Customize the tab size.
+   * @default 4
+   */
+  "--ansi-tab-size"?: string | number;
+
+  /**
+   * Customize the font weight applied to bold text.
+   * @default 700
+   */
+  "--ansi-bold-weight"?: string | number;
+
+  /**
+   * Customize the opacity applied to dim text.
+   * @default 0.5
+   */
+  "--ansi-dim-opacity"?: string | number;
+
+  /** Customize the standard black color. @default "#000000" */
+  "--ansi-black"?: string;
+  /** Customize the standard red color. @default "#cd0000" */
+  "--ansi-red"?: string;
+  /** Customize the standard green color. @default "#00cd00" */
+  "--ansi-green"?: string;
+  /** Customize the standard yellow color. @default "#cdcd00" */
+  "--ansi-yellow"?: string;
+  /** Customize the standard blue color. @default "#0000ee" */
+  "--ansi-blue"?: string;
+  /** Customize the standard magenta color. @default "#cd00cd" */
+  "--ansi-magenta"?: string;
+  /** Customize the standard cyan color. @default "#00cdcd" */
+  "--ansi-cyan"?: string;
+  /** Customize the standard white color. @default "#e5e5e5" */
+  "--ansi-white"?: string;
+  /** Customize the bright black color. @default "#7f7f7f" */
+  "--ansi-bright-black"?: string;
+  /** Customize the bright red color. @default "#ff0000" */
+  "--ansi-bright-red"?: string;
+  /** Customize the bright green color. @default "#00ff00" */
+  "--ansi-bright-green"?: string;
+  /** Customize the bright yellow color. @default "#ffff00" */
+  "--ansi-bright-yellow"?: string;
+  /** Customize the bright blue color. @default "#5c5cff" */
+  "--ansi-bright-blue"?: string;
+  /** Customize the bright magenta color. @default "#ff00ff" */
+  "--ansi-bright-magenta"?: string;
+  /** Customize the bright cyan color. @default "#00ffff" */
+  "--ansi-bright-cyan"?: string;
+  /** Customize the bright white color. @default "#ffffff" */
+  "--ansi-bright-white"?: string;
+};
+
+export type AnsiOutputEvents = {};
+
+export type AnsiOutputSlots = {};
+
+export default class AnsiOutput extends SvelteComponentTyped<
+  AnsiOutputProps,
+  AnsiOutputEvents,
+  AnsiOutputSlots
+> {}

--- a/src/ansi.d.ts
+++ b/src/ansi.d.ts
@@ -1,0 +1,47 @@
+/**
+ * A parsed ANSI color.
+ *
+ * - `name`: one of the 16 themable base colors (e.g. `"red"`, `"bright-red"`).
+ * - `index`: a 256-color palette index (16-255); 0-15 are normalized to `name`.
+ * - `rgb`: a 24-bit truecolor triple.
+ */
+export type AnsiColor =
+  | { name: string }
+  | { index: number }
+  | { rgb: [number, number, number] };
+
+/**
+ * The active styling state while parsing.
+ */
+export type AnsiStyle = {
+  bold?: boolean | undefined;
+  dim?: boolean | undefined;
+  italic?: boolean | undefined;
+  underline?: boolean | undefined;
+  fg?: AnsiColor | undefined;
+  bg?: AnsiColor | undefined;
+};
+
+/**
+ * A run of text sharing the same styling. Attributes are present only when
+ * active.
+ */
+export type AnsiSegment = {
+  /** The literal text of this run (escape codes removed). */
+  text: string;
+  bold?: boolean;
+  dim?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  fg?: AnsiColor;
+  bg?: AnsiColor;
+};
+
+/**
+ * Parse terminal output containing ANSI SGR escape codes into styled segments.
+ * Unsupported or malformed escape sequences are dropped, not thrown.
+ *
+ * @param text Raw terminal output.
+ * @returns Styled text segments, in order.
+ */
+export declare function parseAnsi(text: string): AnsiSegment[];

--- a/src/ansi.js
+++ b/src/ansi.js
@@ -1,0 +1,204 @@
+/**
+ * Parse terminal output containing ANSI SGR (Select Graphic Rendition) escape
+ * codes into a flat list of styled text segments. Separate from highlight.js.
+ *
+ * Supported attributes: foreground/background colors (standard, bright,
+ * 256-color and 24-bit truecolor), bold, dim, italic, underline and reset.
+ * Unsupported or malformed escape sequences are dropped, not thrown.
+ */
+
+// The 8 standard color names, indexed by their SGR offset (30-37 / 40-47).
+const COLOR_NAMES = [
+  "black",
+  "red",
+  "green",
+  "yellow",
+  "blue",
+  "magenta",
+  "cyan",
+  "white",
+];
+
+/** @typedef {import("./ansi").AnsiColor} AnsiColor */
+/** @typedef {import("./ansi").AnsiSegment} AnsiSegment */
+/** @typedef {import("./ansi").AnsiStyle} AnsiStyle */
+
+/**
+ * The themable name for a standard color offset (0-7).
+ * @param {number} offset
+ * @returns {string}
+ */
+function standardName(offset) {
+  return COLOR_NAMES[offset] ?? "white";
+}
+
+/**
+ * Map a palette index (0-15) to a themable named color. Indices outside that
+ * range are returned as-is so the caller can compute their RGB value.
+ * @param {number} index
+ * @returns {AnsiColor}
+ */
+function paletteColor(index) {
+  if (index < 8) return { name: standardName(index) };
+  if (index < 16) return { name: `bright-${standardName(index - 8)}` };
+  return { index };
+}
+
+/**
+ * Apply one SGR sequence's parameters to the running style state.
+ * @param {AnsiStyle} style
+ * @param {number[]} params
+ */
+function applySgr(style, params) {
+  // An empty parameter list (e.g. `ESC[m`) is treated as a reset.
+  const list = params.length === 0 ? [0] : params;
+
+  for (let i = 0; i < list.length; i += 1) {
+    const code = list[i];
+    if (code === undefined) continue;
+
+    if (code === 0) {
+      // Reset every attribute.
+      style.bold = undefined;
+      style.dim = undefined;
+      style.italic = undefined;
+      style.underline = undefined;
+      style.fg = undefined;
+      style.bg = undefined;
+    } else if (code === 1) {
+      style.bold = true;
+    } else if (code === 2) {
+      style.dim = true;
+    } else if (code === 3) {
+      style.italic = true;
+    } else if (code === 4) {
+      style.underline = true;
+    } else if (code === 22) {
+      style.bold = undefined;
+      style.dim = undefined;
+    } else if (code === 23) {
+      style.italic = undefined;
+    } else if (code === 24) {
+      style.underline = undefined;
+    } else if (code >= 30 && code <= 37) {
+      style.fg = { name: standardName(code - 30) };
+    } else if (code >= 40 && code <= 47) {
+      style.bg = { name: standardName(code - 40) };
+    } else if (code >= 90 && code <= 97) {
+      style.fg = { name: `bright-${standardName(code - 90)}` };
+    } else if (code >= 100 && code <= 107) {
+      style.bg = { name: `bright-${standardName(code - 100)}` };
+    } else if (code === 39) {
+      style.fg = undefined;
+    } else if (code === 49) {
+      style.bg = undefined;
+    } else if (code === 38 || code === 48) {
+      // Extended color: `38;5;n` (256-color) or `38;2;r;g;b` (truecolor).
+      const key = code === 38 ? "fg" : "bg";
+      const mode = list[i + 1];
+      if (mode === 5) {
+        const index = list[i + 2];
+        if (typeof index === "number") style[key] = paletteColor(index);
+        i += 2;
+      } else if (mode === 2) {
+        const r = list[i + 2];
+        const g = list[i + 3];
+        const b = list[i + 4];
+        if (
+          typeof r === "number" &&
+          typeof g === "number" &&
+          typeof b === "number"
+        ) {
+          style[key] = { rgb: [r, g, b] };
+        }
+        i += 4;
+      }
+    }
+    // Any other code is ignored safely.
+  }
+}
+
+/**
+ * Snapshot the current style as a segment carrying `text`, omitting any
+ * attribute that is not active so the output stays minimal.
+ * @param {string} text
+ * @param {AnsiStyle} style
+ * @returns {AnsiSegment}
+ */
+function toSegment(text, style) {
+  /** @type {AnsiSegment} */
+  const segment = { text };
+  if (style.bold) segment.bold = true;
+  if (style.dim) segment.dim = true;
+  if (style.italic) segment.italic = true;
+  if (style.underline) segment.underline = true;
+  if (style.fg) segment.fg = style.fg;
+  if (style.bg) segment.bg = style.bg;
+  return segment;
+}
+
+const ESC = "\x1b";
+
+/**
+ * Parse ANSI-escaped terminal output into styled segments.
+ *
+ * @param {string} text Raw terminal output.
+ * @returns {AnsiSegment[]} Styled text segments, in order.
+ */
+export function parseAnsi(text) {
+  if (!text) return [];
+
+  /** @type {AnsiSegment[]} */
+  const segments = [];
+  /** @type {AnsiStyle} */
+  const style = {};
+  let buffer = "";
+
+  const flush = () => {
+    if (buffer) {
+      segments.push(toSegment(buffer, style));
+      buffer = "";
+    }
+  };
+
+  let i = 0;
+  while (i < text.length) {
+    const ch = text[i];
+
+    if (ch === ESC && text[i + 1] === "[") {
+      // Read a CSI sequence: parameters up to a final byte (0x40-0x7e).
+      let j = i + 2;
+      while (j < text.length) {
+        const code = text.charCodeAt(j);
+        if (code >= 0x40 && code <= 0x7e) break;
+        j += 1;
+      }
+
+      if (j >= text.length) {
+        // Unterminated sequence: drop the remainder safely.
+        break;
+      }
+
+      const final = text[j];
+      if (final === "m") {
+        // SGR sequence: the styling applies to text that follows it.
+        flush();
+        const body = text.slice(i + 2, j);
+        const params = body
+          .split(";")
+          .map((part) => (part === "" ? 0 : Number(part)))
+          .filter((n) => Number.isInteger(n));
+        applySgr(style, params);
+      }
+      // Non-SGR CSI sequences (cursor moves, etc.) are skipped.
+      i = j + 1;
+      continue;
+    }
+
+    buffer += ch;
+    i += 1;
+  }
+
+  flush();
+  return segments;
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,5 +1,8 @@
+export { default as AnsiOutput } from "./AnsiOutput.svelte";
 export type { HighlightActionParameters } from "./action";
 export { highlight } from "./action";
+export type { AnsiColor, AnsiSegment, AnsiStyle } from "./ansi";
+export { parseAnsi } from "./ansi";
 export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { default as Highlight, default } from "./Highlight.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,6 @@
+export { default as AnsiOutput } from "./AnsiOutput.svelte";
 export { highlight } from "./action.js";
+export { parseAnsi } from "./ansi.js";
 export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { default, default as Highlight } from "./Highlight.svelte";

--- a/tests/ansi.test.ts
+++ b/tests/ansi.test.ts
@@ -1,0 +1,125 @@
+import { parseAnsi } from "../src/ansi.js";
+
+const ESC = "\x1b";
+
+describe("parseAnsi", () => {
+  it("returns a single plain segment for text without escapes", () => {
+    expect(parseAnsi("hello world")).toEqual([{ text: "hello world" }]);
+  });
+
+  it("returns an empty array for empty input", () => {
+    expect(parseAnsi("")).toEqual([]);
+  });
+
+  it("parses a standard foreground color", () => {
+    expect(parseAnsi(`${ESC}[31mred`)).toEqual([
+      { text: "red", fg: { name: "red" } },
+    ]);
+  });
+
+  it("parses a standard background color", () => {
+    expect(parseAnsi(`${ESC}[42mgreen-bg`)).toEqual([
+      { text: "green-bg", bg: { name: "green" } },
+    ]);
+  });
+
+  it("parses bright foreground and background colors", () => {
+    expect(parseAnsi(`${ESC}[91mx`)).toEqual([
+      { text: "x", fg: { name: "bright-red" } },
+    ]);
+    expect(parseAnsi(`${ESC}[102my`)).toEqual([
+      { text: "y", bg: { name: "bright-green" } },
+    ]);
+  });
+
+  it("parses bold, dim, italic and underline", () => {
+    expect(parseAnsi(`${ESC}[1mb`)).toEqual([{ text: "b", bold: true }]);
+    expect(parseAnsi(`${ESC}[2md`)).toEqual([{ text: "d", dim: true }]);
+    expect(parseAnsi(`${ESC}[3mi`)).toEqual([{ text: "i", italic: true }]);
+    expect(parseAnsi(`${ESC}[4mu`)).toEqual([{ text: "u", underline: true }]);
+  });
+
+  it("combines multiple attributes in one sequence", () => {
+    expect(parseAnsi(`${ESC}[1;4;31mx`)).toEqual([
+      { text: "x", bold: true, underline: true, fg: { name: "red" } },
+    ]);
+  });
+
+  it("parses 256-color codes, normalizing the first 16 to named colors", () => {
+    expect(parseAnsi(`${ESC}[38;5;1mx`)).toEqual([
+      { text: "x", fg: { name: "red" } },
+    ]);
+    expect(parseAnsi(`${ESC}[38;5;9mx`)).toEqual([
+      { text: "x", fg: { name: "bright-red" } },
+    ]);
+    expect(parseAnsi(`${ESC}[38;5;200mx`)).toEqual([
+      { text: "x", fg: { index: 200 } },
+    ]);
+    expect(parseAnsi(`${ESC}[48;5;236mx`)).toEqual([
+      { text: "x", bg: { index: 236 } },
+    ]);
+  });
+
+  it("parses 24-bit truecolor codes", () => {
+    expect(parseAnsi(`${ESC}[38;2;10;20;30mx`)).toEqual([
+      { text: "x", fg: { rgb: [10, 20, 30] } },
+    ]);
+  });
+
+  it("resets all attributes on code 0", () => {
+    expect(parseAnsi(`${ESC}[1;31mA${ESC}[0mB`)).toEqual([
+      { text: "A", bold: true, fg: { name: "red" } },
+      { text: "B" },
+    ]);
+  });
+
+  it("treats an empty SGR sequence as a reset", () => {
+    expect(parseAnsi(`${ESC}[1mA${ESC}[mB`)).toEqual([
+      { text: "A", bold: true },
+      { text: "B" },
+    ]);
+  });
+
+  it("clears individual attributes (22/23/24/39/49)", () => {
+    expect(parseAnsi(`${ESC}[1mA${ESC}[22mB`)).toEqual([
+      { text: "A", bold: true },
+      { text: "B" },
+    ]);
+    expect(parseAnsi(`${ESC}[31mA${ESC}[39mB`)).toEqual([
+      { text: "A", fg: { name: "red" } },
+      { text: "B" },
+    ]);
+    expect(parseAnsi(`${ESC}[41mA${ESC}[49mB`)).toEqual([
+      { text: "A", bg: { name: "red" } },
+      { text: "B" },
+    ]);
+  });
+
+  it("carries styling across multiple runs until changed", () => {
+    expect(parseAnsi(`${ESC}[32mA B${ESC}[34mC`)).toEqual([
+      { text: "A B", fg: { name: "green" } },
+      { text: "C", fg: { name: "blue" } },
+    ]);
+  });
+
+  it("ignores unsupported SGR codes safely", () => {
+    expect(parseAnsi(`${ESC}[53mx`)).toEqual([{ text: "x" }]);
+  });
+
+  it("skips non-SGR CSI sequences (e.g. cursor moves)", () => {
+    expect(parseAnsi(`${ESC}[2Jhello`)).toEqual([{ text: "hello" }]);
+    expect(parseAnsi(`a${ESC}[Kb`)).toEqual([{ text: "ab" }]);
+  });
+
+  it("drops an unterminated escape sequence without throwing", () => {
+    expect(parseAnsi(`ok${ESC}[31`)).toEqual([{ text: "ok" }]);
+    expect(() => parseAnsi(`${ESC}[`)).not.toThrow();
+    expect(parseAnsi(`${ESC}[`)).toEqual([]);
+  });
+
+  it("does not emit empty segments between adjacent codes", () => {
+    expect(parseAnsi(`${ESC}[31m${ESC}[1mx`)).toEqual([
+      { text: "x", bold: true, fg: { name: "red" } },
+    ]);
+  });
+});

--- a/tests/e2e/AnsiOutput.contrast.test.svelte
+++ b/tests/e2e/AnsiOutput.contrast.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { AnsiOutput } from "svelte-highlight";
+
+  const ESC = "\x1b";
+
+  // White background with explicit white text, white background with the
+  // default (no) foreground, and a blue background with white text.
+  const whiteOnWhite = `${ESC}[47;37mWW${ESC}[0m`;
+  const whiteBg = `${ESC}[47mBG${ESC}[0m`;
+  const blueWhite = `${ESC}[44;37mBL${ESC}[0m`;
+
+  const text = `${whiteOnWhite} ${whiteBg} ${blueWhite}`;
+</script>
+
+<div data-testid="auto">
+  <AnsiOutput {text} />
+</div>
+
+<div data-testid="off">
+  <AnsiOutput text={whiteOnWhite} autoContrast={false} />
+</div>

--- a/tests/e2e/AnsiOutput.test.svelte
+++ b/tests/e2e/AnsiOutput.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import { AnsiOutput, CodeWindow } from "svelte-highlight";
+
+  const ESC = "\x1b";
+
+  // A line exercising bold, a standard color, a bright color and a reset.
+  const text =
+    `${ESC}[1;32m$${ESC}[0m npm run build\n` +
+    `${ESC}[31merror${ESC}[0m: ${ESC}[33mwarning${ESC}[0m here\n` +
+    `${ESC}[94mdone${ESC}[0m`;
+</script>
+
+<CodeWindow variant="terminal" title="bash" data-testid="window">
+  <AnsiOutput {text} data-testid="ansi" />
+</CodeWindow>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1,4 +1,6 @@
 import { expect, test } from "@playwright/experimental-ct-svelte";
+import AnsiOutputContrast from "./AnsiOutput.contrast.test.svelte";
+import AnsiOutput from "./AnsiOutput.test.svelte";
 import CodeWindow from "./CodeWindow.test.svelte";
 import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
 import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
@@ -69,6 +71,60 @@ test("CodeWindow - renders each variant wrapping a Highlight", async ({
   await expect(terminal.locator(".prompt")).toBeVisible();
   await expect(macos.locator(".prompt")).toHaveCount(0);
   await expect(plain.locator(".prompt")).toHaveCount(0);
+});
+
+test("AnsiOutput - renders styled spans inside a terminal window", async ({
+  mount,
+  page,
+}) => {
+  await mount(AnsiOutput);
+
+  const ansi = page.getByTestId("ansi");
+  await expect(ansi).toBeVisible();
+
+  // Bold + green prompt: the "$" run is bold and green.
+  const prompt = ansi.locator("span.bold").first();
+  await expect(prompt).toHaveText("$");
+  // a11y default green is #00cd00.
+  await expect(prompt).toHaveCSS("color", "rgb(0, 205, 0)");
+
+  // The "error" run is red and the "warning" run is yellow.
+  const error = ansi.getByText("error", { exact: true });
+  await expect(error).toHaveCSS("color", "rgb(205, 0, 0)");
+  const warning = ansi.getByText("warning", { exact: true });
+  await expect(warning).toHaveCSS("color", "rgb(205, 205, 0)");
+
+  // The "done" run uses a bright blue (94 -> bright-blue #5c5cff).
+  const done = ansi.getByText("done", { exact: true });
+  await expect(done).toHaveCSS("color", "rgb(92, 92, 255)");
+
+  // The reset after "$" drops bold/color: " npm run build" is unstyled text.
+  await expect(ansi).toContainText("npm run build");
+
+  // It pairs with the terminal CodeWindow chrome.
+  await expect(page.getByTestId("window").locator(".prompt")).toBeVisible();
+});
+
+test("AnsiOutput - auto-contrast keeps low-contrast spans readable", async ({
+  mount,
+  page,
+}) => {
+  await mount(AnsiOutputContrast);
+
+  const auto = page.getByTestId("auto");
+
+  // White text on a white background flips to black.
+  await expect(auto.getByText("WW")).toHaveCSS("color", "rgb(0, 0, 0)");
+  // A white background with the default foreground also flips to black.
+  await expect(auto.getByText("BG")).toHaveCSS("color", "rgb(0, 0, 0)");
+  // White on blue already contrasts, so it stays white (#e5e5e5).
+  await expect(auto.getByText("BL")).toHaveCSS("color", "rgb(229, 229, 229)");
+
+  // With autoContrast disabled, the white-on-white text is left untouched.
+  await expect(page.getByTestId("off").getByText("WW")).toHaveCSS(
+    "color",
+    "rgb(229, 229, 229)",
+  );
 });
 
 test("Highlight", async ({ mount, page }) => {

--- a/www/components/AnsiOutput/Examples.svelte
+++ b/www/components/AnsiOutput/Examples.svelte
@@ -1,0 +1,206 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { AnsiOutput, CodeWindow, HighlightSvelte } from "svelte-highlight";
+
+  const ESC = "\x1b";
+  /** @param {...(number)} codes */
+  const sgr = (...codes) => `${ESC}[${codes.join(";")}m`;
+  const R = sgr(0);
+
+  // Usage snippet shown above the live examples. Built as joined lines (rather
+  // than a multiline template) so the formatter leaves the indentation intact.
+  const snippet = [
+    "<script>",
+    '  import { AnsiOutput } from "svelte-highlight";',
+    "",
+    "  // Raw program output, escape codes included.",
+    '  const text = "\\x1b[32m✓\\x1b[0m build succeeded";',
+    "<\/script>",
+    "",
+    "<AnsiOutput {text} />",
+  ].join("\n");
+
+  const vitest = [
+    `${sgr(1)}RUN${R}  ${sgr(2)}v2.1.0 /svelte-highlight${R}`,
+    "",
+    ` ${sgr(42, 30)} PASS ${R} tests/ansi.test.ts ${sgr(2)}(17 tests)${R}`,
+    ` ${sgr(41, 37)} FAIL ${R} tests/parser.test.ts ${sgr(2)}(1 failed)${R}`,
+    `   ${sgr(31)}×${R} malformed input is dropped, not thrown`,
+    "",
+    ` ${sgr(1)}Test Files${R}  ${sgr(32)}1 passed${R} ${sgr(31)}1 failed${R} ${sgr(2)}(2)${R}`,
+    ` ${sgr(1)}     Tests${R}  ${sgr(32)}16 passed${R} ${sgr(31)}1 failed${R} ${sgr(2)}(17)${R}`,
+    ` ${sgr(1)}  Duration${R}  ${sgr(2)}312ms${R}`,
+  ].join("\n");
+
+  const buildLog = [
+    `${sgr(1, 32)}$${R} npm run build`,
+    "",
+    `${sgr(36)}vite v7.3.3${R} ${sgr(2)}building for production...${R}`,
+    `${sgr(32)}✓${R} 42 modules transformed.`,
+    `dist/index.html              ${sgr(2)}0.46 kB${R} ${sgr(33)}│ gzip:  0.30 kB${R}`,
+    `dist/assets/index-a1b2c3.js  ${sgr(2)}143.21 kB${R} ${sgr(33)}│ gzip: 46.12 kB${R}`,
+    `${sgr(1, 32)}✓ built in 2.58s${R}`,
+  ].join("\n");
+
+  const gitDiff = [
+    `${sgr(1)}diff --git a/src/ansi.js b/src/ansi.js${R}`,
+    `${sgr(36)}@@ -1,4 +1,9 @@${R}`,
+    " export function parseAnsi(text) {",
+    `${sgr(32)}+  if (!text) return [];${R}`,
+    `${sgr(32)}+  const segments = [];${R}`,
+    `${sgr(31)}-  // TODO: implement${R}`,
+    "   return segments;",
+    " }",
+  ].join("\n");
+
+  // The markup behind each live example, shown alongside its output. Built as
+  // joined lines so the formatter leaves the indentation intact. `text` is the
+  // captured terminal output (see the usage snippet above).
+  const vitestMarkup = [
+    '<CodeWindow variant="terminal" title="vitest">',
+    "  <AnsiOutput {text} />",
+    "</CodeWindow>",
+  ].join("\n");
+
+  const themedMarkup = [
+    "<AnsiOutput",
+    "  {text}",
+    '  --ansi-background="#002b36"',
+    '  --ansi-foreground="#93a1a1"',
+    '  --ansi-green="#859900"',
+    '  --ansi-yellow="#b58900"',
+    '  --ansi-cyan="#2aa198"',
+    '  --ansi-red="#dc322f"',
+    '  --ansi-dim-opacity="0.65"',
+    "/>",
+  ].join("\n");
+
+  const gitMarkup = "<AnsiOutput {text} />";
+
+  const lightMarkup = [
+    "<AnsiOutput",
+    "  {text}",
+    '  --ansi-background="#fdf6e3"',
+    '  --ansi-foreground="#586e75"',
+    '  --ansi-green="#859900"',
+    '  --ansi-red="#dc322f"',
+    '  --ansi-yellow="#b58900"',
+    '  --ansi-blue="#268bd2"',
+    '  --ansi-cyan="#2aa198"',
+    '  --ansi-padding="1.25em"',
+    '  --ansi-font-size="0.8125em"',
+    '  --ansi-line-height="1.7"',
+    '  --ansi-bold-weight="600"',
+    '  --ansi-dim-opacity="0.7"',
+    "/>",
+  ].join("\n");
+
+  /**
+   * Escape captured output for display inside a copy-pasteable template literal:
+   * real ESC bytes become a visible `\x1b` and template metacharacters are
+   * escaped.
+   * @param {string} text
+   */
+  const forTemplate = (text) =>
+    text
+      .replaceAll("\\", "\\\\")
+      .replaceAll("`", "\\`")
+      .replaceAll("${", "\\${")
+      .replaceAll(ESC, "\\x1b");
+
+  /**
+   * Assemble a complete, runnable snippet: imports, the captured `text`, and the
+   * markup that renders it.
+   * @param {string} imports
+   * @param {string} rawText
+   * @param {string} markup
+   */
+  const snippetFor = (imports, rawText, markup) =>
+    [
+      "<script>",
+      `  import { ${imports} } from "svelte-highlight";`,
+      "",
+      `  const text = \`${forTemplate(rawText)}\`;`,
+      "<\/script>",
+      "",
+      markup,
+    ].join("\n");
+
+  const vitestSnippet = snippetFor(
+    "AnsiOutput, CodeWindow",
+    vitest,
+    vitestMarkup,
+  );
+  const themedSnippet = snippetFor("AnsiOutput", buildLog, themedMarkup);
+  const gitSnippet = snippetFor("AnsiOutput", gitDiff, gitMarkup);
+  const lightSnippet = snippetFor("AnsiOutput", vitest, lightMarkup);
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+<p class="label-01 mb-3">Test runner, framed with a terminal window</p>
+<div class="mb-3">
+  <HighlightSvelte code={vitestSnippet} class={THEME_MODULE_NAME} />
+</div>
+<div class="mb-5">
+  <CodeWindow variant="terminal" title="vitest">
+    <AnsiOutput text={vitest} />
+  </CodeWindow>
+</div>
+
+<p class="label-01 mb-3">
+  Themed palette (Solarized-ish). Colors are
+  <code class="code">--ansi-*</code>
+  CSS variables.
+</p>
+<div class="mb-3">
+  <HighlightSvelte code={themedSnippet} class={THEME_MODULE_NAME} />
+</div>
+<div class="mb-5">
+  <AnsiOutput
+    text={buildLog}
+    --ansi-background="#002b36"
+    --ansi-foreground="#93a1a1"
+    --ansi-green="#859900"
+    --ansi-yellow="#b58900"
+    --ansi-cyan="#2aa198"
+    --ansi-red="#dc322f"
+    --ansi-dim-opacity="0.65"
+  />
+</div>
+
+<p class="label-01 mb-3">Git diff</p>
+<div class="mb-3">
+  <HighlightSvelte code={gitSnippet} class={THEME_MODULE_NAME} />
+</div>
+<div class="mb-5">
+  <AnsiOutput text={gitDiff} />
+</div>
+
+<p class="label-01 mb-3">
+  Light theme. Custom background, palette, and type via
+  <code class="code">--ansi-*</code>
+  props.
+</p>
+<div class="mb-3">
+  <HighlightSvelte code={lightSnippet} class={THEME_MODULE_NAME} />
+</div>
+<div class="mb-5">
+  <AnsiOutput
+    text={vitest}
+    --ansi-background="#fdf6e3"
+    --ansi-foreground="#586e75"
+    --ansi-green="#859900"
+    --ansi-red="#dc322f"
+    --ansi-yellow="#b58900"
+    --ansi-blue="#268bd2"
+    --ansi-cyan="#2aa198"
+    --ansi-padding="1.25em"
+    --ansi-font-size="0.8125em"
+    --ansi-line-height="1.7"
+    --ansi-bold-weight="600"
+    --ansi-dim-opacity="0.7"
+  />
+</div>

--- a/www/components/AnsiOutputPreview.svelte
+++ b/www/components/AnsiOutputPreview.svelte
@@ -1,0 +1,298 @@
+<script>
+  import { Column, Row, Toggle } from "carbon-components-svelte";
+  import { AnsiOutput, CodeWindow, parseAnsi } from "svelte-highlight";
+
+  // Build SGR escape sequences. Keeping the raw `\x1b` out of the markup makes
+  // the examples readable.
+  const ESC = "\x1b";
+  /** @param {...(number)} codes */
+  const sgr = (...codes) => `${ESC}[${codes.join(";")}m`;
+  const R = sgr(0);
+
+  const NAMES = [
+    "black",
+    "red",
+    "green",
+    "yellow",
+    "blue",
+    "magenta",
+    "cyan",
+    "white",
+  ];
+
+  // Render a swatch of every escape code so the full palette is visible.
+  const standardFg = NAMES.map((n, i) => `${sgr(30 + i)}${n}${R}`).join("  ");
+  const brightFg = NAMES.map((n, i) => `${sgr(90 + i)}${n}${R}`).join("  ");
+  const backgrounds = NAMES.map((n, i) => `${sgr(40 + i, 37)} ${n} ${R}`).join(
+    " ",
+  );
+
+  // White text on every background swatch, including white. Shows auto-contrast
+  // against raw output.
+  const lowContrast = backgrounds;
+
+  const attributes = [
+    `${sgr(1)}bold${R}`,
+    `${sgr(2)}dim${R}`,
+    `${sgr(3)}italic${R}`,
+    `${sgr(4)}underline${R}`,
+    `${sgr(1, 4, 31)}bold underline red${R}`,
+    `${sgr(2, 3, 36)}dim italic cyan${R}`,
+  ].join("   ");
+
+  // The 6×6×6 color cube of the 256-color palette, 36 blocks per row.
+  let cube = "";
+  for (let i = 16; i < 232; i += 1) {
+    cube += `${sgr(48, 5, i)}  ${R}`;
+    if ((i - 15) % 36 === 0) cube += "\n";
+  }
+
+  // The 24-step grayscale ramp (indices 232-255).
+  let grayscale = "";
+  for (let i = 232; i < 256; i += 1) grayscale += `${sgr(48, 5, i)}  ${R}`;
+
+  /**
+   * @param {number} h hue in [0, 360)
+   * @returns {[number, number, number]}
+   */
+  function hueToRgb(h) {
+    const c = 1;
+    const x = 1 - Math.abs(((h / 60) % 2) - 1);
+    const [r, g, b] =
+      h < 60
+        ? [c, x, 0]
+        : h < 120
+          ? [x, c, 0]
+          : h < 180
+            ? [0, c, x]
+            : h < 240
+              ? [0, x, c]
+              : h < 300
+                ? [x, 0, c]
+                : [c, 0, x];
+    return [Math.round(r * 255), Math.round(g * 255), Math.round(b * 255)];
+  }
+
+  // A 24-bit truecolor rainbow built from `38;2;r;g;b` sequences.
+  let rainbow = "";
+  for (let i = 0; i <= 72; i += 1) {
+    const [r, g, b] = hueToRgb((i / 72) * 360);
+    rainbow += `${sgr(38, 2, r, g, b)}█${R}`;
+  }
+
+  const buildLog = [
+    `${sgr(1, 32)}$${R} npm run build`,
+    "",
+    `${sgr(36)}vite v7.3.3${R} ${sgr(2)}building for production...${R}`,
+    `${sgr(32)}✓${R} 42 modules transformed.`,
+    `dist/index.html              ${sgr(2)}0.46 kB${R} ${sgr(33)}│ gzip:  0.30 kB${R}`,
+    `dist/assets/index-a1b2c3.js  ${sgr(2)}143.21 kB${R} ${sgr(33)}│ gzip: 46.12 kB${R}`,
+    `${sgr(1, 32)}✓ built in 2.58s${R}`,
+  ].join("\n");
+
+  const testLog = [
+    `${sgr(1)}RUN${R}  ${sgr(2)}v2.1.0 /svelte-highlight${R}`,
+    "",
+    ` ${sgr(42, 30)} PASS ${R} tests/ansi.test.ts ${sgr(2)}(17 tests)${R}`,
+    ` ${sgr(41, 37)} FAIL ${R} tests/parser.test.ts ${sgr(2)}(1 failed)${R}`,
+    `   ${sgr(31)}×${R} malformed input is dropped, not thrown`,
+    "",
+    ` ${sgr(1)}Test Files${R}  ${sgr(32)}1 passed${R} ${sgr(31)}1 failed${R} ${sgr(2)}(2)${R}`,
+    ` ${sgr(1)}     Tests${R}  ${sgr(32)}16 passed${R} ${sgr(31)}1 failed${R} ${sgr(2)}(17)${R}`,
+  ].join("\n");
+
+  const gitDiff = [
+    `${sgr(1)}diff --git a/src/ansi.js b/src/ansi.js${R}`,
+    `${sgr(36)}@@ -1,4 +1,9 @@${R}`,
+    " export function parseAnsi(text) {",
+    `${sgr(32)}+  if (!text) return [];${R}`,
+    `${sgr(32)}+  const segments = [];${R}`,
+    `${sgr(31)}-  // TODO: implement${R}`,
+    "   return segments;",
+    " }",
+  ].join("\n");
+
+  // A line that mixes unsupported (999) and unterminated escape sequences to
+  // show they are dropped rather than thrown.
+  const malformed = `${sgr(32)}safe${R} ${ESC}[999munknown code ignored${R} ${ESC}[1mthen unterminated${ESC}[`;
+
+  const apiSample = `${sgr(1, 31)}error${R}: ${sgr(33)}deprecated${R}`;
+
+  const simpleExamples = [
+    {
+      title: "Standard foreground colors",
+      description: "SGR codes 30–37.",
+      text: standardFg,
+    },
+    {
+      title: "Bright foreground colors",
+      description: "SGR codes 90–97.",
+      text: brightFg,
+    },
+    {
+      title: "Background colors",
+      description:
+        "SGR codes 40–47 with white text. Auto-contrast flips to black where white would vanish (the white swatch).",
+      text: backgrounds,
+    },
+    {
+      title: "Text attributes",
+      description: "Bold, dim, italic, underline, alone or combined.",
+      text: attributes,
+    },
+    {
+      title: "256-color cube",
+      description: "Indices 16–231 (38;5;n / 48;5;n).",
+      text: cube,
+    },
+    {
+      title: "256-color grayscale ramp",
+      description: "Indices 232–255.",
+      text: grayscale,
+    },
+    {
+      title: "24-bit truecolor",
+      description: "A rainbow built from 38;2;r;g;b sequences.",
+      text: rainbow,
+    },
+    {
+      title: "Build log",
+      description: "Typical bundler output.",
+      text: buildLog,
+    },
+    {
+      title: "Test runner",
+      description: "Pass / fail summary with colored badges.",
+      text: testLog,
+    },
+    {
+      title: "Git diff",
+      description: "Added / removed lines.",
+      text: gitDiff,
+    },
+    {
+      title: "Malformed input",
+      description:
+        "Unsupported (999) and unterminated escape sequences are dropped, not thrown.",
+      text: malformed,
+    },
+  ];
+
+  // Show the raw escape codes underneath each example.
+  let showRaw = false;
+
+  /** @param {string} text */
+  const raw = (text) => text.replaceAll(ESC, "␛");
+
+  $: parsed = parseAnsi(apiSample);
+</script>
+
+<Row class="mb-5">
+  <Column>
+    <p class="mb-3">
+      <code class="code">AnsiOutput</code>
+      renders terminal output with ANSI SGR escape codes as styled HTML. The
+      parser is separate from highlight.js. Build logs, CLI output, and test
+      runners are the usual cases.
+    </p>
+    <Toggle
+      labelText="Show raw escape codes"
+      labelA="Hidden"
+      labelB="Shown"
+      bind:toggled={showRaw}
+    />
+  </Column>
+</Row>
+
+{#each simpleExamples as { title, description, text }}
+  <Row class="mb-5">
+    <Column xlg={12}>
+      <h3 class="mb-3">{title}</h3>
+      <p class="label-01 mb-3">{description}</p>
+      <AnsiOutput {text} />
+      {#if showRaw}
+        <pre class="raw">{raw(text)}</pre>
+      {/if}
+    </Column>
+  </Row>
+{/each}
+
+<Row class="mb-5">
+  <Column xlg={12}>
+    <h3 class="mb-3">Auto-contrast</h3>
+    <p class="label-01 mb-3">
+      <code class="code">autoContrast</code>
+      (default on) flips a span's foreground to black or white when it wouldn't
+      read on its background. Set
+      <code class="code">autoContrast={false}</code>
+      to keep the ANSI colors as-is.
+    </p>
+  </Column>
+  <Column xlg={8} lg={8} md={12} class="mb-3">
+    <p class="label-01 mb-3">autoContrast (default)</p>
+    <AnsiOutput text={lowContrast} />
+  </Column>
+  <Column xlg={8} lg={8} md={12} class="mb-3">
+    <p class="label-01 mb-3">autoContrast=&#123;false&#125;</p>
+    <AnsiOutput text={lowContrast} autoContrast={false} />
+  </Column>
+</Row>
+
+<Row class="mb-5">
+  <Column xlg={12}>
+    <h3 class="mb-3">Paired with <code class="code">CodeWindow</code></h3>
+    <p class="label-01 mb-3">
+      Wrap with <code class="code">CodeWindow variant="terminal"</code> for the
+      prompt and title bar.
+    </p>
+    <CodeWindow variant="terminal" title="vitest">
+      <AnsiOutput text={testLog} />
+    </CodeWindow>
+  </Column>
+</Row>
+
+<Row class="mb-5">
+  <Column xlg={12}>
+    <h3 class="mb-3">Themed palette</h3>
+    <p class="label-01 mb-3">
+      The 16 base colors, background, foreground, and bold/dim styling are CSS
+      variables. Same build log, recolored toward Solarized.
+    </p>
+    <AnsiOutput
+      text={buildLog}
+      --ansi-background="#002b36"
+      --ansi-foreground="#93a1a1"
+      --ansi-green="#859900"
+      --ansi-yellow="#b58900"
+      --ansi-cyan="#2aa198"
+      --ansi-red="#dc322f"
+      --ansi-dim-opacity="0.65"
+    />
+  </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}>
+    <h3 class="mb-3">Parser API</h3>
+    <p class="label-01 mb-3">
+      <code class="code">parseAnsi(text)</code>
+      returns the segments behind the component.
+    </p>
+    <AnsiOutput text={apiSample} />
+    <pre class="raw">parseAnsi({JSON.stringify(raw(apiSample))})
+// {JSON.stringify(parsed)}</pre>
+  </Column>
+</Row>
+
+<style>
+  .raw {
+    margin-top: 0.5rem;
+    padding: 0.75rem 1rem;
+    background: #161616;
+    color: #c6c6c6;
+    border-radius: 4px;
+    font-size: 0.8125rem;
+    white-space: pre-wrap;
+    word-break: break-word;
+  }
+</style>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -1,4 +1,5 @@
 <script>
+  import AnsiOutputExamples from "@components/AnsiOutput/Examples.svelte";
   import CodeSnippet from "@components/CodeSnippet.svelte";
   import CodeWindowPreview from "@components/CodeWindowPreview.svelte";
   import CopyButtonBasic from "@components/CopyButton/Basic.svelte";
@@ -514,6 +515,29 @@
     />
   </Column>
   <Column xlg={10} lg={10} md={12}> <TypewriterControls /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Terminal Output</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">AnsiOutput</code>
+      renders terminal output with ANSI SGR escape codes as styled HTML. The
+      parser is separate from highlight.js. Build logs, CLI output, and test
+      runners are the usual cases.
+    </p>
+    <p class="mb-5">
+      Standard, bright, 256-color, and 24-bit truecolor codes work, along with
+      bold, dim, italic, and underline. Bad sequences are dropped.
+    </p>
+    <p class="mb-5">
+      Theme the 16 base colors and bold/dim styling with
+      <code class="code">--ansi-*</code>
+      props. <code class="code">autoContrast</code> (default on) flips text to
+      black or white when it wouldn't read on its background.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <AnsiOutputExamples /> </Column>
 </Row>
 
 <Row class="mb-9">

--- a/www/pages/preview-ansi.astro
+++ b/www/pages/preview-ansi.astro
@@ -1,0 +1,9 @@
+---
+import AnsiOutputPreview from "@components/AnsiOutputPreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="AnsiOutput preview">
+  <h1 class="mb-5">AnsiOutput</h1>
+  <AnsiOutputPreview client:idle />
+</Layout>


### PR DESCRIPTION
`AnsiOutput` renders captured terminal output containing ANSI SGR escape codes as styled HTML. It is a standalone parser that does not route through highlight.js, so it suits build logs, CLI output, and test runners.

It handles standard, bright, 256-color, and 24-bit truecolor codes, plus bold, dim, italic, and underline, and malformed or unsupported sequences are dropped safely. The 16 base colors and bold/dim treatments are themable with `--ansi-*` style props. `autoContrast` (on by default) keeps colored spans legible by flipping the foreground to black or white when it would not read against its background.