### PR TITLE
refactor(components): extract shared highlighter primitive

### DIFF
--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -1,38 +1,28 @@
 <script>
-  /** @type {import("./languages").LanguageType<string>} */
-  export let language;
-
-  /** @type {any} */
-  export let code;
-
-  /** @type {boolean} */
-  export let langtag = false;
-
-  import hljs from "highlight.js/lib/core";
-  import { afterUpdate, createEventDispatcher } from "svelte";
+  import { createEventDispatcher } from "svelte";
+  import { highlightLanguage } from "./core.js";
+  import { createHighlighter } from "./highlighter.svelte.js";
   import LangTag from "./LangTag.svelte";
+
+  /** @type {{ language: import("./languages").LanguageType<string>; code: any; langtag?: boolean; [key: string]: any }} */
+  let { language, code, langtag = false, ...restProps } = $props();
 
   const dispatch = createEventDispatcher();
 
-  /** @type {string} */
-  let highlighted = "";
-
-  afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted });
-  });
-
-  $: {
-    hljs.registerLanguage(language.name, language.register);
-    highlighted = hljs.highlight(code, { language: language.name }).value;
-  }
+  const core = createHighlighter(
+    () => highlightLanguage(language, code),
+    (highlighted) => {
+      if (highlighted) dispatch("highlight", { highlighted });
+    },
+  );
 </script>
 
-<slot {highlighted} {langtag} languageName={language.name}>
+<slot highlighted={core.value} {langtag} languageName={language.name}>
   <LangTag
-    {...$$restProps}
+    {...restProps}
     languageName={language.name}
     {langtag}
-    {highlighted}
+    highlighted={core.value}
     {code}
   />
 </slot>

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -1,17 +1,16 @@
 <script>
+  import hljs from "highlight.js";
+  import { createEventDispatcher } from "svelte";
+  import { createHighlighter } from "./highlighter.svelte.js";
   import LangTag from "./LangTag.svelte";
 
-  /** @type {any} */
-  export let code;
-
-  /** @type {(import("./languages").LanguageName | (string & {}))[] | undefined} */
-  export let languageNames = undefined;
-
-  /** @type {boolean} */
-  export let langtag = false;
-
-  import hljs from "highlight.js";
-  import { afterUpdate, createEventDispatcher } from "svelte";
+  /** @type {{ code: any; languageNames?: (import("./languages").LanguageName | (string & {}))[]; langtag?: boolean; [key: string]: any }} */
+  let {
+    code,
+    languageNames = undefined,
+    langtag = false,
+    ...restProps
+  } = $props();
 
   /**
    * @typedef {{ highlighted: string; language: string; }} HighlightEventDetail
@@ -19,25 +18,21 @@
    */
   const dispatch = createEventDispatcher();
 
-  /** @type {string} */
-  let highlighted = "";
+  const core = createHighlighter(
+    () => hljs.highlightAuto(code, languageNames),
+    ({ value, language }) => {
+      if (value)
+        dispatch("highlight", { highlighted: value, language: language ?? "" });
+    },
+  );
 
-  /** @type {string} */
-  let language = "";
-
-  afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted, language });
-  });
-
-  $: ({ value: highlighted, language = "" } = hljs.highlightAuto(
-    code,
-    languageNames,
-  ));
+  let highlighted = $derived(core.value.value);
+  let language = $derived(core.value.language ?? "");
 </script>
 
 <slot {highlighted} {langtag} languageName={language}>
   <LangTag
-    {...$$restProps}
+    {...restProps}
     languageName={language}
     {langtag}
     {highlighted}

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -1,37 +1,29 @@
 <script>
+  import { createEventDispatcher } from "svelte";
+  import { highlightLanguage } from "./core.js";
+  import { createHighlighter } from "./highlighter.svelte.js";
   import LangTag from "./LangTag.svelte";
-
-  /** @type {any} */
-  export let code;
-
-  /** @type {boolean} */
-  export let langtag = false;
-
-  import hljs from "highlight.js/lib/core";
-  import { afterUpdate, createEventDispatcher } from "svelte";
   import svelte from "./languages/svelte";
+
+  /** @type {{ code: any; langtag?: boolean; [key: string]: any }} */
+  let { code, langtag = false, ...restProps } = $props();
 
   const dispatch = createEventDispatcher();
 
-  /** @type {string} */
-  let highlighted = "";
-
-  afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted });
-  });
-
-  $: {
-    hljs.registerLanguage(svelte.name, svelte.register);
-    highlighted = hljs.highlight(code, { language: svelte.name }).value;
-  }
+  const core = createHighlighter(
+    () => highlightLanguage(svelte, code),
+    (highlighted) => {
+      if (highlighted) dispatch("highlight", { highlighted });
+    },
+  );
 </script>
 
-<slot {highlighted} {langtag} languageName="svelte">
+<slot highlighted={core.value} {langtag} languageName="svelte">
   <LangTag
-    {...$$restProps}
+    {...restProps}
     languageName="svelte"
     {langtag}
-    {highlighted}
+    highlighted={core.value}
     {code}
   />
 </slot>

--- a/src/action.js
+++ b/src/action.js
@@ -1,4 +1,4 @@
-import hljs from "highlight.js/lib/core";
+import { highlightLanguage } from "./core.js";
 
 /**
  * Highlight an element in place with highlight.js.
@@ -9,11 +9,8 @@ import hljs from "highlight.js/lib/core";
 export function highlight(node, parameters) {
   /** @param {{ language: import("./languages").LanguageType<string>; code?: string }} params */
   function apply({ language, code }) {
-    if (!hljs.getLanguage(language.name)) {
-      hljs.registerLanguage(language.name, language.register);
-    }
     const source = code ?? node.textContent ?? "";
-    node.innerHTML = hljs.highlight(source, { language: language.name }).value;
+    node.innerHTML = highlightLanguage(language, source);
     node.classList.add("hljs");
   }
 

--- a/src/core.js
+++ b/src/core.js
@@ -1,0 +1,22 @@
+import hljs from "highlight.js/lib/core";
+
+/**
+ * Register a highlight.js language if it hasn't been registered yet.
+ * @param {import("./languages").LanguageType<string>} language
+ */
+export function registerLanguage(language) {
+  if (!hljs.getLanguage(language.name)) {
+    hljs.registerLanguage(language.name, language.register);
+  }
+}
+
+/**
+ * Register (if needed) and highlight `code` with the given language.
+ * @param {import("./languages").LanguageType<string>} language
+ * @param {any} code
+ * @returns {string}
+ */
+export function highlightLanguage(language, code) {
+  registerLanguage(language);
+  return hljs.highlight(code, { language: language.name }).value;
+}

--- a/src/highlighter.svelte.js
+++ b/src/highlighter.svelte.js
@@ -1,0 +1,22 @@
+/**
+ * Shared reactive core behind `Highlight`, `HighlightAuto`, and
+ * `HighlightSvelte`: derives a result from `compute` whenever its
+ * dependencies change, and notifies `onHighlight` when that result changes.
+ *
+ * @template T
+ * @param {() => T} compute
+ * @param {(result: T) => void} [onHighlight]
+ */
+export function createHighlighter(compute, onHighlight) {
+  const result = $derived.by(compute);
+
+  $effect(() => {
+    onHighlight?.(result);
+  });
+
+  return {
+    get value() {
+      return result;
+    },
+  };
+}


### PR DESCRIPTION
Highlight, HighlightSvelte, and the highlight action each reimplemented register-then-highlight, and HighlightAuto duplicated the derive-and-notify glue. This pulls both into core.js and a new highlighter.svelte.js rune primitive, converting those three components to Svelte 5 runes in the process. Public props, the on:highlight event shape, and slot signatures are unchanged.