### PR TITLE
fix(components): preserve multi-line highlight spans in LineNumbers

### DIFF
--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -28,7 +28,7 @@
 
   $: lines = splitLines(highlighted);
   $: focusMode = highlightedLines.length > 0;
-  $: len_digits = lines.length.toString().length;
+  $: len_digits = (startingLineNumber + lines.length - 1).toString().length;
   $: len = len_digits - MIN_DIGITS < 1 ? MIN_DIGITS : len_digits;
   $: width = len * DIGIT_WIDTH;
 </script>

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -1,4 +1,6 @@
 <script>
+  import { splitLines } from "./split-lines.js";
+
   /** @type {string} */
   export let highlighted;
 
@@ -24,7 +26,7 @@
   const MIN_DIGITS = 2;
   const HIGHLIGHTED_BACKGROUND = "rgba(254, 241, 96, 0.2)";
 
-  $: lines = highlighted.split("\n");
+  $: lines = splitLines(highlighted);
   $: focusMode = highlightedLines.length > 0;
   $: len_digits = lines.length.toString().length;
   $: len = len_digits - MIN_DIGITS < 1 ? MIN_DIGITS : len_digits;

--- a/src/split-lines.d.ts
+++ b/src/split-lines.d.ts
@@ -1,0 +1,6 @@
+/**
+ * Splits highlight.js output HTML into lines, closing any `<span>` elements
+ * left open at a line break and reopening the same stack (in order) on the
+ * next line.
+ */
+export declare function splitLines(html: string): string[];

--- a/src/split-lines.js
+++ b/src/split-lines.js
@@ -1,0 +1,50 @@
+/**
+ * Splits highlight.js output HTML into lines without corrupting `<span>`
+ * elements that wrap a line break (block comments, template literals).
+ * Open spans are closed at the end of a line and the same stack is
+ * reopened, in order, at the start of the next line -- the strategy
+ * Prism and Shiki use for line-level transforms.
+ * @param {string} html
+ * @returns {string[]}
+ */
+export function splitLines(html) {
+  const lines = [];
+  /** @type {string[]} */
+  const stack = [];
+  let current = "";
+  let i = 0;
+
+  while (i < html.length) {
+    const char = html[i];
+
+    if (char === "<") {
+      const tagEnd = html.indexOf(">", i);
+      const tag = html.slice(i, tagEnd + 1);
+
+      if (tag.startsWith("</span")) {
+        stack.pop();
+      } else if (tag.startsWith("<span")) {
+        stack.push(tag);
+      }
+
+      current += tag;
+      i = tagEnd + 1;
+      continue;
+    }
+
+    if (char === "\n") {
+      current += "</span>".repeat(stack.length);
+      lines.push(current);
+      current = stack.join("");
+      i++;
+      continue;
+    }
+
+    current += char;
+    i++;
+  }
+
+  lines.push(current);
+
+  return lines;
+}

--- a/tests/e2e/LineNumbers.gutterOverflow.test.svelte
+++ b/tests/e2e/LineNumbers.gutterOverflow.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Highlight, { LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+
+  const code = `const a = 1;
+const b = 2;
+const c = 3;`;
+</script>
+
+<svelte:head> {@html horizonDark} </svelte:head>
+
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers {highlighted} startingLineNumber={999} />
+</Highlight>

--- a/tests/e2e/LineNumbers.multilineSpan.test.svelte
+++ b/tests/e2e/LineNumbers.multilineSpan.test.svelte
@@ -1,0 +1,15 @@
+<script lang="ts">
+  import Highlight, { LineNumbers } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+
+  const code = `/* line1
+line2
+line3 */`;
+</script>
+
+<svelte:head> {@html horizonDark} </svelte:head>
+
+<Highlight language={javascript} {code} let:highlighted>
+  <LineNumbers {highlighted} />
+</Highlight>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -16,6 +16,7 @@ import LangTag from "./LangTag.test.svelte";
 import LineNumbersCssVariables from "./LineNumbers.cssVariables.test.svelte";
 import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test.svelte";
 import LineNumbersFocusLines from "./LineNumbers.focusLines.test.svelte";
+import LineNumbersGutterOverflow from "./LineNumbers.gutterOverflow.test.svelte";
 import LineNumbersHideBorder from "./LineNumbers.hideBorder.test.svelte";
 import LineNumbersLangtag from "./LineNumbers.langtag.test.svelte";
 import LineNumbersMultilineSpan from "./LineNumbers.multilineSpan.test.svelte";
@@ -242,6 +243,21 @@ test("LineNumbers - preserves a span across a multi-line block comment", async (
       expect(rows.nth(i).locator("td:last-child .hljs-comment")).toBeVisible(),
     ),
   );
+});
+
+test("LineNumbers - sizes the gutter by the final rendered line number", async ({
+  mount,
+  page,
+}) => {
+  await mount(LineNumbersGutterOverflow);
+
+  const gutterCells = page.locator("td.hljs");
+  await expect(gutterCells.last()).toHaveText("1001");
+
+  const overflows = await gutterCells
+    .last()
+    .evaluate((el) => el.scrollWidth > el.clientWidth);
+  expect(overflows).toBe(false);
 });
 
 test("LineNumbers - langtag", async ({ mount, page }) => {

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -18,6 +18,7 @@ import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test
 import LineNumbersFocusLines from "./LineNumbers.focusLines.test.svelte";
 import LineNumbersHideBorder from "./LineNumbers.hideBorder.test.svelte";
 import LineNumbersLangtag from "./LineNumbers.langtag.test.svelte";
+import LineNumbersMultilineSpan from "./LineNumbers.multilineSpan.test.svelte";
 import LineNumbers from "./LineNumbers.test.svelte";
 import LineNumbersWrapLines from "./LineNumbers.wrapLines.test.svelte";
 import ScopedStyle from "./ScopedStyle.test.svelte";
@@ -225,6 +226,22 @@ test("LineNumbers - custom starting number", async ({ mount, page }) => {
   await mount(LineNumbersCustomStartingLine);
 
   await expect(page.getByText("100")).toBeVisible();
+});
+
+test("LineNumbers - preserves a span across a multi-line block comment", async ({
+  mount,
+  page,
+}) => {
+  await mount(LineNumbersMultilineSpan);
+
+  const rows = page.locator("tbody > tr");
+  await expect(rows).toHaveCount(3);
+
+  await Promise.all(
+    [0, 1, 2].map((i) =>
+      expect(rows.nth(i).locator("td:last-child .hljs-comment")).toBeVisible(),
+    ),
+  );
 });
 
 test("LineNumbers - langtag", async ({ mount, page }) => {

--- a/tests/split-lines.test.ts
+++ b/tests/split-lines.test.ts
@@ -1,0 +1,53 @@
+import { splitLines } from "../src/split-lines.js";
+
+describe("splitLines", () => {
+  it("closes and reopens a span that wraps a block comment across lines", () => {
+    const html = '<span class="hljs-comment">/* line1\nline2\nline3 */</span>';
+    const lines = splitLines(html);
+
+    expect(lines).toEqual([
+      '<span class="hljs-comment">/* line1</span>',
+      '<span class="hljs-comment">line2</span>',
+      '<span class="hljs-comment">line3 */</span>',
+    ]);
+
+    for (const line of lines) {
+      expect(line.startsWith('<span class="hljs-comment">')).toBe(true);
+      expect(line.endsWith("</span>")).toBe(true);
+    }
+  });
+
+  it("re-opens the full nested stack, in order, on the next line", () => {
+    const html =
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${} under test, not JS interpolation
+      '<span class="hljs-string">`a\n<span class="hljs-subst">${b}</span>\nc`</span>';
+    const lines = splitLines(html);
+
+    expect(lines).toEqual([
+      '<span class="hljs-string">`a</span>',
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${} under test, not JS interpolation
+      '<span class="hljs-string"><span class="hljs-subst">${b}</span></span>',
+      '<span class="hljs-string">c`</span>',
+    ]);
+  });
+
+  it("passes plain lines through unchanged", () => {
+    const html = "const a = 1;\nconst b = 2;";
+    expect(splitLines(html)).toEqual(["const a = 1;", "const b = 2;"]);
+  });
+
+  it('yields the same line count as split("\\n") for trailing newlines', () => {
+    const html = "a\nb\n";
+    expect(splitLines(html)).toEqual(html.split("\n"));
+  });
+
+  it("preserves attributes exactly on re-opened spans", () => {
+    const html = '<span class="hljs-comment" data-foo="bar">a\nb</span>';
+    const lines = splitLines(html);
+
+    expect(lines).toEqual([
+      '<span class="hljs-comment" data-foo="bar">a</span>',
+      '<span class="hljs-comment" data-foo="bar">b</span>',
+    ]);
+  });
+});


### PR DESCRIPTION
LineNumbers split highlighted HTML on \n, which cuts through span elements that highlight.js emits across multiple lines, such as block comments and template literals. The first line was left with an unclosed span and every continuation line lost its styling entirely.

This adds src/split-lines.js, a small dependency-free tokenizer that tracks the stack of currently open span tags and closes/reopens them at each line break, the same approach Prism and Shiki use for line-level transforms. LineNumbers.svelte now uses splitLines instead of a raw string split. It's exported internally but left out of the public export map for now, since upcoming line-marker and streaming features will reuse it.

Also fixes the gutter width calculation, which previously sized digits off lines.length alone. With a non-default startingLineNumber, that undercounted the digits needed for the actual rendered numbers and caused overflow/misalignment. It now accounts for startingLineNumber + lines.length - 1.

Risk is limited to LineNumbers rendering: anyone relying on the old (broken) split behavior for multi-line spans would see different, correctly-styled output. Gutter width for typical single-digit-start cases is unchanged since the fix only affects blocks with a non-default starting line number.