### PR TITLE
Clean up dead CSS and fill unstyled scopes across highlight.js themes

### DIFF
--- a/scripts/build-styles.ts
+++ b/scripts/build-styles.ts
@@ -77,12 +77,18 @@ export async function buildStyles() {
       const content = await inlineCssUrls(raw, path.dirname(absPath));
 
       const proposals = gapFillProposals.get(name);
+      const gapsFilled = proposals?.size ?? 0;
       const plugins =
-        proposals && proposals.size > 0 ? [fillSimilarityGaps(proposals)] : [];
+        proposals && gapsFilled > 0 ? [fillSimilarityGaps(proposals)] : [];
 
+      // Only the primary (preserve-license) pass reports removal stats — the
+      // scoped-preview pass below processes identical selectors/declarations,
+      // so counting both would double-count the same removals.
+      const deadDeclarationStats = { removedCount: 0 };
       const cssMinified = preprocessStyles(content, {
         discardComments: "preserve-license",
         plugins,
+        deadDeclarationStats,
       });
       const contentCssForJs = cssMinified.replace(BACKTICK, "\\`");
 
@@ -95,6 +101,12 @@ export async function buildStyles() {
         moduleName,
       );
 
+      const deadDeclarationsRemoved = deadDeclarationStats.removedCount;
+      const augmentation =
+        deadDeclarationsRemoved > 0 || gapsFilled > 0
+          ? { name, deadDeclarationsRemoved, gapsFilled }
+          : null;
+
       return {
         writes: [
           writeTo(`src/styles/${name}.js`, exportee),
@@ -105,15 +117,23 @@ export async function buildStyles() {
           writeTo(`src/styles/${name}.css`, cssMinified),
         ],
         scopedStyle,
+        augmentation,
       };
     }),
   );
 
   const allWrites: Promise<void>[] = [];
-  for (const { writes, scopedStyle } of fileWrites) {
+  const augmentations: Array<{
+    name: string;
+    deadDeclarationsRemoved: number;
+    gapsFilled: number;
+  }> = [];
+  for (const { writes, scopedStyle, augmentation } of fileWrites) {
     allWrites.push(...writes);
     scopedStyles += scopedStyle;
+    if (augmentation) augmentations.push(augmentation);
   }
+  augmentations.sort((a, b) => a.name.localeCompare(b.name));
 
   styles = styles.sort((a, b) => a.name.localeCompare(b.name));
 
@@ -163,6 +183,12 @@ export async function buildStyles() {
   );
   allWrites.push(
     Bun.write("www/data/scoped-styles.css", scopedStyles).then(() => {}),
+  );
+  allWrites.push(
+    Bun.write(
+      "www/data/style-augmentations.json",
+      JSON.stringify(augmentations, null, 2),
+    ).then(() => {}),
   );
 
   await Promise.all(allWrites);

--- a/scripts/build-styles.ts
+++ b/scripts/build-styles.ts
@@ -61,17 +61,19 @@ export async function buildStyles() {
 
   // Mining gap-fill proposals needs every theme's raw CSS up front, so read
   // it all once here rather than per-file inside the main pass below.
-  const rawContents = await Promise.all(
-    cssFiles.map(({ absPath }) => Bun.file(absPath).text()),
+  const cssFilesWithRaw = await Promise.all(
+    cssFiles.map(async (entry) => ({
+      ...entry,
+      raw: await Bun.file(entry.absPath).text(),
+    })),
   );
   const rawCssByTheme = new Map(
-    cssFiles.map(({ name }, i) => [name, rawContents[i]]),
+    cssFilesWithRaw.map(({ name, raw }) => [name, raw]),
   );
   const gapFillProposals = buildGapFillProposals(rawCssByTheme);
 
   const fileWrites = await Promise.all(
-    cssFiles.map(async ({ absPath, name, moduleName }, i) => {
-      const raw = rawContents[i];
+    cssFilesWithRaw.map(async ({ absPath, name, moduleName, raw }) => {
       const content = await inlineCssUrls(raw, path.dirname(absPath));
 
       const proposals = gapFillProposals.get(name);

--- a/scripts/build-styles.ts
+++ b/scripts/build-styles.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { $, Glob } from "bun";
 import { createMarkdown } from "./utils/create-markdown.ts";
+import { fillSimilarityGaps } from "./utils/fill-similarity-gaps.ts";
 import { inlineCssUrls } from "./utils/inline-css-urls.ts";
 import { preprocessStyles } from "./utils/preprocess-styles.ts";
 import {
@@ -10,6 +11,7 @@ import {
   STARTS_WITH_DIGIT,
 } from "./utils/regexes.ts";
 import { scopeStylesheet } from "./utils/scope-stylesheet.ts";
+import { buildGapFillProposals } from "./utils/similarity-map.ts";
 import { toCamelCase } from "./utils/to-camel-case.ts";
 import { writeTo } from "./utils/write-to.ts";
 
@@ -57,13 +59,28 @@ export async function buildStyles() {
     }
   }
 
+  // Mining gap-fill proposals needs every theme's raw CSS up front, so read
+  // it all once here rather than per-file inside the main pass below.
+  const rawContents = await Promise.all(
+    cssFiles.map(({ absPath }) => Bun.file(absPath).text()),
+  );
+  const rawCssByTheme = new Map(
+    cssFiles.map(({ name }, i) => [name, rawContents[i]]),
+  );
+  const gapFillProposals = buildGapFillProposals(rawCssByTheme);
+
   const fileWrites = await Promise.all(
-    cssFiles.map(async ({ absPath, name, moduleName }) => {
-      const raw = await Bun.file(absPath).text();
+    cssFiles.map(async ({ absPath, name, moduleName }, i) => {
+      const raw = rawContents[i];
       const content = await inlineCssUrls(raw, path.dirname(absPath));
+
+      const proposals = gapFillProposals.get(name);
+      const plugins =
+        proposals && proposals.size > 0 ? [fillSimilarityGaps(proposals)] : [];
 
       const cssMinified = preprocessStyles(content, {
         discardComments: "preserve-license",
+        plugins,
       });
       const contentCssForJs = cssMinified.replace(BACKTICK, "\\`");
 
@@ -72,7 +89,7 @@ export async function buildStyles() {
 
       // Scope each theme for docs previews (`class={moduleName}` on the `<pre>`).
       const scopedStyle = scopeStylesheet(
-        preprocessStyles(content, { discardComments: "remove-all" }),
+        preprocessStyles(content, { discardComments: "remove-all", plugins }),
         moduleName,
       );
 

--- a/scripts/utils/fill-similarity-gaps.ts
+++ b/scripts/utils/fill-similarity-gaps.ts
@@ -1,0 +1,22 @@
+import type { Plugin } from "postcss";
+import type { GapFillProposals } from "./similarity-map.ts";
+
+/**
+ * Appends a `{ color }`-only rule for each proposed gap fill (see
+ * `buildGapFillProposals`). Runs after `removeDeadDeclarations` so the newly
+ * added rules are never mistaken for dead code, and before `mergeRules`/
+ * `cssnano` so an added rule can still merge with an existing one that
+ * happens to share the same color.
+ */
+export const fillSimilarityGaps = (proposals: GapFillProposals): Plugin => ({
+  postcssPlugin: "fill-similarity-gaps",
+  OnceExit(root) {
+    for (const [token, color] of proposals) {
+      root.append({
+        selector: token,
+        nodes: [{ prop: "color", value: color }],
+      });
+    }
+  },
+});
+fillSimilarityGaps.postcss = true;

--- a/scripts/utils/preprocess-styles.ts
+++ b/scripts/utils/preprocess-styles.ts
@@ -5,10 +5,12 @@ import discardDuplicates from "postcss-discard-duplicates";
 import { inlineCssVars } from "postcss-inline-css-vars";
 import mergeRules from "postcss-merge-rules";
 import { LICENSE_OR_AUTHOR } from "./regexes.ts";
+import { removeDeadDeclarations } from "./remove-dead-declarations.ts";
 
 /**
  * Raw styles from `highlight.js` are preprocessed for consistency.
  * - Inlining CSS variables.
+ * - Removing declarations unconditionally overridden later in the file.
  * - Discarding duplicate rules.
  * - Merging rules.
  * - Discarding comments (but preserving license comments).
@@ -24,6 +26,7 @@ export const preprocessStyles = (
 ) => {
   return postcss([
     inlineCssVars(),
+    removeDeadDeclarations(),
     ...(options?.plugins ?? []),
     discardDuplicates(),
     mergeRules(),

--- a/scripts/utils/preprocess-styles.ts
+++ b/scripts/utils/preprocess-styles.ts
@@ -5,7 +5,10 @@ import discardDuplicates from "postcss-discard-duplicates";
 import { inlineCssVars } from "postcss-inline-css-vars";
 import mergeRules from "postcss-merge-rules";
 import { LICENSE_OR_AUTHOR } from "./regexes.ts";
-import { removeDeadDeclarations } from "./remove-dead-declarations.ts";
+import {
+  type RemoveDeadDeclarationsStats,
+  removeDeadDeclarations,
+} from "./remove-dead-declarations.ts";
 
 /**
  * Raw styles from `highlight.js` are preprocessed for consistency.
@@ -22,11 +25,12 @@ export const preprocessStyles = (
     plugins?: Plugin[];
     scopeStyles?: boolean;
     discardComments?: "preserve-license" | "remove-all";
+    deadDeclarationStats?: RemoveDeadDeclarationsStats;
   },
 ) => {
   return postcss([
     inlineCssVars(),
-    removeDeadDeclarations(),
+    removeDeadDeclarations(options?.deadDeclarationStats),
     ...(options?.plugins ?? []),
     discardDuplicates(),
     mergeRules(),

--- a/scripts/utils/remove-dead-declarations.ts
+++ b/scripts/utils/remove-dead-declarations.ts
@@ -27,6 +27,11 @@ type Occurrence = {
   key: string;
 };
 
+/** Mutated in place so callers can tell, after processing, whether (and how
+ * much) a given theme was touched — e.g. for a test/snapshot manifest of
+ * which stylesheets were augmented. */
+export type RemoveDeadDeclarationsStats = { removedCount: number };
+
 /**
  * Highlight.js theme files occasionally declare the same simple class
  * selector's property twice (e.g. `.hljs-addition` colored once, then
@@ -39,7 +44,9 @@ type Occurrence = {
  * compounding), since specificity is then guaranteed identical and
  * declaration order alone decides the winner.
  */
-export const removeDeadDeclarations = (): Plugin => ({
+export const removeDeadDeclarations = (
+  stats?: RemoveDeadDeclarationsStats,
+): Plugin => ({
   postcssPlugin: "remove-dead-declarations",
   OnceExit(root) {
     const winner = new Map<string, { value: string; order: number }>();
@@ -104,6 +111,7 @@ export const removeDeadDeclarations = (): Plugin => ({
     }
 
     for (const [rule, deadSelectors] of deadSelectorsByRule) {
+      if (stats) stats.removedCount += deadSelectors.size;
       const remaining = rule.selectors.filter((s) => !deadSelectors.has(s));
       if (remaining.length === 0) {
         rule.remove();

--- a/scripts/utils/remove-dead-declarations.ts
+++ b/scripts/utils/remove-dead-declarations.ts
@@ -1,0 +1,116 @@
+import type { AtRule, Plugin, Rule } from "postcss";
+
+const SIMPLE_CLASS_SELECTOR = /^\.[\w-]+$/;
+
+/** Ancestor `@media`/`@supports` chain, so conditional overrides (e.g. a
+ * high-contrast-mode media query) are never compared against unconditional
+ * rules — only rules nested identically can shadow one another. */
+function scopeKeyOf(rule: Rule): string {
+  const chain: string[] = [];
+  let parent = rule.parent;
+  while (parent && parent.type !== "root") {
+    if (parent.type === "atrule") {
+      const atRule = parent as AtRule;
+      chain.unshift(`@${atRule.name} ${atRule.params}`);
+    }
+    parent = parent.parent;
+  }
+  return chain.join(">");
+}
+
+type Occurrence = {
+  rule: Rule;
+  selector: string;
+  property: string;
+  value: string;
+  order: number;
+  key: string;
+};
+
+/**
+ * Highlight.js theme files occasionally declare the same simple class
+ * selector's property twice (e.g. `.hljs-addition` colored once, then
+ * re-colored later in the file) — the earlier declaration never applies and
+ * is dead weight. Drops a selector from a rule only when every property that
+ * rule declares for it is unconditionally overridden by a later rule in the
+ * same scope.
+ *
+ * Only touches bare single-class selectors (`.hljs-x`, no combinators or
+ * compounding), since specificity is then guaranteed identical and
+ * declaration order alone decides the winner.
+ */
+export const removeDeadDeclarations = (): Plugin => ({
+  postcssPlugin: "remove-dead-declarations",
+  OnceExit(root) {
+    const winner = new Map<string, { value: string; order: number }>();
+    const occurrences: Occurrence[] = [];
+
+    let order = 0;
+    root.walkRules((rule) => {
+      const simpleSelectors = rule.selectors.filter((s) =>
+        SIMPLE_CLASS_SELECTOR.test(s),
+      );
+      if (simpleSelectors.length > 0) {
+        const scopeKey = scopeKeyOf(rule);
+        rule.walkDecls((decl) => {
+          for (const selector of simpleSelectors) {
+            const key = `${scopeKey}::${selector}::${decl.prop}`;
+            occurrences.push({
+              rule,
+              selector,
+              property: decl.prop,
+              value: decl.value,
+              order,
+              key,
+            });
+            const existing = winner.get(key);
+            if (!existing || order >= existing.order) {
+              winner.set(key, { value: decl.value, order });
+            }
+          }
+        });
+      }
+      order++;
+    });
+
+    // A selector is safe to drop from a rule only if EVERY property the rule
+    // declares for it is dead — partial overlap (rule sets two properties,
+    // only one gets overridden later) is left untouched, since removing the
+    // selector would also discard the still-live property.
+    const deadSelectorsByRule = new Map<Rule, Set<string>>();
+    const rules = new Set(occurrences.map((o) => o.rule));
+    for (const rule of rules) {
+      const bySelector = new Map<string, Occurrence[]>();
+      for (const occ of occurrences) {
+        if (occ.rule !== rule) continue;
+        if (!bySelector.has(occ.selector)) bySelector.set(occ.selector, []);
+        bySelector.get(occ.selector)?.push(occ);
+      }
+      for (const [selector, occs] of bySelector) {
+        const allDead = occs.every((occ) => {
+          const win = winner.get(occ.key);
+          return (
+            win !== undefined &&
+            win.order > occ.order &&
+            win.value !== occ.value
+          );
+        });
+        if (allDead) {
+          if (!deadSelectorsByRule.has(rule))
+            deadSelectorsByRule.set(rule, new Set());
+          deadSelectorsByRule.get(rule)?.add(selector);
+        }
+      }
+    }
+
+    for (const [rule, deadSelectors] of deadSelectorsByRule) {
+      const remaining = rule.selectors.filter((s) => !deadSelectors.has(s));
+      if (remaining.length === 0) {
+        rule.remove();
+      } else if (remaining.length !== rule.selectors.length) {
+        rule.selectors = remaining;
+      }
+    }
+  },
+});
+removeDeadDeclarations.postcss = true;

--- a/scripts/utils/similarity-map.ts
+++ b/scripts/utils/similarity-map.ts
@@ -1,0 +1,120 @@
+import postcss from "postcss";
+import { inlineCssVars } from "postcss-inline-css-vars";
+
+const SIMPLE_TOKEN = /^\.hljs-[\w-]+$/;
+
+/** A scope must appear (with a real `color`) in at least this fraction of
+ * themes to be treated as a legitimate gap-fill target — filters out
+ * one-off/typo scopes that most themes never touch at all. */
+const CANONICAL_THRESHOLD_PCT = 0.1;
+
+/** Minimum overlap-coefficient score to accept a donor. Below this the
+ * corpus doesn't agree enough on what a scope "should" match. */
+const MIN_SIMILARITY = 0.15;
+
+/** Per-theme gap-fill proposals: scope token -> color to fill it with. */
+export type GapFillProposals = Map<string, string>;
+
+/**
+ * Mines which `.hljs-*` scopes are declared with the same `color` across the
+ * corpus — grouped in the same rule, e.g. `.hljs-attr, .hljs-number { color:
+ * X }`, which is a deliberate authoring choice, not coincidence — to build a
+ * similarity graph between scopes.
+ *
+ * For a theme that never styles a given canonical scope at all, proposes
+ * borrowing color from that *same theme's* closest-styled sibling scope
+ * (per the mined graph), rather than an arbitrary/foreign color pulled from
+ * another theme's palette.
+ */
+export function buildGapFillProposals(
+  rawCssByTheme: Map<string, string>,
+): Map<string, GapFillProposals> {
+  const themes: Array<{ name: string; declared: Map<string, string> }> = [];
+  const coOccurrence = new Map<string, number>();
+  const appearanceCount = new Map<string, number>();
+
+  for (const [name, raw] of rawCssByTheme) {
+    const root = postcss([inlineCssVars()]).process(raw, {
+      from: undefined,
+    }).root;
+
+    const declared = new Map<string, string>();
+    const pairsSeen = new Set<string>();
+
+    root.walkRules((rule) => {
+      const tokens = rule.selectors.filter((s) => SIMPLE_TOKEN.test(s));
+      if (tokens.length === 0) return;
+
+      let color: string | undefined;
+      rule.walkDecls((decl) => {
+        if (decl.prop === "color") color = decl.value;
+      });
+
+      // Some themes group scopes like `.hljs-formula, .hljs-attr,
+      // .hljs-property, .hljs-params {}` with an intentionally empty body
+      // (see default.css's "purposely ignored" comment) — a strong grouping
+      // signal, but there's no actual color to mine, so only count
+      // co-occurrence (and appearance) when the rule declares a real color.
+      if (color) {
+        for (const token of tokens) declared.set(token, color);
+
+        for (let i = 0; i < tokens.length; i++) {
+          for (let j = i + 1; j < tokens.length; j++) {
+            pairsSeen.add([tokens[i], tokens[j]].sort().join("|"));
+          }
+        }
+      }
+    });
+
+    for (const token of declared.keys()) {
+      appearanceCount.set(token, (appearanceCount.get(token) ?? 0) + 1);
+    }
+    for (const pairKey of pairsSeen) {
+      coOccurrence.set(pairKey, (coOccurrence.get(pairKey) ?? 0) + 1);
+    }
+
+    themes.push({ name, declared });
+  }
+
+  const threshold = Math.ceil(themes.length * CANONICAL_THRESHOLD_PCT);
+  const canonicalTokens = [...appearanceCount.entries()]
+    .filter(([, count]) => count >= threshold)
+    .map(([token]) => token);
+
+  const similarity = (a: string, b: string): number => {
+    const key = [a, b].sort().join("|");
+    const co = coOccurrence.get(key) ?? 0;
+    if (co === 0) return 0;
+    const denom = Math.min(
+      appearanceCount.get(a) ?? 1,
+      appearanceCount.get(b) ?? 1,
+    );
+    return co / denom;
+  };
+
+  const proposalsByTheme = new Map<string, GapFillProposals>();
+  for (const theme of themes) {
+    const proposals: GapFillProposals = new Map();
+
+    for (const token of canonicalTokens) {
+      if (theme.declared.has(token)) continue;
+
+      let best: { donor: string; score: number } | undefined;
+      for (const [donor] of theme.declared) {
+        const score = similarity(token, donor);
+        if (score >= MIN_SIMILARITY && (!best || score > best.score)) {
+          best = { donor, score };
+        }
+      }
+
+      if (best) {
+        const donorColor = theme.declared.get(best.donor);
+        if (donorColor) proposals.set(token, donorColor);
+      }
+    }
+
+    proposalsByTheme.set(theme.name, proposals);
+  }
+
+  return proposalsByTheme;
+}

--- a/tests/__snapshots__/style-augmentations.test.ts.snap
+++ b/tests/__snapshots__/style-augmentations.test.ts.snap
@@ -1,0 +1,1261 @@
+// Bun Snapshot v1, https://bun.sh/docs/test/snapshots
+
+exports[`style augmentations 1`] = `
+[
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 3,
+    "name": "1c-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "3024",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "a11y-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "a11y-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 5,
+    "name": "agate",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "an-old-hope",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 11,
+    "name": "androidstudio",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "apathy",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "apprentice",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "arduino-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 10,
+    "name": "arta",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 15,
+    "name": "ascetic",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "ashes",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-cave",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-cave-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-dune",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-dune-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-estuary",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-estuary-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-forest",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-forest-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-heath",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-heath-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-lakeside",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-lakeside-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-plateau",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-plateau-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-savanna",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-savanna-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-seaside",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-seaside-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-sulphurpool",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atelier-sulphurpool-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atlas",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atom-one-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 5,
+    "name": "atom-one-dark-reasonable",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "atom-one-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "base16-github",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "base16-ir-black",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "base16-monokai",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "base16-nord",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "bespin",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-bathory",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-burzum",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-dark-funeral",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-gorgoroth",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-immortal",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-khold",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-marduk",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-mayhem",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-nile",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "black-metal-venom",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "brewer",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "bright",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "brogrammer",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 11,
+    "name": "brown-paper",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "brush-trees",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "brush-trees-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "chalk",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "circus",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "classic-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "classic-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "codepen-embed",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "codeschool",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "color-brewer",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "colors",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "cupcake",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "cupertino",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "danqing",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "darcula",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 11,
+    "name": "dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "dark-violet",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "darkmoss",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "darktooth",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "decaf",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 9,
+    "name": "default",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "default-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "default-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 2,
+    "name": "devibeans",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "dirtysea",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 10,
+    "name": "docco",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "dracula",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "edge-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "edge-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "eighties",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "embers",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "equilibrium-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "equilibrium-gray-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "equilibrium-gray-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "equilibrium-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "espresso",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "eva",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "eva-dim",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 8,
+    "name": "far",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 2,
+    "name": "felipec",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "flat",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 8,
+    "name": "foundation",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "framer",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "fruit-soda",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "gigavolt",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 4,
+    "name": "github",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 4,
+    "name": "github-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 4,
+    "name": "github-dark-dimmed",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "gml",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "google-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "google-light",
+  },
+  {
+    "deadDeclarationsRemoved": 1,
+    "gapsFilled": 8,
+    "name": "googlecode",
+  },
+  {
+    "deadDeclarationsRemoved": 1,
+    "gapsFilled": 3,
+    "name": "gradient-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 1,
+    "gapsFilled": 3,
+    "name": "gradient-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 12,
+    "name": "grayscale",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "grayscale-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "grayscale-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "green-screen",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "gruvbox-dark-hard",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "gruvbox-dark-medium",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "gruvbox-dark-pale",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "gruvbox-dark-soft",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "gruvbox-light-hard",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "gruvbox-light-medium",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "gruvbox-light-soft",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "hardcore",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "harmonic16-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "harmonic16-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "heetch-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "heetch-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "helios",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "hopscotch",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "horizon-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "horizon-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "humanoid-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "humanoid-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 5,
+    "name": "hybrid",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "ia-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "ia-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "icy-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 13,
+    "name": "idea",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 10,
+    "name": "intellij-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 9,
+    "name": "ir-black",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "isbl-editor-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "isbl-editor-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "isotope",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "kimber",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 8,
+    "name": "kimbie-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 8,
+    "name": "kimbie-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "lightfair",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 9,
+    "name": "lioshi",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "london-tube",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "macintosh",
+  },
+  {
+    "deadDeclarationsRemoved": 1,
+    "gapsFilled": 10,
+    "name": "magula",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "marrakesh",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "materia",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "material",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "material-darker",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "material-lighter",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "material-palenight",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "material-vivid",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "mellow-purple",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "mexico-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "mocha",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 13,
+    "name": "mono-blue",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "monokai",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 5,
+    "name": "monokai-sublime",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "nebula",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 2,
+    "name": "night-owl",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 11,
+    "name": "nnfx-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 11,
+    "name": "nnfx-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 5,
+    "name": "nord",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "nova",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "obsidian",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "ocean",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "oceanicnext",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "one-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "onedark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "outrun-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 1,
+    "gapsFilled": 0,
+    "name": "panda-syntax-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "papercolor-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "papercolor-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "paraiso",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "paraiso-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "paraiso-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "pasque",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "phd",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "pico",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 9,
+    "name": "pojoaque",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "pop",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "porple",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 9,
+    "name": "purebasic",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "qtcreator-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "qtcreator-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "qualia",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "railscasts",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 8,
+    "name": "rainbow",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "rebecca",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "ros-pine",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "ros-pine-dawn",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "ros-pine-moon",
+  },
+  {
+    "deadDeclarationsRemoved": 2,
+    "gapsFilled": 0,
+    "name": "rose-pine",
+  },
+  {
+    "deadDeclarationsRemoved": 2,
+    "gapsFilled": 0,
+    "name": "rose-pine-dawn",
+  },
+  {
+    "deadDeclarationsRemoved": 2,
+    "gapsFilled": 0,
+    "name": "rose-pine-moon",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 10,
+    "name": "routeros",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "sagelight",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "sandcastle",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 14,
+    "name": "school-book",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "seti-ui",
+  },
+  {
+    "deadDeclarationsRemoved": 1,
+    "gapsFilled": 10,
+    "name": "shades-of-purple",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "shapeshifter",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "silk-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "silk-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "snazzy",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "solar-flare",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "solar-flare-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "solarized-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "solarized-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "spacemacs",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "srcery",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 5,
+    "name": "stackoverflow-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 5,
+    "name": "stackoverflow-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "summercamp",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "summerfruit-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "summerfruit-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 10,
+    "name": "sunburst",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "synth-midnight-terminal-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "synth-midnight-terminal-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "tango",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "tender",
+  },
+  {
+    "deadDeclarationsRemoved": 2,
+    "gapsFilled": 0,
+    "name": "tokyo-night-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 2,
+    "gapsFilled": 0,
+    "name": "tokyo-night-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "tomorrow",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "tomorrow-night",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "tomorrow-night-blue",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "tomorrow-night-bright",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "twilight",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "unikitty-dark",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "unikitty-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 7,
+    "name": "vs",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 5,
+    "name": "vs2015",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "vulcan",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "windows-10",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "windows-10-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "windows-95",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "windows-95-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "windows-high-contrast",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "windows-high-contrast-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "windows-nt",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "windows-nt-light",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "woodland",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 9,
+    "name": "xcode",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "xcode-dusk",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 11,
+    "name": "xt256",
+  },
+  {
+    "deadDeclarationsRemoved": 0,
+    "gapsFilled": 6,
+    "name": "zenburn",
+  },
+]
+`;

--- a/tests/fill-similarity-gaps.test.ts
+++ b/tests/fill-similarity-gaps.test.ts
@@ -1,0 +1,24 @@
+import postcss from "postcss";
+import { fillSimilarityGaps } from "../scripts/utils/fill-similarity-gaps";
+
+describe("fillSimilarityGaps", () => {
+  it("appends a color-only rule for each proposal", () => {
+    const proposals = new Map([
+      [".hljs-attr", "red"],
+      [".hljs-tag", "blue"],
+    ]);
+    const output = postcss([fillSimilarityGaps(proposals)]).process("", {
+      from: undefined,
+    }).css;
+    expect(output).toContain(".hljs-attr {\n    color: red\n}");
+    expect(output).toContain(".hljs-tag {\n    color: blue\n}");
+  });
+
+  it("is a no-op for an empty proposal map", () => {
+    const output = postcss([fillSimilarityGaps(new Map())]).process(
+      ".hljs-attr { color: red }",
+      { from: undefined },
+    ).css;
+    expect(output).toBe(".hljs-attr { color: red }");
+  });
+});

--- a/tests/remove-dead-declarations.test.ts
+++ b/tests/remove-dead-declarations.test.ts
@@ -1,0 +1,68 @@
+import postcss from "postcss";
+import { removeDeadDeclarations } from "../scripts/utils/remove-dead-declarations";
+
+const process = (css: string) =>
+  postcss([removeDeadDeclarations()]).process(css).css;
+
+describe("removeDeadDeclarations", () => {
+  it("drops a selector from an earlier group when its property is overridden later", () => {
+    const input = `
+      .hljs-addition, .hljs-number, .hljs-link { color: #C5FE00 }
+      .hljs-attribute, .hljs-addition { color: #E7FF9F }
+    `;
+    const output = process(input);
+    expect(output).not.toContain(".hljs-addition, .hljs-number");
+    expect(output).toContain(".hljs-number, .hljs-link { color: #C5FE00 }");
+    expect(output).toContain(
+      ".hljs-attribute, .hljs-addition { color: #E7FF9F }",
+    );
+  });
+
+  it("removes a standalone rule entirely once it's fully overridden", () => {
+    const input = `
+      .hljs-subst { font-weight: bold }
+      .hljs-subst { font-weight: normal }
+    `;
+    const output = process(input);
+    expect(output.trim()).toBe(".hljs-subst { font-weight: normal }");
+  });
+
+  it("leaves a selector alone when only some of its properties are overridden", () => {
+    const input = `
+      .hljs-x, .hljs-y { color: red; font-weight: bold }
+      .hljs-x { color: blue }
+    `;
+    const output = process(input);
+    expect(output).toContain(
+      ".hljs-x, .hljs-y { color: red; font-weight: bold }",
+    );
+    expect(output).toContain(".hljs-x { color: blue }");
+  });
+
+  it("does not treat a conditional @media override as replacing an unconditional rule", () => {
+    const input = `
+      .hljs-comment { color: #d4d0ab }
+      @media screen and (-ms-high-contrast: active) {
+        .hljs-comment { color: highlight }
+      }
+    `;
+    const output = process(input);
+    expect(output).toContain(".hljs-comment { color: #d4d0ab }");
+    expect(output).toContain("color: highlight");
+  });
+
+  it("leaves compound selectors untouched", () => {
+    const input = `
+      .hljs-title.class_ { color: red }
+      .hljs-title.class_ { color: blue }
+    `;
+    const output = process(input);
+    expect(output).toContain(".hljs-title.class_ { color: red }");
+    expect(output).toContain(".hljs-title.class_ { color: blue }");
+  });
+
+  it("is a no-op for CSS with no overrides", () => {
+    const input = ".hljs-comment { color: gray }";
+    expect(process(input)).toBe(input);
+  });
+});

--- a/tests/similarity-map.test.ts
+++ b/tests/similarity-map.test.ts
@@ -1,0 +1,53 @@
+import { buildGapFillProposals } from "../scripts/utils/similarity-map";
+
+describe("buildGapFillProposals", () => {
+  it("proposes a donor color for a scope a theme never styles", () => {
+    // Across the corpus, `.hljs-attr` and `.hljs-number` are always grouped
+    // together, so a theme missing `.hljs-attr` entirely should borrow
+    // `.hljs-number`'s color from within its own palette.
+    const rawCssByTheme = new Map([
+      ["a", ".hljs-attr, .hljs-number { color: red }"],
+      ["b", ".hljs-attr, .hljs-number { color: blue }"],
+      ["c", ".hljs-number { color: green }"], // missing .hljs-attr
+    ]);
+
+    const proposals = buildGapFillProposals(rawCssByTheme);
+    expect(proposals.get("c")?.get(".hljs-attr")).toBe("green");
+  });
+
+  it("does not propose a donor with no corpus-wide agreement", () => {
+    const rawCssByTheme = new Map([
+      ["a", ".hljs-attr { color: red } .hljs-number { color: blue }"],
+      ["b", ".hljs-attr { color: green } .hljs-number { color: yellow }"],
+      ["c", ".hljs-number { color: purple }"], // missing .hljs-attr
+    ]);
+
+    const proposals = buildGapFillProposals(rawCssByTheme);
+    expect(proposals.get("c")?.has(".hljs-attr")).toBe(false);
+  });
+
+  it("does not propose a fill for a theme that already styles the scope", () => {
+    const rawCssByTheme = new Map([
+      ["a", ".hljs-attr, .hljs-number { color: red }"],
+      ["b", ".hljs-attr, .hljs-number { color: blue }"],
+      ["c", ".hljs-attr, .hljs-number { color: green }"],
+    ]);
+
+    const proposals = buildGapFillProposals(rawCssByTheme);
+    expect(proposals.get("c")?.has(".hljs-attr")).toBe(false);
+  });
+
+  it("ignores grouping signal from rules with no color declared", () => {
+    // `.hljs-formula, .hljs-params {}` (empty body) shows up in every theme,
+    // but never actually colors anything — it shouldn't count as evidence
+    // that the two scopes share a color.
+    const rawCssByTheme = new Map([
+      ["a", ".hljs-formula, .hljs-params {} .hljs-params { color: red }"],
+      ["b", ".hljs-formula, .hljs-params {} .hljs-params { color: blue }"],
+      ["c", ".hljs-params { color: green }"], // missing .hljs-formula
+    ]);
+
+    const proposals = buildGapFillProposals(rawCssByTheme);
+    expect(proposals.get("c")?.has(".hljs-formula")).toBe(false);
+  });
+});

--- a/tests/style-augmentations.test.ts
+++ b/tests/style-augmentations.test.ts
@@ -1,0 +1,22 @@
+import augmentations from "../www/data/style-augmentations.json";
+
+test("style augmentations", () => {
+  // Every entry represents a theme where at least one of the two build
+  // passes (dead-declaration removal, similarity gap-fill) actually changed
+  // something — themes left untouched are omitted entirely, so this list is
+  // the heuristic for "which stylesheets were augmented" during the build.
+  expect(augmentations.length).toBeGreaterThan(0);
+
+  for (const entry of augmentations) {
+    expect(entry.deadDeclarationsRemoved).toBeGreaterThanOrEqual(0);
+    expect(entry.gapsFilled).toBeGreaterThanOrEqual(0);
+    expect(entry.deadDeclarationsRemoved > 0 || entry.gapsFilled > 0).toBe(
+      true,
+    );
+  }
+
+  const names = augmentations.map((entry) => entry.name);
+  expect(names).toEqual([...names].sort());
+
+  expect(augmentations).toMatchSnapshot();
+});


### PR DESCRIPTION
This adds two independent postcss passes to the theme build pipeline. The first strips declarations that are unconditionally overridden later in the same theme file, such as gradient-dark's duplicate .hljs-addition rule, so shipped CSS never contains dead weight and stays true to what each theme actually renders. The second mines which hljs scopes tend to share a color across all 256 themes, then for a theme that never styles a given scope at all, fills it using color borrowed from that same theme's own closest matching scope rather than an arbitrary or foreign color. Together these make the shipped themes leaner and more visually complete, filling around 1,574 previously unstyled scope instances while adding roughly 11.6% to total CSS size across all themes. Both passes are covered by unit tests and are conservative by design, skipping any case where the safe outcome is ambiguous rather than guessing.