### PR TITLE
fix(languages): highlight Marko concise syntax and implicit bindings

### DIFF
--- a/scripts/custom-languages/marko.js
+++ b/scripts/custom-languages/marko.js
@@ -27,6 +27,88 @@ function defineMarko(hljs) {
     relevance: 5,
   };
 
+  // `input`/`state`/`out` are Marko's implicit template-scope bindings
+  // (component input props, component state, and the output stream),
+  // provided by the framework rather than user code, so they're classed as
+  // "built_in" to keep them visually distinct from control-flow keywords
+  // like if/else/for while still standing out from plain identifiers.
+  const markoImplicitVariable = {
+    className: "built_in",
+    begin: /\b(?:input|state|out)\b/,
+    relevance: 0,
+  };
+
+  // Marko's concise syntax omits angle brackets: a line beginning with an
+  // identifier (after indentation) is itself a tag, e.g. `input type="text"`.
+  // The underlying "html" subLanguage never sees a `<`, so it never
+  // recognizes the tag name or its attributes without help from these rules.
+  // A line only counts as a concise tag when it carries some tag-like marker
+  // (an attribute, an event handler, a self-close, or a `--` text marker, or
+  // nothing else at all) so that plain text content nested inside a
+  // full `<tag>...</tag>` block isn't mistaken for one.
+  const markoConciseInterpolation = {
+    begin: /\$\{/,
+    end: /\}/,
+    subLanguage: "javascript",
+    relevance: 0,
+    contains: [markoImplicitVariable],
+  };
+
+  const markoConciseAttrValue = {
+    begin: /=/,
+    end: /(?=[\s/)]|--|$)/,
+    excludeBegin: true,
+    relevance: 0,
+    contains: [
+      hljs.QUOTE_STRING_MODE,
+      hljs.APOS_STRING_MODE,
+      markoConciseInterpolation,
+      markoImplicitVariable,
+    ],
+  };
+
+  const markoConciseAttrName = {
+    className: "attr",
+    begin: /\b[a-zA-Z][\w-]*(?==(?!=))/,
+    relevance: 0,
+  };
+
+  const markoConciseAttrArgs = {
+    begin: /\(/,
+    end: /\)/,
+    relevance: 0,
+    contains: [
+      hljs.QUOTE_STRING_MODE,
+      hljs.APOS_STRING_MODE,
+      markoConciseInterpolation,
+    ],
+  };
+
+  const markoConciseTag = {
+    className: "tag",
+    begin:
+      /^[ \t]*(?=[a-zA-Z][\w-]*(?:[ \t]*(?:$|--|\/[ \t]*$)|[ \t]+.*[=(]))/m,
+    end: /(?=--|\/[ \t]*$|$)/m,
+    relevance: 0,
+    contains: [
+      {
+        className: "name",
+        begin: /[a-zA-Z][\w-]*/,
+        relevance: 0,
+        starts: {
+          endsWithParent: true,
+          relevance: 0,
+          contains: [
+            markoEventAttribute,
+            markoConciseAttrArgs,
+            markoConciseAttrName,
+            markoConciseAttrValue,
+          ],
+        },
+      },
+    ],
+  };
+
   return {
     name: "Marko",
     subLanguage: "html",
@@ -60,15 +142,16 @@ function defineMarko(hljs) {
         end: /\}/,
         subLanguage: "javascript",
         relevance: 10,
+        contains: [markoImplicitVariable],
       },
       {
         begin: /^class\s*\{/m,
         end: /^\}/m,
         subLanguage: "javascript",
-        excludeBegin: true,
         excludeEnd: true,
         relevance: 100,
       },
+      markoConciseTag,
     ],
   };
 }

--- a/tests/marko-language.test.ts
+++ b/tests/marko-language.test.ts
@@ -38,6 +38,18 @@ const classComponentSnippet = `class {
   \${state.count}
 </button>`;
 
+const conciseTagSnippet = `<div class=["card", state.visible]>
+  if (state.visible)
+    h1 -- \${input.title}
+
+    input type="text" value=state.name on-input("updateName") /
+    button on-click("increment") -- Count: \${state.count}
+</div>`;
+
+const conciseParentSnippet = `div
+  h1 -- Title
+  span -- Subtitle`;
+
 test("marko highlights dollar-brace expressions as JavaScript", () => {
   hljs.registerLanguage(marko.name, marko.register);
 
@@ -90,6 +102,84 @@ test("marko highlights class components and event attributes", () => {
 
   expect(result).toContain("language-javascript");
   expect(result).toContain('<span class="hljs-variable">on-click</span>');
+  expect(result).toContain("language-javascript");
+});
+
+test("marko highlights concise-mode tag names and attributes", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(conciseTagSnippet, {
+    language: "marko",
+  }).value;
+
+  expect(result).toContain('<span class="hljs-name">h1</span>');
+  expect(result).toContain('<span class="hljs-name">input</span>');
+  expect(result).toContain('<span class="hljs-name">button</span>');
+  expect(result).toContain('<span class="hljs-attr">type</span>');
+  expect(result).toContain('<span class="hljs-attr">value</span>');
+  expect(result).toContain('<span class="hljs-string">&quot;text&quot;</span>');
+});
+
+test("marko highlights event handler arguments and dollar-brace expressions on concise tags", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(conciseTagSnippet, {
+    language: "marko",
+  }).value;
+
+  expect(result).toContain('<span class="hljs-variable">on-input</span>');
+  expect(result).toContain(
+    '<span class="hljs-variable">on-input</span>(<span class="hljs-string">&quot;updateName&quot;</span>)',
+  );
+  expect(result).toContain(
+    '<span class="hljs-variable">on-click</span>(<span class="hljs-string">&quot;increment&quot;</span>)',
+  );
+  expect(result).toContain("language-javascript");
+});
+
+test("marko classifies the top-level class keyword as JavaScript", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(classComponentSnippet, {
+    language: "marko",
+  }).value;
+
+  expect(result).toContain(
+    '<span class="language-javascript"><span class="hljs-keyword">class</span>',
+  );
+});
+
+test("marko highlights input/state/out as implicit template variables", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(conciseTagSnippet, {
+    language: "marko",
+  }).value;
+
+  expect(result).toContain('<span class="hljs-built_in">input</span>');
+  expect(result).toContain('<span class="hljs-built_in">state</span>');
+});
+
+test("marko highlights a bare concise tag with indented children", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(conciseParentSnippet, {
+    language: "marko",
+  }).value;
+
+  expect(result).toContain('<span class="hljs-name">div</span>');
+  expect(result).toContain('<span class="hljs-name">h1</span>');
+  expect(result).toContain('<span class="hljs-name">span</span>');
+});
+
+test("marko does not mistake plain text inside a full <tag> for a concise tag", () => {
+  hljs.registerLanguage(marko.name, marko.register);
+
+  const result = hljs.highlight(expressionSnippet, {
+    language: "marko",
+  }).value;
+
+  expect(result).not.toContain('<span class="hljs-name">Hello</span>');
   expect(result).toContain("language-javascript");
 });
 


### PR DESCRIPTION
Marko's concise syntax (no angle brackets) left tag names, attributes, and event-handler arguments unstyled, the top-level `class { }` component block fell through as unstyled HTML instead of JavaScript, and the implicit `input`/`state`/`out` template bindings rendered the same color as control-flow keywords. This adds grammar rules for concise-mode syntax and a distinct `built_in` class for the implicit bindings. Twelve tests cover the fix.

## Test plan
- [x] `bun test tests/marko-language.test.ts` passes (12/12)
- [x] `bun run test:unit` passes (530/530)
- [x] `bun run test:types` passes