### PR TITLE
feat(static): add build-time zero-runtime svelte-highlight/static preprocessor

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,60 @@ async function highlightFence(fenceLang, code) {
 }
 ```
 
+## Static mode
+
+`svelte-highlight/static` is a Svelte preprocessor. At build time it replaces `<Highlight>` usages that have known `code` and `language` with pre-rendered `highlight.js` HTML, so the client never downloads `highlight.js` or that grammar module.
+
+The biggest win is on server-rendered or statically-generated pages, since a client-only SPA still ships the pre-rendered markup as a string inside the JS bundle, just without `highlight.js` and the grammar module.
+
+```js
+// vite.config.js
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { highlightStatic } from "svelte-highlight/static";
+
+export default {
+  plugins: [svelte({ preprocess: [highlightStatic()] })],
+};
+```
+
+```svelte
+<script>
+  import Highlight from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+</script>
+
+<Highlight language={javascript} code="const x = 1;" />
+```
+
+At build time this becomes plain HTML:
+
+```html
+<pre class="hljs" data-language="javascript"><code class="hljs"
+  ><span class="hljs-keyword">const</span> x = <span class="hljs-number">1</span>;</code
+></pre>
+```
+
+The static transform runs only when all of these are true:
+
+- `language` is a plain identifier from a static `import` of `svelte-highlight/languages/*`.
+- `code` is a string literal or a template literal with no `${...}` interpolation.
+- The element has no slot content, spread props, or directives (`bind:`, `on:`, etc.).
+- `langtag` is not set. Static output can't pull in `langtag.css`; that only happens when a runtime `LangTag` is in the bundle.
+
+Dynamic `code` or `language`, `loadLanguage`, `HighlightAuto`, `HighlightSvelte`, and `HighlightEditable` keep the runtime component. No warning. That's intentional.
+
+If a usage looks static but still fails (language module missing, `highlight.js` throws), it falls back to the runtime component and calls `onWarn`. Usually that's a typo or a resolution quirk, not a dynamic usage you meant to keep:
+
+```js
+highlightStatic({
+  onWarn(message, { filename, line, cause }) {
+    // defaults to `console.warn(`[svelte-highlight/static] ${filename}:${line} - ${message}`)`
+  },
+});
+```
+
+Scope is small on purpose. Extra props on `<Highlight>` don't carry over to the emitted `<pre>`. Unused `Highlight` and language imports are left in place; bundlers drop them (`sideEffects` in `package.json` is narrow enough). No Astro/MDX fence hook yet.
+
 ## Action
 
 Use the `highlight` action to highlight existing `<pre><code>` markup in place. This is useful for progressively enhancing server-rendered content (e.g. markdown) without swapping in a component.

--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "svelte-highlight",
       "dependencies": {
         "highlight.js": "11.11.1",
+        "magic-string": "^0.30.17",
       },
       "devDependencies": {
         "@astrojs/svelte": "^8.1.2",
@@ -580,7 +581,7 @@
 
     "lru-cache": ["lru-cache@11.2.7", "", {}, "sha512-aY/R+aEsRelme17KGQa/1ZSIpLpNYYrhcrepKTZgE+W3WM16YMCaPwOHLHsmopZHELU0Ojin1lPVxKR0MihncA=="],
 
-    "magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+    "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "magicast": ["magicast@0.5.2", "", { "dependencies": { "@babel/parser": "^7.29.0", "@babel/types": "^7.29.0", "source-map-js": "^1.2.1" } }, "sha512-E3ZJh4J3S9KfwdjZhe2afj6R9lGIN5Pher1pF39UGrXRqq/VDaGVIGN13BjHd2u8B61hArAGOnso7nBOouW3TQ=="],
 
@@ -968,11 +969,11 @@
 
     "@shikijs/core/hast-util-to-html": ["hast-util-to-html@9.0.5", "", { "dependencies": { "@types/hast": "^3.0.0", "@types/unist": "^3.0.0", "ccount": "^2.0.0", "comma-separated-tokens": "^2.0.0", "hast-util-whitespace": "^3.0.0", "html-void-elements": "^3.0.0", "mdast-util-to-hast": "^13.0.0", "property-information": "^7.0.0", "space-separated-tokens": "^2.0.0", "stringify-entities": "^4.0.0", "zwitch": "^2.0.4" } }, "sha512-OguPdidb+fbHQSU4Q4ZiLKnzWo8Wwsf5bZfbvu7//a9oTYoqD/fWpe96NuHkoS9h0ccGOTe0C4NGXdtS0iObOw=="],
 
+    "@sveltejs/vite-plugin-svelte/magic-string": ["magic-string@0.30.17", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0" } }, "sha512-sNPKHvyjVf7gyjwS4xGTaW/mCnF8wnjtifKBEhxfZ7E/S8tQ0rssrwGNn6q8JH/ohItJfSQp9mBtQYuTlH5QnA=="],
+
     "@sveltejs/vite-plugin-svelte/vitefu": ["vitefu@1.1.1", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0-beta.0" }, "optionalPeers": ["vite"] }, "sha512-B/Fegf3i8zh0yFbpzZ21amWzHmuNlLlmJT6n7bu5e+pCHUKQIfXSYokrqOBGEMMe9UG2sostKQF9mml/vYaWJQ=="],
 
     "anymatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
-
-    "astro/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "bun-types/@types/node": ["@types/node@25.8.0", "", { "dependencies": { "undici-types": ">=7.24.0 <7.24.7" } }, "sha512-TCFSk8IZh+iLX1xtksoBVtdmgL+1IX0fC9BeU4QqFSuNdN/K+HUlhqOzEmSYYpZUVsLYcPqc9KX+60iDuninSQ=="],
 
@@ -997,8 +998,6 @@
     "jest-util/ci-info": ["ci-info@4.3.0", "", {}, "sha512-l+2bNRMiQgcfILUi33labAZYIWlH1kWDp+ecNo5iisRKrbm0xcRyCww71/YU0Fkw0mAFpz9bJayXPjey6vkmaQ=="],
 
     "jest-util/picomatch": ["picomatch@4.0.2", "", {}, "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg=="],
-
-    "magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
     "mdast-util-definitions/unist-util-visit": ["unist-util-visit@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg=="],
 
@@ -1026,8 +1025,6 @@
 
     "svelte/aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
-    "svelte/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
-
     "tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
 
     "unist-util-remove-position/unist-util-visit": ["unist-util-visit@5.0.0", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0", "unist-util-visit-parents": "^6.0.0" } }, "sha512-MR04uvD+07cwl/yhVuVWAtw+3GOR/knlL55Nd/wAdblk27GCVt3lqpTivy/tkJcZoNPzTwS1Y+KMojlLDhoTzg=="],
@@ -1037,8 +1034,6 @@
     "vite/postcss": ["postcss@8.5.14", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg=="],
 
     "@astrojs/svelte/@sveltejs/vite-plugin-svelte/@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@5.0.2", "", { "dependencies": { "obug": "^2.1.0" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0", "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig=="],
-
-    "@astrojs/svelte/@sveltejs/vite-plugin-svelte/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
 
     "@jest/pattern/@types/node/undici-types": ["undici-types@6.21.0", "", {}, "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ=="],
 
@@ -1053,6 +1048,8 @@
     "@playwright/experimental-ct-core/vite/postcss": ["postcss@8.5.6", "", { "dependencies": { "nanoid": "^3.3.11", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-3Ybi1tAuwAP9s0r1UQ2J4n5Y0G05bJkpUIO0/bI9MhwmD70S5aTWbXGBwxHrelT+XM1k6dM0pk+SwNkpTRN7Pg=="],
 
     "@shikijs/core/hast-util-to-html/property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "@sveltejs/vite-plugin-svelte/magic-string/@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.0", "", {}, "sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ=="],
 
     "caniuse-api/browserslist/electron-to-chromium": ["electron-to-chromium@1.5.90", "", {}, "sha512-C3PN4aydfW91Natdyd449Kw+BzhLmof6tzy5W1pFC5SpQxVXT+oyiyOG9AgYYSN9OdA/ik3YkCrpwqI8ug5Tug=="],
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
     "playwright": "playwright"
   },
   "dependencies": {
-    "highlight.js": "11.11.1"
+    "highlight.js": "11.11.1",
+    "magic-string": "^0.30.17"
   },
   "devDependencies": {
     "@astrojs/svelte": "^8.1.2",

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
     "package": "bun scripts/npm-package.ts",
     "test:unit": "bun test tests/*.ts",
     "test:e2e": "bunx playwright test",
+    "test:static-app": "bun run build:lib && bun run package && cd tests/e2e/static-app && bun install && bun run test",
     "test:types": "tsgo",
     "format": "biome format --write .",
     "lint": "biome lint .",

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -19,6 +19,14 @@ pkgJson.exports = {
     types: "./index.d.ts",
     svelte: "./index.js",
   },
+  "./static": {
+    types: "./static.d.ts",
+    import: "./static.js",
+  },
+  "./static.js": {
+    types: "./static.d.ts",
+    import: "./static.js",
+  },
   "./*.svelte": {
     types: "./*.svelte.d.ts",
     import: "./*.svelte",

--- a/src/preprocessor.js
+++ b/src/preprocessor.js
@@ -1,0 +1,373 @@
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import hljs from "highlight.js/lib/core";
+import MagicString from "magic-string";
+import { parse } from "svelte/compiler";
+
+// Bare specifiers resolve via this package's own subpath exports (Node self-reference).
+// Relative paths are only for this repo's own internal dev/testing.
+const HIGHLIGHT_SOURCE_RE = /^svelte-highlight(\/.*\.svelte)?$/;
+const HIGHLIGHT_RELATIVE_RE = /\/Highlight\.svelte$/;
+const LANGUAGE_SOURCE_RE = /^svelte-highlight\/languages\//;
+const LANGUAGE_RELATIVE_RE = /\/languages\//;
+
+/** @param {string} source */
+function isHighlightImportSource(source) {
+  return HIGHLIGHT_SOURCE_RE.test(source) || HIGHLIGHT_RELATIVE_RE.test(source);
+}
+
+/** @param {string} source */
+function isLanguageImportSource(source) {
+  return LANGUAGE_SOURCE_RE.test(source) || LANGUAGE_RELATIVE_RE.test(source);
+}
+
+/** @param {import("svelte/compiler").AST.Root} ast */
+function collectDefaultImports(ast) {
+  /** @type {Map<string, string>} */
+  const imports = new Map();
+  const body = ast.instance?.content.body ?? [];
+
+  for (const node of body) {
+    if (node.type !== "ImportDeclaration") continue;
+    for (const specifier of node.specifiers) {
+      if (specifier.type === "ImportDefaultSpecifier") {
+        imports.set(specifier.local.name, String(node.source.value));
+      }
+    }
+  }
+
+  return imports;
+}
+
+/**
+ * Recursively collect every Component/RegularElement in the fragment tree,
+ * including those nested inside control-flow blocks.
+ *
+ * @param {import("svelte/compiler").AST.Fragment | null | undefined} fragment
+ * @param {import("svelte/compiler").AST.ElementLike[]} out
+ */
+function collectElements(fragment, out = []) {
+  if (!fragment) return out;
+
+  for (const node of fragment.nodes) {
+    switch (node.type) {
+      case "Component":
+      case "RegularElement":
+        out.push(node);
+        collectElements(node.fragment, out);
+        break;
+      case "IfBlock":
+        collectElements(node.consequent, out);
+        if (node.alternate) collectElements(node.alternate, out);
+        break;
+      case "EachBlock":
+        collectElements(node.body, out);
+        if (node.fallback) collectElements(node.fallback, out);
+        break;
+      case "AwaitBlock":
+        if (node.pending) collectElements(node.pending, out);
+        if (node.then) collectElements(node.then, out);
+        if (node.catch) collectElements(node.catch, out);
+        break;
+      case "KeyBlock":
+        collectElements(node.fragment, out);
+        break;
+      case "SnippetBlock":
+        collectElements(node.body, out);
+        break;
+      default:
+        break;
+    }
+  }
+
+  return out;
+}
+
+/** @param {import("svelte/compiler").AST.Fragment} fragment */
+function isSlotEmpty(fragment) {
+  return fragment.nodes.every(
+    (node) => node.type === "Text" && node.data.trim() === "",
+  );
+}
+
+/** @param {import("estree").Expression} expression */
+function getStaticStringExpression(expression) {
+  if (expression.type === "Literal" && typeof expression.value === "string") {
+    return expression.value;
+  }
+  if (
+    expression.type === "TemplateLiteral" &&
+    expression.expressions.length === 0
+  ) {
+    return expression.quasis.map((quasi) => quasi.value.cooked ?? "").join("");
+  }
+  return null;
+}
+
+/** @param {import("svelte/compiler").AST.Attribute} attribute */
+function getStaticStringAttribute(attribute) {
+  if (attribute.value === true) return null;
+  const values = Array.isArray(attribute.value)
+    ? attribute.value
+    : [attribute.value];
+  if (values.length !== 1) return null;
+  const [value] = values;
+  if (!value) return null;
+  if (value.type === "Text") return value.data;
+  if (value.type === "ExpressionTag")
+    return getStaticStringExpression(value.expression);
+  return null;
+}
+
+/** @param {import("svelte/compiler").AST.Attribute} attribute */
+function getIdentifierAttribute(attribute) {
+  if (attribute.value === true) return null;
+  const values = Array.isArray(attribute.value)
+    ? attribute.value
+    : [attribute.value];
+  if (values.length !== 1) return null;
+  const [value] = values;
+  if (
+    value?.type !== "ExpressionTag" ||
+    value.expression.type !== "Identifier"
+  ) {
+    return null;
+  }
+  return value.expression.name;
+}
+
+/**
+ * @param {import("svelte/compiler").AST.ElementLike} element
+ * @param {Map<string, string>} imports
+ */
+function matchHighlightElement(element, imports) {
+  if (element.type !== "Component") return null;
+
+  const importSource = imports.get(element.name);
+  if (!importSource || !isHighlightImportSource(importSource)) return null;
+  if (!isSlotEmpty(element.fragment)) return null;
+
+  /** @type {Map<string, import("svelte/compiler").AST.Attribute>} */
+  const attrs = new Map();
+  for (const attribute of element.attributes) {
+    // Reject spread attributes and any directive (bind:, on:, use:, class:, etc.) -
+    // none of these can be safely replicated in static HTML.
+    if (attribute.type !== "Attribute") return null;
+    // Reject any attribute outside the supported set (this also excludes `langtag`,
+    // which needs global CSS the static output can't guarantee is bundled - see README).
+    if (attribute.name !== "language" && attribute.name !== "code") return null;
+    attrs.set(attribute.name, attribute);
+  }
+
+  const codeAttr = attrs.get("code");
+  const languageAttr = attrs.get("language");
+  if (!codeAttr || !languageAttr) return null;
+
+  const code = getStaticStringAttribute(codeAttr);
+  if (code === null) return null;
+
+  const languageLocalName = getIdentifierAttribute(languageAttr);
+  if (languageLocalName === null) return null;
+
+  const languageSource = imports.get(languageLocalName);
+  if (!languageSource || !isLanguageImportSource(languageSource)) return null;
+
+  return { code, languageSource };
+}
+
+/**
+ * @param {string} source
+ * @param {string | undefined} filename
+ */
+async function resolveLanguageModule(source, filename) {
+  if (source.startsWith(".") || source.startsWith("/")) {
+    const base = filename
+      ? path.dirname(path.resolve(filename))
+      : process.cwd();
+    const resolved = path.resolve(base, source);
+    return import(pathToFileURL(resolved).href);
+  }
+  return import(source);
+}
+
+/** @param {string} value */
+function escapeAttribute(value) {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+/**
+ * @param {string} content
+ * @param {number} index
+ */
+function locate(content, index) {
+  let line = 1;
+  let lastNewline = -1;
+
+  for (let i = 0; i < index; i += 1) {
+    if (content[i] === "\n") {
+      line += 1;
+      lastNewline = i;
+    }
+  }
+
+  return { line, column: index - lastNewline };
+}
+
+/**
+ * @param {string} message
+ * @param {{ filename?: string | undefined; line: number; cause: unknown }} details
+ */
+function defaultWarn(message, details) {
+  const location = details.filename
+    ? `${details.filename}:${details.line}`
+    : `line ${details.line}`;
+  console.warn(
+    `[svelte-highlight/static] ${location} - ${message}; falling back to runtime Highlight.`,
+  );
+}
+
+/**
+ * Escape literal `{`/`}` so Svelte's compiler (which re-parses the preprocessed markup) treats
+ * them as text instead of the start/end of a template expression. Needed because the highlighted
+ * source can legitimately contain braces (CSS rules, JS/TS blocks and objects, JSON, etc.).
+ *
+ * @param {string} html
+ */
+function escapeSvelteBraces(html) {
+  return html.replace(/[{}]/g, (char) => (char === "{" ? "{'{'}" : "{'}'}"));
+}
+
+/**
+ * @param {import("./languages").LanguageType<string>} language
+ * @param {string} code
+ */
+function renderStatic(language, code) {
+  if (!hljs.getLanguage(language.name)) {
+    hljs.registerLanguage(language.name, language.register);
+  }
+  const { value } = hljs.highlight(code, { language: language.name });
+  return escapeSvelteBraces(
+    `<pre class="hljs" data-language="${escapeAttribute(language.name)}" ` +
+      `style="overflow-x:var(--overflow-x, auto);overflow-y:var(--overflow-y, auto);` +
+      `border-radius:var(--border-radius, 0);width:var(--width, auto);max-width:var(--max-width, none)">` +
+      `<code class="hljs">${value}</code></pre>`,
+  );
+}
+
+/**
+ * @typedef {{
+ *   onWarn?: (message: string, details: { filename?: string | undefined; line: number; cause: unknown }) => void;
+ * }} HighlightStaticOptions
+ */
+
+/**
+ * Build-time preprocessor: replaces `<Highlight code="..." language={lang} />` with
+ * pre-rendered highlight.js HTML when `code` and `language` are known at compile time.
+ * Dynamic usages keep the runtime component without a warning.
+ *
+ * If a usage looks static but fails to resolve or highlight, it still falls back and
+ * `onWarn` runs (default: `console.warn`).
+ *
+ * @param {HighlightStaticOptions} [options]
+ * @returns {import("svelte/compiler").PreprocessorGroup}
+ */
+export function highlightStatic(options = {}) {
+  const warn = options.onWarn ?? defaultWarn;
+
+  return {
+    name: "svelte-highlight-static",
+    async markup({ content, filename }) {
+      if (
+        !content.includes("svelte-highlight") &&
+        !content.includes("Highlight.svelte")
+      ) {
+        return;
+      }
+
+      /** @type {import("svelte/compiler").AST.Root} */
+      let ast;
+      /** @type {{ filename?: string; modern: true }} */
+      const parseOptions =
+        filename === undefined ? { modern: true } : { filename, modern: true };
+      try {
+        ast = parse(content, parseOptions);
+      } catch {
+        // Let the real compiler surface the syntax error.
+        return;
+      }
+
+      const imports = collectDefaultImports(ast);
+      if (imports.size === 0) return;
+
+      const matches = collectElements(ast.fragment)
+        .map((element) => {
+          const match = matchHighlightElement(element, imports);
+          return match && { element, ...match };
+        })
+        .filter((match) => match !== null);
+      if (matches.length === 0) return;
+
+      const htmlByMatch = await Promise.all(
+        matches.map(async (match) => {
+          const line = locate(content, match.element.start).line;
+
+          /** @type {import("./languages").LanguageType<string>} */
+          let language;
+          try {
+            const languageModule = await resolveLanguageModule(
+              match.languageSource,
+              filename,
+            );
+            language = languageModule.default ?? languageModule;
+          } catch (cause) {
+            warn(
+              `could not resolve language module "${match.languageSource}"`,
+              {
+                filename,
+                line,
+                cause,
+              },
+            );
+            return null;
+          }
+
+          try {
+            return renderStatic(language, match.code);
+          } catch (cause) {
+            warn(
+              `highlight.js failed to highlight the code (language "${language.name}")`,
+              {
+                filename,
+                line,
+                cause,
+              },
+            );
+            return null;
+          }
+        }),
+      );
+
+      const ms = new MagicString(content);
+      let changed = false;
+
+      for (const [index, match] of matches.entries()) {
+        const html = htmlByMatch[index];
+        if (!html) continue;
+
+        try {
+          ms.overwrite(match.element.start, match.element.end, html);
+          changed = true;
+        } catch (cause) {
+          warn("failed to apply the static replacement", {
+            filename,
+            line: locate(content, match.element.start).line,
+            cause,
+          });
+        }
+      }
+
+      if (!changed) return;
+      return { code: ms.toString(), map: ms.generateMap({ hires: true }) };
+    },
+  };
+}

--- a/src/static.d.ts
+++ b/src/static.d.ts
@@ -1,0 +1,36 @@
+import type { PreprocessorGroup } from "svelte/compiler";
+
+export interface HighlightStaticOptions {
+  /**
+   * Called when a usage looks static but fails to resolve or highlight (missing language
+   * module, `highlight.js` throw, etc.). It still falls back to runtime `Highlight`; this
+   * hook is for logging those failures.
+   *
+   * Defaults to `console.warn`.
+   */
+  onWarn?: (
+    message: string,
+    details: { filename?: string; line: number; cause: unknown },
+  ) => void;
+}
+
+/**
+ * Build-time preprocessor: replaces `<Highlight code="..." language={lang} />` with
+ * pre-rendered highlight.js HTML when `code` and `language` are known at compile time.
+ * Dynamic `code`/`language`, slot content, spread props, directives, and `langtag` keep
+ * the runtime `Highlight` component.
+ *
+ * @example
+ * ```js
+ * // vite.config.js / svelte.config.js
+ * import { svelte } from "@sveltejs/vite-plugin-svelte";
+ * import { highlightStatic } from "svelte-highlight/static";
+ *
+ * export default {
+ *   plugins: [svelte({ preprocess: [highlightStatic()] })],
+ * };
+ * ```
+ */
+export function highlightStatic(
+  options?: HighlightStaticOptions,
+): PreprocessorGroup;

--- a/src/static.js
+++ b/src/static.js
@@ -1,0 +1,1 @@
+export { highlightStatic } from "./preprocessor.js";

--- a/tests/e2e/static-app/.gitignore
+++ b/tests/e2e/static-app/.gitignore
@@ -1,0 +1,1 @@
+bun.lock

--- a/tests/e2e/static-app/README.md
+++ b/tests/e2e/static-app/README.md
@@ -1,0 +1,58 @@
+# tests/e2e/static-app
+
+Multi-entry Vite 8 + Svelte 5 app for `svelte-highlight/static`. Each folder under `entries/` is a tiny app with one scenario, built with real `vite build` against the packaged output in `../../../package`, not the monorepo `src/`.
+
+Layout follows [carbon-preprocess-svelte's `examples/vite@svelte-5`](https://github.com/carbon-design-system/carbon-preprocess-svelte/tree/main/examples/vite%40svelte-5): one `vite.config.ts` reads `ENTRY` for `root`/`outDir`, `entries.manifest.json` lists entries, and `scripts/build-all-entries.ts` builds and verifies them in order.
+
+`tests/static-preprocessor.test.ts` calls `preprocess()` directly. These builds go through `@sveltejs/vite-plugin-svelte` and Vite 8. `verify.ts` checks that `highlight.js` never lands in the bundle.
+
+## Entries
+
+| Entry | Scenario |
+| --- | --- |
+| `single-snippet-injected-style` | One static `<Highlight>`; theme via `svelte:head` injected style |
+| `single-snippet-stylesheet` | One static `<Highlight>`; theme via `svelte-highlight/styles/atom-one-dark.css` import |
+| `multiple-snippets-same-language` | Three static `<Highlight>` usages, same language |
+| `multiple-snippets-various-languages` | Three static usages: javascript, typescript, css |
+| `scoped-styles-multiple-themes` | Two static usages, each in a different `HighlightStyle` theme |
+
+## Layout
+
+```
+entries/<name>/
+  index.html
+  App.svelte
+entries.manifest.json   # list for build-all-entries.ts and verify.ts
+vite.config.ts          # root = entries/<ENTRY>, outDir = dist/<ENTRY>
+verify.ts               # per-entry assertions, run with `node verify.ts <entry>`
+scripts/
+  ensure-ready.ts       # builds ../../../package if missing (see below)
+  build-all-entries.ts  # builds + verifies every entry in entries.manifest.json
+dist/<name>/            # per-entry build output (gitignored)
+```
+
+## Running
+
+The app depends on `"svelte-highlight": "file:../../../package"`. `bun install` fails if that folder doesn't exist yet, because `file:` deps resolve before any lifecycle script runs.
+
+`dev`, `build`, and `test` all run `scripts/ensure-ready.ts` first (`predev`/`prebuild`/`pretest`). It builds `../../../package` (`bun run build:lib && bun run package`) and runs `bun install` here when needed. From this directory:
+
+```bash
+bun run test
+```
+
+works on a fresh checkout with no manual root step. The guard only runs when something is missing, so repeat runs stay fast. After you edit `src/preprocessor.js` or anything else in the root package, delete `../../../package` so the guard rebuilds it, or run from the repo root for an always-fresh build:
+
+```bash
+bun run test:static-app
+```
+
+`bun run test` and `bun run build` both call `scripts/build-all-entries.ts`, which loops `entries.manifest.json`, runs `ENTRY=<name> vite build`, then `node verify.ts <name>`. Single entry:
+
+```bash
+bun run dev:scoped-styles-multiple-themes
+bun run build:multiple-snippets-various-languages
+node verify.ts multiple-snippets-various-languages
+```
+
+`verify.ts` checks static markup and theme CSS in the output, and that `highlight.js` core is absent (via minification-resistant internal strings).

--- a/tests/e2e/static-app/entries.manifest.json
+++ b/tests/e2e/static-app/entries.manifest.json
@@ -1,0 +1,7 @@
+[
+  "single-snippet-injected-style",
+  "single-snippet-stylesheet",
+  "multiple-snippets-same-language",
+  "multiple-snippets-various-languages",
+  "scoped-styles-multiple-themes"
+]

--- a/tests/e2e/static-app/entries/multiple-snippets-same-language/App.svelte
+++ b/tests/e2e/static-app/entries/multiple-snippets-same-language/App.svelte
@@ -1,0 +1,11 @@
+<script>
+  import Highlight from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<Highlight language={javascript} code="const a = 1;" />
+<Highlight language={javascript} code="const b = 2;" />
+<Highlight language={javascript} code="const c = 3;" />

--- a/tests/e2e/static-app/entries/multiple-snippets-same-language/index.html
+++ b/tests/e2e/static-app/entries/multiple-snippets-same-language/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>multiple-snippets-same-language</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import { mount } from "svelte";
+      import App from "./App.svelte";
+
+      mount(App, { target: document.getElementById("app") });
+    </script>
+  </body>
+</html>

--- a/tests/e2e/static-app/entries/multiple-snippets-various-languages/App.svelte
+++ b/tests/e2e/static-app/entries/multiple-snippets-various-languages/App.svelte
@@ -1,0 +1,13 @@
+<script>
+  import Highlight from "svelte-highlight";
+  import css from "svelte-highlight/languages/css";
+  import javascript from "svelte-highlight/languages/javascript";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<Highlight language={javascript} code="const x = 1;" />
+<Highlight language={typescript} code="const y: number = 2;" />
+<Highlight language={css} code={".a { color: red; }"} />

--- a/tests/e2e/static-app/entries/multiple-snippets-various-languages/index.html
+++ b/tests/e2e/static-app/entries/multiple-snippets-various-languages/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>multiple-snippets-various-languages</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import { mount } from "svelte";
+      import App from "./App.svelte";
+
+      mount(App, { target: document.getElementById("app") });
+    </script>
+  </body>
+</html>

--- a/tests/e2e/static-app/entries/scoped-styles-multiple-themes/App.svelte
+++ b/tests/e2e/static-app/entries/scoped-styles-multiple-themes/App.svelte
@@ -1,0 +1,14 @@
+<script>
+  import Highlight, { HighlightStyle } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import a11yDark from "svelte-highlight/styles/a11y-dark";
+  import github from "svelte-highlight/styles/github";
+</script>
+
+<HighlightStyle theme={a11yDark}>
+  <Highlight language={javascript} code="const x = 1;" />
+</HighlightStyle>
+
+<HighlightStyle theme={github}>
+  <Highlight language={javascript} code="const y = 2;" />
+</HighlightStyle>

--- a/tests/e2e/static-app/entries/scoped-styles-multiple-themes/index.html
+++ b/tests/e2e/static-app/entries/scoped-styles-multiple-themes/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>scoped-styles-multiple-themes</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import { mount } from "svelte";
+      import App from "./App.svelte";
+
+      mount(App, { target: document.getElementById("app") });
+    </script>
+  </body>
+</html>

--- a/tests/e2e/static-app/entries/single-snippet-injected-style/App.svelte
+++ b/tests/e2e/static-app/entries/single-snippet-injected-style/App.svelte
@@ -1,0 +1,9 @@
+<script>
+  import Highlight from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<Highlight language={javascript} code="const x = 1;" />

--- a/tests/e2e/static-app/entries/single-snippet-injected-style/index.html
+++ b/tests/e2e/static-app/entries/single-snippet-injected-style/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>single-snippet-injected-style</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import { mount } from "svelte";
+      import App from "./App.svelte";
+
+      mount(App, { target: document.getElementById("app") });
+    </script>
+  </body>
+</html>

--- a/tests/e2e/static-app/entries/single-snippet-stylesheet/App.svelte
+++ b/tests/e2e/static-app/entries/single-snippet-stylesheet/App.svelte
@@ -1,0 +1,7 @@
+<script>
+  import "svelte-highlight/styles/atom-one-dark.css";
+  import Highlight from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+</script>
+
+<Highlight language={javascript} code="const x = 1;" />

--- a/tests/e2e/static-app/entries/single-snippet-stylesheet/index.html
+++ b/tests/e2e/static-app/entries/single-snippet-stylesheet/index.html
@@ -1,0 +1,16 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8">
+    <title>single-snippet-stylesheet</title>
+  </head>
+  <body>
+    <div id="app"></div>
+    <script type="module">
+      import { mount } from "svelte";
+      import App from "./App.svelte";
+
+      mount(App, { target: document.getElementById("app") });
+    </script>
+  </body>
+</html>

--- a/tests/e2e/static-app/package.json
+++ b/tests/e2e/static-app/package.json
@@ -1,0 +1,36 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "predev": "node scripts/ensure-ready.ts",
+    "dev": "vite",
+    "prebuild": "node scripts/ensure-ready.ts",
+    "build": "bun scripts/build-all-entries.ts",
+    "preview": "vite preview",
+    "pretest": "node scripts/ensure-ready.ts",
+    "test": "bun scripts/build-all-entries.ts",
+    "dev:single-snippet-injected-style": "ENTRY=single-snippet-injected-style vite",
+    "build:single-snippet-injected-style": "ENTRY=single-snippet-injected-style vite build",
+    "preview:single-snippet-injected-style": "ENTRY=single-snippet-injected-style vite preview",
+    "dev:single-snippet-stylesheet": "ENTRY=single-snippet-stylesheet vite",
+    "build:single-snippet-stylesheet": "ENTRY=single-snippet-stylesheet vite build",
+    "preview:single-snippet-stylesheet": "ENTRY=single-snippet-stylesheet vite preview",
+    "dev:multiple-snippets-same-language": "ENTRY=multiple-snippets-same-language vite",
+    "build:multiple-snippets-same-language": "ENTRY=multiple-snippets-same-language vite build",
+    "preview:multiple-snippets-same-language": "ENTRY=multiple-snippets-same-language vite preview",
+    "dev:multiple-snippets-various-languages": "ENTRY=multiple-snippets-various-languages vite",
+    "build:multiple-snippets-various-languages": "ENTRY=multiple-snippets-various-languages vite build",
+    "preview:multiple-snippets-various-languages": "ENTRY=multiple-snippets-various-languages vite preview",
+    "dev:scoped-styles-multiple-themes": "ENTRY=scoped-styles-multiple-themes vite",
+    "build:scoped-styles-multiple-themes": "ENTRY=scoped-styles-multiple-themes vite build",
+    "preview:scoped-styles-multiple-themes": "ENTRY=scoped-styles-multiple-themes vite preview"
+  },
+  "dependencies": {
+    "svelte-highlight": "file:../../../package"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "^7.1.2",
+    "svelte": "^5.56.3",
+    "vite": "^8.1.2"
+  }
+}

--- a/tests/e2e/static-app/scripts/build-all-entries.ts
+++ b/tests/e2e/static-app/scripts/build-all-entries.ts
@@ -1,0 +1,28 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { $ } from "bun";
+
+const appDir = join(import.meta.dirname, "..");
+const manifest = JSON.parse(
+  readFileSync(join(appDir, "entries.manifest.json"), "utf8"),
+);
+
+let failed = false;
+
+for (const entry of manifest) {
+  console.log(`\nBuilding entry: ${entry}`);
+  try {
+    // biome-ignore lint/performance/noAwaitInLoops: sequential builds avoid dist races and keep logs readable
+    await $`cd ${appDir} && ENTRY=${entry} bunx vite build`;
+    await $`cd ${appDir} && node verify.ts ${entry}`;
+  } catch {
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error("\nOne or more static-app entries failed.");
+  process.exit(1);
+}
+
+console.log("\nAll static-app entries passed.");

--- a/tests/e2e/static-app/scripts/ensure-ready.ts
+++ b/tests/e2e/static-app/scripts/ensure-ready.ts
@@ -1,0 +1,24 @@
+import { execFileSync } from "node:child_process";
+import { existsSync } from "node:fs";
+
+const repoRoot = new URL("../../../../", import.meta.url);
+const appDir = new URL("../", import.meta.url);
+
+function run(cmd: string, args: string[], cwd: URL) {
+  execFileSync(cmd, args, { cwd, stdio: "inherit" });
+}
+
+if (!existsSync(new URL("package/package.json", repoRoot))) {
+  console.log(
+    "[static-app] svelte-highlight package/ not found - building it first (bun run build:lib && bun run package)...",
+  );
+  run("bun", ["run", "build:lib"], repoRoot);
+  run("bun", ["run", "package"], repoRoot);
+}
+
+if (
+  !existsSync(new URL("node_modules/svelte-highlight/package.json", appDir))
+) {
+  console.log("[static-app] installing dependencies...");
+  run("bun", ["install"], appDir);
+}

--- a/tests/e2e/static-app/verify.ts
+++ b/tests/e2e/static-app/verify.ts
@@ -1,0 +1,131 @@
+import { readdirSync, readFileSync } from "node:fs";
+import { join } from "node:path";
+
+const BUILT_ASSET_RE = /\.(js|html|css)$/;
+
+// A private, minification-resistant internal string from highlight.js/lib/core - present only if
+// highlight.js core actually ships in the bundle.
+const HLJS_CORE_MARKER = "highlight.js/private";
+// highlight.js's own registerLanguage error string - a second, independent absence check.
+const HLJS_REGISTER_MARKER = "Language definition for";
+
+function readAllText(dir: string): string {
+  let text = "";
+
+  for (const entry of readdirSync(dir, { withFileTypes: true })) {
+    const path = join(dir, entry.name);
+    if (entry.isDirectory()) {
+      text += readAllText(path);
+    } else if (BUILT_ASSET_RE.test(entry.name)) {
+      text += readFileSync(path, "utf8");
+    }
+  }
+
+  return text;
+}
+
+function noRuntimeHljs(output: string): Array<{ name: string; pass: boolean }> {
+  return [
+    {
+      name: "highlight.js core is not bundled (a private, minification-resistant internal string is absent)",
+      pass: !output.includes(HLJS_CORE_MARKER),
+    },
+    {
+      name: "highlight.js's registerLanguage error string is not bundled",
+      pass: !output.includes(HLJS_REGISTER_MARKER),
+    },
+  ];
+}
+
+const CHECKS: Record<
+  string,
+  (output: string) => Array<{ name: string; pass: boolean }>
+> = {
+  "single-snippet-injected-style": (output) => [
+    {
+      name: "the static hljs markup for the <Highlight> usage is present",
+      pass:
+        output.includes('data-language="javascript"') &&
+        output.includes("hljs-keyword"),
+    },
+    {
+      name: "the atom-one-dark theme (loaded via svelte:head) is present",
+      pass: output.includes("#282c34") && output.includes("#abb2bf"),
+    },
+    ...noRuntimeHljs(output),
+  ],
+  "single-snippet-stylesheet": (output) => [
+    {
+      name: "the static hljs markup for the <Highlight> usage is present",
+      pass:
+        output.includes('data-language="javascript"') &&
+        output.includes("hljs-keyword"),
+    },
+    {
+      name: "the atom-one-dark theme (loaded via a CSS stylesheet import) is present",
+      pass: output.includes("#282c34") && output.includes("#abb2bf"),
+    },
+    ...noRuntimeHljs(output),
+  ],
+  "multiple-snippets-same-language": (output) => [
+    {
+      name: "all three same-language <Highlight> usages are statically rendered",
+      pass:
+        (output.match(/data-language="javascript"/g) ?? []).length >= 3 &&
+        output.includes('a = <span class="hljs-number">1') &&
+        output.includes('b = <span class="hljs-number">2') &&
+        output.includes('c = <span class="hljs-number">3'),
+    },
+    ...noRuntimeHljs(output),
+  ],
+  "multiple-snippets-various-languages": (output) => [
+    {
+      name: "the javascript, typescript, and css <Highlight> usages are all statically rendered",
+      pass:
+        output.includes('data-language="javascript"') &&
+        output.includes('data-language="typescript"') &&
+        output.includes('data-language="css"'),
+    },
+    ...noRuntimeHljs(output),
+  ],
+  "scoped-styles-multiple-themes": (output) => [
+    {
+      name: "both <Highlight> usages (one per HighlightStyle scope) are statically rendered",
+      pass: (output.match(/data-language="javascript"/g) ?? []).length >= 2,
+    },
+    {
+      name: "both themes (a11y-dark and github) are present, each under its own scope class",
+      // a11y-dark's base background; github's base color.
+      pass: output.includes("#2b2b2b") && output.includes("#24292e"),
+    },
+    ...noRuntimeHljs(output),
+  ],
+};
+
+const entry = process.argv[2] ?? process.env.ENTRY;
+
+if (!entry || !CHECKS[entry]) {
+  console.error(
+    `Usage: node verify.ts <entry>\nKnown entries: ${Object.keys(CHECKS).join(", ")}`,
+  );
+  process.exit(1);
+}
+
+const distDir = new URL(`./dist/${entry}/`, import.meta.url).pathname;
+const output = readAllText(distDir);
+const checks = CHECKS[entry](output);
+
+let failed = false;
+
+console.log(`\n${entry}:`);
+for (const check of checks) {
+  console.log(`  ${check.pass ? "PASS" : "FAIL"} - ${check.name}`);
+  if (!check.pass) failed = true;
+}
+
+if (failed) {
+  console.error(`\n${entry}: verification failed.`);
+  process.exit(1);
+}
+
+console.log(`\n${entry}: verification passed.`);

--- a/tests/e2e/static-app/vite.config.ts
+++ b/tests/e2e/static-app/vite.config.ts
@@ -1,0 +1,16 @@
+import { resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { highlightStatic } from "svelte-highlight/static.js";
+
+const dir = fileURLToPath(new URL(".", import.meta.url));
+const entry = process.env.ENTRY ?? "single-snippet-injected-style";
+
+export default {
+  root: resolve(dir, "entries", entry),
+  build: {
+    outDir: resolve(dir, "dist", entry),
+    emptyOutDir: true,
+  },
+  plugins: [svelte({ preprocess: [highlightStatic()] })],
+};

--- a/tests/static-preprocessor.test.ts
+++ b/tests/static-preprocessor.test.ts
@@ -1,0 +1,176 @@
+import { compile, preprocess } from "svelte/compiler";
+import { highlightStatic } from "../src/static.js";
+
+const filename = "tests/fixture.svelte";
+
+/** @param {string} source */
+async function transform(source: string) {
+  const result = await preprocess(source, highlightStatic(), { filename });
+  return result.code;
+}
+
+describe("highlightStatic", () => {
+  it("replaces a literal code + imported language usage with static hljs markup", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+<Highlight language={javascript} code="const x = 1;" />
+`;
+    const output = await transform(source);
+
+    expect(output).not.toContain("<Highlight");
+    expect(output).toContain('<pre class="hljs" data-language="javascript"');
+    expect(output).toContain('<code class="hljs">');
+    expect(output).toContain("hljs-keyword");
+    // Runtime imports are left in place; tree-shaking is left to the consumer's bundler.
+    expect(output).toContain('import Highlight from "../src/Highlight.svelte"');
+  });
+
+  it("leaves dynamic code untouched", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+  let code = "const x = 1;";
+</script>
+
+<Highlight language={javascript} {code} />
+`;
+    const output = await transform(source);
+    expect(output).toBe(source);
+  });
+
+  it("leaves dynamic language untouched", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+
+  function getLanguage() {}
+</script>
+
+<Highlight language={getLanguage()} code="const x = 1;" />
+`;
+    const output = await transform(source);
+    expect(output).toBe(source);
+  });
+
+  it("leaves usages with default slot content untouched", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+<Highlight language={javascript} code="const x = 1;">
+  custom
+</Highlight>
+`;
+    const output = await transform(source);
+    expect(output).toBe(source);
+  });
+
+  it("leaves usages with the langtag prop untouched", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+<Highlight language={javascript} code="const x = 1;" langtag />
+`;
+    const output = await transform(source);
+    expect(output).toBe(source);
+  });
+
+  it("leaves untouched when a local component is merely named Highlight", async () => {
+    const source = `<script>
+  import Highlight from "./MyOwnComponent.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+<Highlight language={javascript} code="const x = 1;" />
+`;
+    const output = await transform(source);
+    expect(output).toBe(source);
+  });
+
+  it("only transforms the eligible usage when multiple Highlight elements are present", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+  let code = "const x = 1;";
+</script>
+
+<Highlight language={javascript} code="const eligible = 1;" />
+<Highlight language={javascript} {code} />
+`;
+    const output = await transform(source);
+
+    expect(output).toContain('data-language="javascript"');
+    expect(output).toContain("<Highlight language={javascript} {code} />");
+    expect(output.match(/<Highlight/g)).toHaveLength(1);
+  });
+
+  it("escapes literal braces in the highlighted output so the compiler doesn't parse them as expressions", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import css from "../src/languages/css.js";
+</script>
+
+<Highlight language={css} code={".a { color: red; }"} />
+`;
+    const output = await transform(source);
+
+    expect(output).not.toContain("<Highlight");
+    expect(output).toContain("{'{'}");
+    expect(output).toContain("{'}'}");
+    // The real regression check: unescaped braces would make the compiler throw a
+    // js_parse_error when it re-parses the preprocessed markup.
+    expect(() => compile(output, { filename })).not.toThrow();
+  });
+
+  it("falls back and reports via onWarn when an eligible usage's language module can't be resolved", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import doesNotExist from "svelte-highlight/languages/does-not-exist";
+</script>
+
+<Highlight language={doesNotExist} code="const x = 1;" />
+`;
+    const warnings: Array<{ message: string; details: unknown }> = [];
+    const result = await preprocess(
+      source,
+      highlightStatic({
+        onWarn: (message, details) => warnings.push({ message, details }),
+      }),
+      { filename },
+    );
+
+    expect(result.code).toBe(source);
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]?.message).toContain(
+      'could not resolve language module "svelte-highlight/languages/does-not-exist"',
+    );
+    expect(warnings[0]?.details).toMatchObject({ filename, line: 6 });
+  });
+
+  it("defaults to console.warn without throwing when onWarn is not provided", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import doesNotExist from "svelte-highlight/languages/does-not-exist";
+</script>
+
+<Highlight language={doesNotExist} code="const x = 1;" />
+`;
+    const originalWarn = console.warn;
+    const calls: unknown[][] = [];
+    console.warn = (...args: unknown[]) => calls.push(args);
+
+    try {
+      const output = await transform(source);
+      expect(output).toBe(source);
+      expect(calls).toHaveLength(1);
+      expect(String(calls[0]?.[0])).toContain("[svelte-highlight/static]");
+    } finally {
+      console.warn = originalWarn;
+    }
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,6 @@
       "svelte-highlight/*": ["./src/*"]
     }
   },
-  "include": ["src/**/*", "www/**/*", "tests/**/*", "scripts/**/*"]
+  "include": ["src/**/*", "www/**/*", "tests/**/*", "scripts/**/*"],
+  "exclude": ["tests/e2e/static-app/dist/**"]
 }

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -756,6 +756,126 @@
   </Column>
 </Row>
 
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Static Mode</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">svelte-highlight/static</code>
+      is a Svelte preprocessor. At build time it replaces
+      <code class="code">Highlight</code>
+      usages with known <code class="code">code</code> and
+      <code class="code">language</code>
+      with pre-rendered
+      <code class="code">highlight.js</code>
+      HTML, so the client never downloads
+      <code class="code">highlight.js</code>
+      or that grammar module.
+    </p>
+    <p class="mb-5">Wire it into your Vite/Svelte preprocess config:</p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <HighlightSvelte
+      code={`// vite.config.js
+import { svelte } from "@sveltejs/vite-plugin-svelte";
+import { highlightStatic } from "svelte-highlight/static";
+
+export default {
+  plugins: [svelte({ preprocess: [highlightStatic()] })],
+};`}
+      class={THEME_MODULE_NAME}
+    />
+  </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      With a literal <code class="code">code</code> string and a static
+      <code class="code">language</code>
+      import, the build emits plain HTML:
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <HighlightSvelte
+      code={`<script>
+  import Highlight from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+<\/script>
+
+<Highlight language={javascript} code="const x = 1;" />`}
+      class={THEME_MODULE_NAME}
+    />
+  </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      ...into plain HTML, with no <code class="code">highlight.js</code> or
+      grammar module shipped to the client:
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <HighlightSvelte
+      code={`<pre class="hljs" data-language="javascript"><code class="hljs"
+  ><span class="hljs-keyword">const</span> x = <span class="hljs-number">1</span>;</code
+></pre>`}
+      class={THEME_MODULE_NAME}
+    />
+  </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      The static transform runs only when all of these are true:
+    </p>
+    <UnorderedList class="mb-5">
+      <ListItem>
+        <code class="code">language</code>
+        is a plain identifier bound to a static import from
+        <code class="code">svelte-highlight/languages/*</code>.
+      </ListItem>
+      <ListItem>
+        <code class="code">code</code>
+        is a string literal or a template literal with no interpolated
+        expressions.
+      </ListItem>
+      <ListItem>
+        The element has no default-slot content, no spread props, and no
+        <code class="code">bind:</code>/<code class="code">on:</code>/other
+        directives.
+      </ListItem>
+      <ListItem>
+        The <code class="code">langtag</code> prop is not used. Static output
+        can't pull in <code class="code">langtag.css</code>; that only happens
+        when a runtime <code class="code">LangTag</code> is in the bundle.
+      </ListItem>
+    </UnorderedList>
+    <p class="mb-5">
+      Dynamic <code class="code">code</code> or
+      <code class="code">language</code>,
+      <code class="code">loadLanguage</code>,
+      <code class="code">HighlightAuto</code>,
+      <code class="code">HighlightSvelte</code>, and
+      <code class="code">HighlightEditable</code>
+      keep the runtime component. No warning.
+    </p>
+    <p class="mb-5">
+      If a usage looks static but fails to resolve or highlight, it falls back
+      and calls <code class="code">onWarn</code>:
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <HighlightSvelte
+      code={`highlightStatic({
+  onWarn(message, details) {
+    // defaults to a console.warn with the filename, line, and message
+  },
+});`}
+      class={THEME_MODULE_NAME}
+    />
+    <InlineNotification
+      lowContrast
+      hideCloseButton
+      kind="info"
+      title="Note:"
+      subtitle="Scope is small on purpose: extra props on Highlight don't carry over to the emitted &lt;pre&gt;, unused imports are left for bundlers to drop, and there's no Astro/MDX fence hook yet."
+    />
+  </Column>
+</Row>
+
 <Row>
   <Column xlg={12}><h3>Examples</h3></Column>
   <Column xlg={6} lg={6} md={12}>


### PR DESCRIPTION
## Summary

Adds `svelte-highlight/static`, a Svelte preprocessor that replaces statically-known `<Highlight>` usages with pre-rendered highlight.js HTML at build time, so highlight.js and the grammar module ship zero runtime code for that usage. Dynamic usages, slot content, spread props, directives, and `langtag` fall back untouched to the runtime component. Also adds a multi-entry Vite 8 test app under `tests/e2e/static-app` that proves this through real production builds, not just unit tests.

Given this component:

```svelte
<script>
  import Highlight from "svelte-highlight";
  import javascript from "svelte-highlight/languages/javascript";
</script>

<Highlight language={javascript} code="const x = 1;" />
```

wiring in the preprocessor:

```js
import { svelte } from "@sveltejs/vite-plugin-svelte";
import { highlightStatic } from "svelte-highlight/static";

export default {
  plugins: [svelte({ preprocess: [highlightStatic()] })],
};
```

turns the build output into plain HTML with no `highlight.js` shipped to the client.

## Test plan

- [x] `bun test tests/*.ts` (274 unit tests, including new preprocessor tests)
- [x] `bun run test:types` and `bun run lint`
- [x] `bun run test:static-app` builds and verifies all 5 entries under `tests/e2e/static-app` against the real published package shape