### PR TITLE
build(scripts): fix sideEffects globs to match published layout

### DIFF
--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -67,7 +67,9 @@ pkgJson.types = "./index.d.ts";
 
 // Most modern bundlers know if standalone StyleSheets are used.
 // We specify it here to be sure so that it will not be mistakenly tree-shaken.
-pkgJson.sideEffects = ["src/styles/*.css", "src/langtag.css"];
+// `cp -r ./src/ ./package` flattens src/ into the package root, so these
+// globs must match the published layout, not the source layout.
+pkgJson.sideEffects = ["styles/*.css", "langtag.css"];
 
 await Bun.write("./package/package.json", JSON.stringify(pkgJson, null, 2));
 console.timeEnd("package");

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -58,6 +58,18 @@ pkgJson.exports = {
     types: "./languages/*.d.ts",
     import: "./languages/*.js",
   },
+  "./ansi": {
+    types: "./ansi.d.ts",
+    default: "./ansi.js",
+  },
+  "./load-language": {
+    types: "./load-language.d.ts",
+    default: "./load-language.js",
+  },
+  "./scoped": {
+    types: "./scoped.d.ts",
+    default: "./scoped.js",
+  },
   "./package.json": "./package.json",
 };
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -14,4 +14,10 @@ export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export type { LanguageName, LanguageType } from "./languages";
 export { loadLanguage } from "./load-language";
+export {
+  dualStyle,
+  scopeClassFor,
+  scopeSelectors,
+  scopeStyle,
+} from "./scoped";
 export { default as Typewriter } from "./Typewriter.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -11,4 +11,10 @@ export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export { loadLanguage } from "./load-language.js";
+export {
+  dualStyle,
+  scopeClassFor,
+  scopeSelectors,
+  scopeStyle,
+} from "./scoped.js";
 export { default as Typewriter } from "./Typewriter.svelte";

--- a/tests/package-shape.test.ts
+++ b/tests/package-shape.test.ts
@@ -1,0 +1,55 @@
+import { existsSync } from "node:fs";
+import { join } from "node:path";
+
+const PACKAGE_DIR = join(import.meta.dir, "..", "package");
+const packageExists = existsSync(join(PACKAGE_DIR, "package.json"));
+
+/** @param {string} target An exports-map value, e.g. "./ansi.js" or "./styles/*.css". */
+function assertResolvable(target: string) {
+  const relative = target.replace(/^\.\//, "");
+  if (relative.includes("*")) {
+    const glob = new Bun.Glob(relative);
+    const matches = [...glob.scanSync({ cwd: PACKAGE_DIR })];
+    expect(matches.length).toBeGreaterThan(0);
+  } else {
+    expect(existsSync(join(PACKAGE_DIR, relative))).toBe(true);
+  }
+}
+
+if (packageExists) {
+  describe("published package shape", () => {
+    test("every exports map entry resolves to a file on disk", async () => {
+      const pkgJson = await Bun.file(join(PACKAGE_DIR, "package.json")).json();
+
+      for (const conditions of Object.values(pkgJson.exports)) {
+        const targets =
+          typeof conditions === "string"
+            ? [conditions]
+            : Object.values(conditions as Record<string, string>);
+
+        for (const target of targets) assertResolvable(target);
+      }
+    });
+
+    test("every sideEffects glob matches at least one published file", async () => {
+      const pkgJson = await Bun.file(join(PACKAGE_DIR, "package.json")).json();
+
+      expect(pkgJson.sideEffects.length).toBeGreaterThan(0);
+
+      for (const pattern of pkgJson.sideEffects as string[]) {
+        const glob = new Bun.Glob(pattern);
+        const matches = [...glob.scanSync({ cwd: PACKAGE_DIR })];
+        expect(matches.length).toBeGreaterThan(0);
+      }
+    });
+
+    test("ansi.js resolves without the svelte condition and exposes parseAnsi", async () => {
+      const mod = await import(join(PACKAGE_DIR, "ansi.js"));
+      expect(typeof mod.parseAnsi).toBe("function");
+    });
+  });
+} else {
+  console.warn(
+    "Skipping tests/package-shape.test.ts: ./package not found. Run `bun run build:lib && bun run package` first.",
+  );
+}


### PR DESCRIPTION
npm-package.ts copies the contents of src/ into the package root (cp -r ./src/ ./package), so the published layout is styles/*.css and langtag.css at the root, with no src/ prefix. The sideEffects field in the generated package.json still listed src/styles/*.css and src/langtag.css, globs that match nothing in the published package. Bundlers that respect sideEffects, webpack in particular, could tree-shake style imports like svelte-highlight/styles/github.css out of a build entirely, leaving users with unstyled code blocks and no error. This fixes the globs to match the actual published layout.

While in the same script, this also adds exports subpaths for the pure-JS, Svelte-independent modules: ./ansi, ./load-language, and ./scoped, each with types and a default condition. Previously these were only reachable through the root export, which is gated behind the svelte resolve condition, so plain Node ESM consumers (server scripts, tooling without that condition) couldn't import them. scoped.js in particular shipped a hand-written scoped.d.ts but had no exports entry at all, making it unreachable in the published package. The scoped.js helpers (scopeStyle, dualStyle, scopeSelectors, scopeClassFor) are now also re-exported from the root index for component consumers. The root export's exports map is unchanged otherwise, still requiring the svelte condition since it imports .svelte files.

Adds tests/package-shape.test.ts, which builds confidence that this doesn't regress: it resolves every exports map entry against the built package, asserts every sideEffects glob matches at least one file, and does a plain dynamic import of ansi.js to confirm it resolves without the svelte condition. The test skips gracefully with a warning if ./package hasn't been built.

Risk is low and mostly packaging-shape related. The main things to watch are the exports map syntax being accepted correctly by downstream bundlers/resolvers, and that the new root re-exports of scoped.js helpers don't collide with existing names.