### PR TITLE
docs(languages): clarify highlight.js vs custom language counts

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -1,6 +1,6 @@
 # Supported Languages
 
-> 244 languages exported from highlight.js@11.11.1
+> 244 languages: 192 exported from highlight.js@11.11.1, 52 custom grammars added by svelte-highlight
 
 ## 1c (`_1c`)
 

--- a/scripts/build-languages.ts
+++ b/scripts/build-languages.ts
@@ -325,7 +325,11 @@ export async function buildLanguages() {
     })),
   ].sort((a, b) => a.name.localeCompare(b.name));
 
-  let markdown = createMarkdown("Languages", entries.length);
+  let markdown = createMarkdown(
+    "Languages",
+    entries.length,
+    CUSTOM_LANGUAGES.length,
+  );
   let base = "";
   let baseTs = `
   import type { LanguageFn } from "highlight.js";

--- a/scripts/utils/create-markdown.ts
+++ b/scripts/utils/create-markdown.ts
@@ -1,11 +1,22 @@
 import { dependencies } from "../../package.json";
 
 /** Creates header metadata for supported languages/styles */
-export const createMarkdown = (type: "Languages" | "Styles", len: number) =>
-  `# Supported ${type}
+export const createMarkdown = (
+  type: "Languages" | "Styles",
+  len: number,
+  customCount = 0,
+) => {
+  const hljsVersion = dependencies["highlight.js"];
+  const summary =
+    customCount > 0
+      ? `> ${len} ${type.toLowerCase()}: ${
+          len - customCount
+        } exported from highlight.js@${hljsVersion}, ${customCount} custom grammars added by svelte-highlight`
+      : `> ${len} ${type.toLowerCase()} exported from highlight.js@${hljsVersion}`;
 
-> ${len} ${type.toLowerCase()} exported from highlight.js@${
-    dependencies["highlight.js"]
-  }
+  return `# Supported ${type}
+
+${summary}
 
 `;
+};


### PR DESCRIPTION
SUPPORTED_LANGUAGES.md claimed all languages were "exported
from highlight.js," but 52 are custom svelte-highlight grammars.
Split the header count so the source of each language is accurate.