### PR TITLE
feat(components): add FileTabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1116,6 +1116,44 @@ parseAnsi("\x1b[31merror\x1b[0m");
 // => [{ text: "error", fg: { name: "red" } }]
 ```
 
+## File Tabs
+
+`FileTabs` groups code snippets behind a tab strip, like files in an editor. Pass file names as `files`, then use `let:active` in the default slot to render the matching snippet.
+
+Arrow keys move between tabs; `Home` and `End` jump to the first and last. The markup follows the WAI-ARIA tabs pattern (`role="tablist"`, `role="tab"`, `role="tabpanel"`).
+
+```svelte
+<script>
+  import Highlight, { FileTabs } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const sources = {
+    "App.svelte": { language: typescript, code: "const answer = 42;" },
+    "index.js": { language: javascript, code: "export default answer;" },
+  };
+
+  const files = Object.keys(sources);
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<FileTabs {files} let:active>
+  <Highlight language={sources[active].language} code={sources[active].code} />
+</FileTabs>
+```
+
+`bind:active` sets the open tab from your code. `on:change` fires when the user picks a different one.
+
+```svelte
+<FileTabs {files} bind:active on:change={(e) => console.log(e.detail.active)}>
+  <Highlight language={sources[active].language} code={sources[active].code} />
+</FileTabs>
+```
+
 ## Component API
 
 ### `Highlight`
@@ -1314,6 +1352,27 @@ Use `bind:this`, then call `undo()`, `redo()`, `focus()`, `selectAll()`, `insert
   on:change={(e) => console.log(e.detail.code)}
   on:history={(e) => console.log(e.detail.canUndo, e.detail.canRedo)}
 />
+```
+
+### `FileTabs`
+
+#### Props
+
+| Name   | Type       | Default value  |
+| :----- | :--------- | :------------- |
+| files  | `string[]` | N/A (required) |
+| active | `string`   | `files[0]`     |
+
+`$$restProps` are forwarded to the top-level `div` element. `active` supports `bind:active`.
+
+#### Dispatched Events
+
+- **on:change**: fired when the user picks a tab, with `{ active }`
+
+```svelte
+<FileTabs {files} on:change={(e) => console.log(e.detail.active)} let:active>
+  <Highlight language={sources[active].language} code={sources[active].code} />
+</FileTabs>
 ```
 
 ### `Typewriter`

--- a/src/FileTabs.svelte
+++ b/src/FileTabs.svelte
@@ -1,0 +1,164 @@
+<script context="module">
+  let uid = 0;
+</script>
+
+<script>
+  /** @type {string[]} */
+  export let files;
+
+  /** @type {string} */
+  export let active = files[0];
+
+  import { afterUpdate, createEventDispatcher } from "svelte";
+
+  const dispatch = createEventDispatcher();
+
+  const baseId = `svelte-highlight-file-tabs-${uid++}`;
+
+  /** @type {HTMLDivElement} */
+  let root;
+
+  /** @type {HTMLButtonElement[]} */
+  let tabs = [];
+
+  $: activeIndex = files.indexOf(active);
+
+  /** @param {string} file */
+  function selectTab(file) {
+    if (file === active) return;
+    active = file;
+    dispatch("change", { active });
+  }
+
+  /**
+   * Roving-tabindex keyboard navigation per the WAI-ARIA tabs pattern.
+   * @param {KeyboardEvent} event
+   * @param {number} index
+   */
+  function handleKeydown(event, index) {
+    const lastIndex = files.length - 1;
+    let nextIndex = index;
+
+    switch (event.key) {
+      case "ArrowRight":
+      case "ArrowDown":
+        nextIndex = index === lastIndex ? 0 : index + 1;
+        break;
+      case "ArrowLeft":
+      case "ArrowUp":
+        nextIndex = index === 0 ? lastIndex : index - 1;
+        break;
+      case "Home":
+        nextIndex = 0;
+        break;
+      case "End":
+        nextIndex = lastIndex;
+        break;
+      default:
+        return;
+    }
+
+    event.preventDefault();
+    selectTab(files[nextIndex]);
+    tabs[nextIndex]?.focus();
+  }
+
+  // Copy the highlighted block's background and text color onto the active tab
+  // so it matches whatever highlight.js theme is loaded. Falls back to
+  // transparent/inherit when `.hljs` isn't painted yet (e.g. SSR).
+  afterUpdate(() => {
+    const code = root?.querySelector(".tabpanel .hljs");
+
+    if (code) {
+      const { backgroundColor, color } = getComputedStyle(code);
+      root.style.setProperty(
+        "--tab-active-resolved-background",
+        backgroundColor,
+      );
+      root.style.setProperty("--tab-active-resolved-color", color);
+    }
+  });
+</script>
+
+<div class="file-tabs" bind:this={root} {...$$restProps}>
+  <div role="tablist" class="tablist">
+    {#each files as file, index (file)}
+      <button
+        bind:this={tabs[index]}
+        type="button"
+        role="tab"
+        id="{baseId}-tab-{index}"
+        class="tab"
+        class:active={file === active}
+        aria-controls="{baseId}-panel"
+        tabindex={file === active ? 0 : -1}
+        {...{
+          // Spread keeps the dynamic boolean out of Biome's static
+          // `useValidAriaValues` check, which misreads templated values.
+          "aria-selected": file === active,
+        }}
+        on:click={() => selectTab(file)}
+        on:keydown={(event) => handleKeydown(event, index)}
+      >
+        {file}
+      </button>
+    {/each}
+  </div>
+
+  <div
+    role="tabpanel"
+    id="{baseId}-panel"
+    class="tabpanel"
+    aria-labelledby="{baseId}-tab-{activeIndex}"
+  >
+    <slot {active} />
+  </div>
+</div>
+
+<style>
+  .file-tabs {
+    display: flex;
+    flex-direction: column;
+  }
+
+  .tablist {
+    display: flex;
+    gap: var(--file-tabs-gap, 0);
+    background: var(--file-tabs-background, inherit);
+    overflow-x: auto;
+  }
+
+  .tab {
+    display: inline-flex;
+    align-items: center;
+    padding: var(--tab-padding, 0.5em 1em);
+    font: inherit;
+    color: var(--tab-color, inherit);
+    background: var(--tab-background, transparent);
+    border: 0;
+    cursor: pointer;
+    white-space: nowrap;
+    opacity: var(--tab-inactive-opacity, 0.55);
+    transition:
+      opacity 0.1s ease,
+      background-color 0.1s ease;
+  }
+
+  .tab:hover {
+    opacity: 1;
+  }
+
+  .tab.active {
+    opacity: 1;
+    color: var(--tab-active-color, var(--tab-active-resolved-color, inherit));
+    background: var(
+      --tab-active-background,
+      var(--tab-active-resolved-background, transparent)
+    );
+  }
+
+  .tab:focus-visible {
+    outline: var(--tab-focus-outline, 2px solid currentColor);
+    outline-offset: -2px;
+  }
+</style>

--- a/src/FileTabs.svelte.d.ts
+++ b/src/FileTabs.svelte.d.ts
@@ -1,0 +1,97 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+
+export type FileTabsProps = HTMLAttributes<HTMLDivElement> & {
+  /**
+   * Specify the file names to render as tabs.
+   * @example ["App.svelte", "index.js"]
+   */
+  files: string[];
+
+  /**
+   * Specify the active file. Supports `bind:active`.
+   * @default files[0]
+   */
+  active?: string;
+
+  /**
+   * Customize the gap between tabs.
+   * @default 0
+   */
+  "--file-tabs-gap"?: string | number;
+
+  /**
+   * Customize the background color of the tab strip.
+   * @default "inherit"
+   */
+  "--file-tabs-background"?: string;
+
+  /**
+   * Customize the padding of each tab.
+   * @default "0.5em 1em"
+   */
+  "--tab-padding"?: string;
+
+  /**
+   * Customize the text color of an inactive tab.
+   * @default "inherit"
+   */
+  "--tab-color"?: string;
+
+  /**
+   * Customize the background color of an inactive tab.
+   * @default "transparent"
+   */
+  "--tab-background"?: string;
+
+  /**
+   * Customize the opacity of inactive tabs. Active and hovered tabs are
+   * always fully opaque.
+   * @default 0.55
+   */
+  "--tab-inactive-opacity"?: string | number;
+
+  /**
+   * Customize the text color of the active tab.
+   * Defaults to the highlighted code block's text color.
+   * @default the highlighted code's color
+   */
+  "--tab-active-color"?: string;
+
+  /**
+   * Customize the background color of the active tab.
+   * Defaults to the highlighted code block's background.
+   * @default the highlighted code's background
+   */
+  "--tab-active-background"?: string;
+
+  /**
+   * Customize the focus outline shown when a tab is focused via the keyboard.
+   * @default "2px solid currentColor"
+   */
+  "--tab-focus-outline"?: string;
+};
+
+export type FileTabsEvents = {
+  change: CustomEvent<{
+    /**
+     * The newly active file.
+     */
+    active: string;
+  }>;
+};
+
+export type FileTabsSlots = {
+  default: {
+    /**
+     * The active file.
+     */
+    active: string;
+  };
+};
+
+export default class FileTabs extends SvelteComponentTyped<
+  FileTabsProps,
+  FileTabsEvents,
+  FileTabsSlots
+> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ export type { AnsiColor, AnsiSegment, AnsiStyle } from "./ansi";
 export { parseAnsi } from "./ansi";
 export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
+export { default as FileTabs } from "./FileTabs.svelte";
 export { default as Highlight, default } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
 export { default as HighlightEditable } from "./HighlightEditable.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export { highlight } from "./action.js";
 export { parseAnsi } from "./ansi.js";
 export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
+export { default as FileTabs } from "./FileTabs.svelte";
 export { default, default as Highlight } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
 export { default as HighlightEditable } from "./HighlightEditable.svelte";

--- a/tests/e2e/FileTabs.test.svelte
+++ b/tests/e2e/FileTabs.test.svelte
@@ -1,0 +1,32 @@
+<script lang="ts">
+  import Highlight, { FileTabs } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const sources: Record<string, { language: typeof typescript; code: string }> =
+    {
+      "App.svelte": { language: typescript, code: "const answer = 42;" },
+      "index.js": { language: javascript, code: "export default answer;" },
+      "vite.config.js": { language: javascript, code: "export default {};" },
+    };
+
+  const files = Object.keys(sources);
+
+  let active = files[0];
+  let lastChange = "";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<FileTabs
+  {files}
+  bind:active
+  on:change={(event) => (lastChange = event.detail.active)}
+  let:active
+>
+  <Highlight language={sources[active].language} code={sources[active].code} />
+</FileTabs>
+
+<p data-testid="active">{active}</p>
+<p data-testid="last-change">{lastChange}</p>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -5,6 +5,7 @@ import CodeWindow from "./CodeWindow.test.svelte";
 import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
 import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
 import CopyButton from "./CopyButton.test.svelte";
+import FileTabs from "./FileTabs.test.svelte";
 import Highlight from "./Highlight.test.svelte";
 import HighlightAction from "./HighlightAction.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
@@ -666,4 +667,99 @@ test("HighlightEditable - two instances share the same bound code", async ({
 
   await page.getByTestId("insert-first").click();
   await expect(second).toHaveText("abX");
+});
+
+test("FileTabs - renders a tab per file with the first active", async ({
+  mount,
+  page,
+}) => {
+  await mount(FileTabs);
+
+  const tabs = page.getByRole("tab");
+  await expect(tabs).toHaveCount(3);
+
+  // The first file is active by default.
+  await expect(page.getByRole("tab", { name: "App.svelte" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(page.getByTestId("active")).toHaveText("App.svelte");
+
+  // The active file's code is shown in the panel.
+  await expect(page.getByRole("tabpanel")).toContainText("const answer = 42;");
+});
+
+test("FileTabs - clicking a tab switches the active file and dispatches change", async ({
+  mount,
+  page,
+}) => {
+  await mount(FileTabs);
+
+  await page.getByRole("tab", { name: "index.js" }).click();
+
+  await expect(page.getByRole("tab", { name: "index.js" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+  await expect(page.getByRole("tab", { name: "App.svelte" })).toHaveAttribute(
+    "aria-selected",
+    "false",
+  );
+
+  // The visual `active` class follows the selected tab.
+  await expect(page.getByRole("tab", { name: "index.js" })).toHaveClass(
+    /active/,
+  );
+  await expect(page.getByRole("tab", { name: "App.svelte" })).not.toHaveClass(
+    /active/,
+  );
+
+  // The slot prop and the `change` event both reflect the new file.
+  await expect(page.getByTestId("active")).toHaveText("index.js");
+  await expect(page.getByTestId("last-change")).toHaveText("index.js");
+  await expect(page.getByRole("tabpanel")).toContainText(
+    "export default answer;",
+  );
+});
+
+test("FileTabs - arrow keys move between tabs (roving tabindex)", async ({
+  mount,
+  page,
+}) => {
+  await mount(FileTabs);
+
+  await page.getByRole("tab", { name: "App.svelte" }).focus();
+
+  await page.keyboard.press("ArrowRight");
+  await expect(page.getByRole("tab", { name: "index.js" })).toBeFocused();
+  await expect(page.getByTestId("active")).toHaveText("index.js");
+
+  // Wraps from the last tab back to the first.
+  await page.keyboard.press("ArrowRight");
+  await expect(page.getByRole("tab", { name: "vite.config.js" })).toBeFocused();
+  await page.keyboard.press("ArrowRight");
+  await expect(page.getByRole("tab", { name: "App.svelte" })).toBeFocused();
+
+  // ArrowLeft wraps the other way.
+  await page.keyboard.press("ArrowLeft");
+  await expect(page.getByRole("tab", { name: "vite.config.js" })).toBeFocused();
+  await expect(page.getByTestId("active")).toHaveText("vite.config.js");
+});
+
+test("FileTabs - active tab background matches the highlighted code theme", async ({
+  mount,
+  page,
+}) => {
+  await mount(FileTabs);
+
+  // atom-one-dark paints `.hljs` rgb(40, 44, 52). The active tab should match.
+  const codeBackground = await page
+    .locator(".hljs")
+    .first()
+    .evaluate((node) => getComputedStyle(node).backgroundColor);
+
+  await expect(page.getByRole("tab", { selected: true })).toHaveCSS(
+    "background-color",
+    codeBackground,
+  );
 });

--- a/www/components/FileTabs.svelte
+++ b/www/components/FileTabs.svelte
@@ -1,0 +1,51 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import Highlight, { FileTabs, HighlightSvelte } from "svelte-highlight";
+  import css from "svelte-highlight/languages/css";
+  import javascript from "svelte-highlight/languages/javascript";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const sources = {
+    "App.svelte": { language: typescript, code: "const answer = 42;" },
+    "index.js": { language: javascript, code: "export default answer;" },
+    "styles.css": { language: css, code: ".hljs {\n  color: inherit;\n}" },
+  };
+
+  const files = Object.keys(sources);
+
+  const snippet = `<script>
+    import Highlight, { FileTabs } from "svelte-highlight";
+    import javascript from "svelte-highlight/languages/javascript";
+    import typescript from "svelte-highlight/languages/typescript";
+    import github from "svelte-highlight/styles/github";
+
+    const sources = {
+      "App.svelte": { language: typescript, code: "const answer = 42;" },
+      "index.js": { language: javascript, code: "export default answer;" },
+    };
+
+    const files = Object.keys(sources);
+  <\/script>
+
+  <svelte:head>
+    {@html github}
+  </svelte:head>
+
+  <FileTabs {files} let:active>
+    <Highlight language={sources[active].language} code={sources[active].code} />
+  </FileTabs>`;
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+<p class="mb-5">Pick a tab, or use the arrow keys:</p>
+
+<FileTabs {files} let:active>
+  <Highlight
+    language={sources[active].language}
+    code={sources[active].code}
+    class={THEME_MODULE_NAME}
+  />
+</FileTabs>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -8,6 +8,7 @@
   import CopyButtonLineNumbers from "@components/CopyButton/LineNumbers.svelte";
   import CopyButtonSlot from "@components/CopyButton/Slot.svelte";
   import CopyButtonStyleProps from "@components/CopyButton/StyleProps.svelte";
+  import FileTabs from "@components/FileTabs.svelte";
   import EditableBasic from "@components/HighlightEditable/Basic.svelte";
   import EditableCommands from "@components/HighlightEditable/Commands.svelte";
   import Basic from "@components/LineNumbers/Basic.svelte";
@@ -40,9 +41,9 @@
   import css from "svelte-highlight/languages/css";
 
   const svelteHeadCdn = `<link
-    rel="stylesheet"
-    href="https://unpkg.com/svelte-highlight/styles/github.css"
-  />\n`;
+      rel="stylesheet"
+      href="https://unpkg.com/svelte-highlight/styles/github.css"
+    />\n`;
 </script>
 
 <Row>
@@ -589,6 +590,32 @@
       <code class="code">--outline-offset</code>.
     </p>
   </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>File Tabs</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">FileTabs</code>
+      groups snippets behind a tab strip. Pass file names as
+      <code class="code">files</code>
+      and use
+      <code class="code">let:active</code>
+      in the default slot to render the matching
+      <code class="code">Highlight</code>
+      block.
+    </p>
+    <p class="mb-5">
+      Arrow keys move between tabs; <code class="code">Home</code> and
+      <code class="code">End</code>
+      jump to the ends.
+      <code class="code">bind:active</code>
+      sets the open tab from your code.
+      <code class="code">on:change</code>
+      fires when the user picks a different one.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <FileTabs /> </Column>
 </Row>
 
 <Row class="mb-9">


### PR DESCRIPTION
This PR adds `FileTabs`, a new component for switching between highlighted code snippets behind a file-style tab strip. Pass `files` and use `let:active` in the default slot:

```svelte
<FileTabs {files} let:active>
  <Highlight language={sources[active].language} code={sources[active].code} />
</FileTabs>
```

The component follows the WAI-ARIA tabs pattern and the active tab background inherits from the loaded highlight.js theme. You can drive or observe the open tab from parent code with `bind:active` and `on:change`:

```svelte
<FileTabs {files} bind:active on:change={(e) => console.log(e.detail.active)}>
  <Highlight language={sources[active].language} code={sources[active].code} />
</FileTabs>
```