### PR TITLE
fix(languages): highlight dotted Svelte 5 rune suffixes as keywords

### DIFF
--- a/scripts/custom-languages/svelte.js
+++ b/scripts/custom-languages/svelte.js
@@ -2,7 +2,8 @@ import typescriptRegister from "highlight.js/lib/languages/typescript";
 import html from "./html.js";
 
 const RUNE_NAMES = "state|derived|effect|props|bindable|inspect|host";
-const RUNE_SUFFIXES = "raw|snapshot|by|eager";
+const RUNE_SUFFIXES =
+  "raw|snapshot|by|eager|pre|tracking|pending|root|id|trace";
 const SVELTE_DIRECTIVES =
   "on|bind|use|transition|in|out|animate|class|style|let";
 const TS_LANG = "(?:ts|typescript)";

--- a/tests/svelte-language.test.ts
+++ b/tests/svelte-language.test.ts
@@ -43,6 +43,15 @@ const moduleTypescriptSnippet = `<script lang="ts" context="module">
   export const x: number = 1;
 </script>`;
 
+const runeSuffixSnippet = `<script>
+  $effect.pre(() => {});
+  $effect.tracking();
+  $effect.pending();
+  $effect.root(() => {});
+  $props.id();
+  $inspect.trace();
+</script>`;
+
 const storeSubscriptionSnippet = `<script>
   $count += 1;
 </script>
@@ -157,6 +166,23 @@ test("svelte highlights runes, event attributes, and block continuations", () =>
   expect(result).toContain('<span class="hljs-keyword">@render</span>');
   expect(result).toContain('<span class="hljs-keyword">:else if</span>');
   expect(result).toContain('<span class="hljs-keyword">:else</span>');
+});
+
+test("svelte highlights dotted rune suffixes as a single keyword", () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const result = hljs.highlight(runeSuffixSnippet, {
+    language: "svelte",
+  }).value;
+
+  expect(result).toContain('<span class="hljs-keyword">$effect.pre</span>');
+  expect(result).toContain(
+    '<span class="hljs-keyword">$effect.tracking</span>',
+  );
+  expect(result).toContain('<span class="hljs-keyword">$effect.pending</span>');
+  expect(result).toContain('<span class="hljs-keyword">$effect.root</span>');
+  expect(result).toContain('<span class="hljs-keyword">$props.id</span>');
+  expect(result).toContain('<span class="hljs-keyword">$inspect.trace</span>');
 });
 
 test("svelte highlights bare $store subscriptions without parens", () => {

--- a/www/preview/svelte-preview-snippets.ts
+++ b/www/preview/svelte-preview-snippets.ts
@@ -74,6 +74,26 @@ export const sveltePreviewSnippets: SveltePreviewSnippet[] = [
 {/if}`,
   },
   {
+    title: "Dotted rune suffixes",
+    description: "$effect.pre, $effect.tracking, $state.raw, and more",
+    code: `<script>
+  let count = $state.raw(0);
+  let doubled = $derived.by(() => count * 2);
+
+  $effect.pre(() => {
+    console.log("before DOM update");
+  });
+
+  $effect(() => {
+    if ($effect.tracking()) {
+      console.log("running inside a tracking context");
+    }
+  });
+
+  const id = $props.id();
+</script>`,
+  },
+  {
     title: "Legacy directives",
     description:
       "on:, bind:, class:, use:, transition:, and let: prop directives",


### PR DESCRIPTION
Dotted rune forms like $effect.pre only had the base rune highlighted as a keyword because RUNE_SUFFIXES was missing several Svelte 5 suffixes. This adds pre, tracking, pending, root, id, and trace so $effect.pre, $effect.tracking, $effect.pending, $effect.root, $props.id, and $inspect.trace all highlight fully. The Svelte language preview now includes an example demonstrating these dotted rune forms.

