### PR TITLE
feat(components): add transform hook to CopyButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -535,6 +535,22 @@ The component dispatches a `copy` event on success and an `error` event if the c
 />
 ```
 
+### Transforming copied text
+
+Displayed code often carries decoration that shouldn't survive a copy -- shell prompts, REPL markers, diff signs. Pass a `transform` function to strip it before the `copy` function runs; `on:copy` reports the transformed string, not the original `code`.
+
+`stripPrompts` and `stripDiffMarkers` cover the common cases and are exported for reuse (compose them for your own `transform` when a block needs both):
+
+```svelte
+<script>
+  import { CopyButton, stripPrompts } from "svelte-highlight";
+
+  const code = "$ npm install\nadded 1 package";
+</script>
+
+<CopyButton {code} transform={stripPrompts} />
+```
+
 ### Custom Button Content
 
 Provide custom button content using the default slot to replace the default icons. The slot exposes a `copied` boolean and a `copying` boolean (`true` while an async `copy` is in flight), so you can render a pending state for slow copy functions.
@@ -1264,6 +1280,7 @@ Arrow keys move between tabs; `Home` and `End` jump to the first and last. The m
 | :--------- | :----------------------------------------- | :------------------------------------------- |
 | code       | `string`                                   | N/A (required)                               |
 | copy       | `(code: string) => void \| Promise<void>`  | `(code) => navigator.clipboard.writeText(code)` |
+| transform  | `(code: string) => string`                 | `(code) => code`                             |
 | timeout    | `number`                                   | `2000`                                       |
 | text       | `string`                                   | `"Copy"`                                     |
 | copiedText | `string`                                   | `"Copied!"`                                  |
@@ -1272,7 +1289,7 @@ Arrow keys move between tabs; `Home` and `End` jump to the first and last. The m
 
 #### Dispatched Events
 
-- **on:copy**: fired after a successful copy, with `{ code }`
+- **on:copy**: fired after a successful copy, with `{ code }` -- the `transform`-applied string, not the original `code` prop
 - **on:error**: fired if the copy behavior throws, with `{ error }`
 
 ```svelte

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -62,6 +62,10 @@ pkgJson.exports = {
     types: "./ansi.d.ts",
     default: "./ansi.js",
   },
+  "./copy-transforms": {
+    types: "./copy-transforms.d.ts",
+    default: "./copy-transforms.js",
+  },
   "./load-language": {
     types: "./load-language.d.ts",
     default: "./load-language.js",

--- a/src/CopyButton.svelte
+++ b/src/CopyButton.svelte
@@ -8,6 +8,13 @@
    */
   export let copy = (code) => navigator.clipboard.writeText(code);
 
+  /**
+   * Transform `code` before it is passed to `copy`. Defaults to identity.
+   * The transformed string is what `on:copy` reports in `detail.code`.
+   * @type {(code: string) => string}
+   */
+  export let transform = (code) => code;
+
   /** @type {number} */
   export let timeout = 2_000;
 
@@ -36,9 +43,10 @@
 
     try {
       copying = true;
-      await copy(code);
+      const transformed = transform(code);
+      await copy(transformed);
       copied = true;
-      dispatch("copy", { code });
+      dispatch("copy", { code: transformed });
       timeoutId = setTimeout(() => {
         copied = false;
       }, timeout);

--- a/src/CopyButton.svelte.d.ts
+++ b/src/CopyButton.svelte.d.ts
@@ -14,6 +14,13 @@ export type CopyButtonProps = HTMLButtonAttributes & {
   copy?: (code: string) => void | Promise<void>;
 
   /**
+   * Transform `code` before it is passed to `copy`. Defaults to identity.
+   * The transformed string is what `on:copy` reports in `detail.code`.
+   * @default (code) => code
+   */
+  transform?: (code: string) => string;
+
+  /**
    * How long the "copied" state lasts (ms).
    * @default 2000
    */
@@ -91,7 +98,7 @@ export type CopyButtonProps = HTMLButtonAttributes & {
 export type CopyButtonEvents = {
   copy: CustomEvent<{
     /**
-     * The code that was copied.
+     * The code that was copied, after `transform` is applied.
      */
     code: string;
   }>;

--- a/src/copy-transforms.d.ts
+++ b/src/copy-transforms.d.ts
@@ -1,0 +1,13 @@
+/**
+ * Strip a leading prompt from each line that has one. Lines without a
+ * matching prompt (e.g. command output in a multi-command block) are kept
+ * as-is.
+ */
+export declare function stripPrompts(code: string, prompts?: string[]): string;
+
+/**
+ * Strip a leading diff marker (`+ `, `- `, or a bare `+`/`-` immediately
+ * before content) from each line. Context lines without a marker are left
+ * unchanged.
+ */
+export declare function stripDiffMarkers(code: string): string;

--- a/src/copy-transforms.js
+++ b/src/copy-transforms.js
@@ -1,0 +1,41 @@
+/**
+ * Composable transforms for `CopyButton`'s `transform` prop, for stripping
+ * decoration (shell prompts, REPL markers, diff signs) that should not
+ * survive a copy.
+ */
+
+/**
+ * Strip a leading prompt from each line that has one. Lines without a
+ * matching prompt (e.g. command output in a multi-command block) are kept
+ * as-is.
+ * @param {string} code
+ * @param {string[]} [prompts]
+ * @returns {string}
+ */
+export function stripPrompts(code, prompts = ["$ ", "> "]) {
+  return code
+    .split("\n")
+    .map((line) => {
+      const prompt = prompts.find((p) => line.startsWith(p));
+      return prompt ? line.slice(prompt.length) : line;
+    })
+    .join("\n");
+}
+
+/**
+ * Strip a leading diff marker (`+ `, `- `, or a bare `+`/`-` immediately
+ * before content) from each line. Context lines without a marker are left
+ * unchanged.
+ * @param {string} code
+ * @returns {string}
+ */
+export function stripDiffMarkers(code) {
+  return code
+    .split("\n")
+    .map((line) => {
+      if (line.startsWith("+ ") || line.startsWith("- ")) return line.slice(2);
+      if (line.startsWith("+") || line.startsWith("-")) return line.slice(1);
+      return line;
+    })
+    .join("\n");
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -5,6 +5,7 @@ export type { AnsiColor, AnsiSegment, AnsiStyle } from "./ansi";
 export { parseAnsi } from "./ansi";
 export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
+export { stripDiffMarkers, stripPrompts } from "./copy-transforms";
 export { default as FileTabs } from "./FileTabs.svelte";
 export { default as Highlight, default } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -3,6 +3,7 @@ export { highlight } from "./action.js";
 export { parseAnsi } from "./ansi.js";
 export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
+export { stripDiffMarkers, stripPrompts } from "./copy-transforms.js";
 export { default as FileTabs } from "./FileTabs.svelte";
 export { default, default as Highlight } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";

--- a/tests/copy-transforms.test.ts
+++ b/tests/copy-transforms.test.ts
@@ -1,0 +1,52 @@
+import { stripDiffMarkers, stripPrompts } from "../src/copy-transforms.js";
+
+describe("stripPrompts", () => {
+  it("strips the default `$ ` prompt and leaves output lines untouched", () => {
+    const code = "$ npm i\nadded 1 package";
+    expect(stripPrompts(code)).toBe("npm i\nadded 1 package");
+  });
+
+  it("strips the default `> ` prompt", () => {
+    const code = "> 1 + 1\n2";
+    expect(stripPrompts(code)).toBe("1 + 1\n2");
+  });
+
+  it("handles a mix of prompted and output lines in one block", () => {
+    const code = "$ npm i\nadded 1 package\n$ npm test\nok";
+    expect(stripPrompts(code)).toBe("npm i\nadded 1 package\nnpm test\nok");
+  });
+
+  it("accepts a custom prompt list", () => {
+    const code = "In [1]: 1 + 1\nOut[1]: 2";
+    expect(stripPrompts(code, ["In [1]: ", "Out[1]: "])).toBe("1 + 1\n2");
+  });
+
+  it("leaves lines without a matching prompt unchanged", () => {
+    const code = "plain line";
+    expect(stripPrompts(code)).toBe("plain line");
+  });
+});
+
+describe("stripDiffMarkers", () => {
+  it("leaves context lines untouched", () => {
+    const code = "  function foo() {\n  }";
+    expect(stripDiffMarkers(code)).toBe("  function foo() {\n  }");
+  });
+
+  it("strips a `+ ` / `- ` marker and preserves indentation exactly", () => {
+    const code = "-   return 1;\n+   return 2;";
+    expect(stripDiffMarkers(code)).toBe("  return 1;\n  return 2;");
+  });
+
+  it("strips a bare `+`/`-` immediately before content", () => {
+    const code = "+return 2;\n-return 1;";
+    expect(stripDiffMarkers(code)).toBe("return 2;\nreturn 1;");
+  });
+
+  it("handles a full block of context and changed lines", () => {
+    const code = "  function foo() {\n-   return 1;\n+   return 2;\n  }";
+    expect(stripDiffMarkers(code)).toBe(
+      "  function foo() {\n  return 1;\n  return 2;\n  }",
+    );
+  });
+});

--- a/tests/e2e/CopyButton.transform.test.svelte
+++ b/tests/e2e/CopyButton.transform.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { CopyButton, stripPrompts } from "svelte-highlight";
+
+  const code = "$ npm i\nadded 1 package";
+
+  let detail = "";
+
+  function onCopy(e: CustomEvent<{ code: string }>) {
+    detail = e.detail.code;
+  }
+</script>
+
+<div style="position: relative">
+  <CopyButton {code} transform={stripPrompts} timeout={1000} on:copy={onCopy} />
+</div>
+
+<output data-testid="detail">{detail}</output>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -5,6 +5,7 @@ import CodeWindow from "./CodeWindow.test.svelte";
 import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
 import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
 import CopyButton from "./CopyButton.test.svelte";
+import CopyButtonTransform from "./CopyButton.transform.test.svelte";
 import FileTabs from "./FileTabs.test.svelte";
 import Highlight from "./Highlight.test.svelte";
 import HighlightAction from "./HighlightAction.test.svelte";
@@ -463,6 +464,27 @@ test("CopyButton - dedupes clicks while an async copy is in flight", async ({
   await expect(button).toHaveAttribute("aria-label", "Copy", {
     timeout: 3_000,
   });
+});
+
+test("CopyButton - transform strips decoration before copying and reporting on:copy", async ({
+  mount,
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== "chromium",
+    "Clipboard permissions are Chromium-only",
+  );
+
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  const component = await mount(CopyButtonTransform);
+
+  await component.getByRole("button").click();
+
+  const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+  expect(clipboard).toBe("npm i\nadded 1 package");
+  await expect(page.getByTestId("detail")).toHaveText("npm i\nadded 1 package");
 });
 
 test("HighlightEditable - renders an editable, highlighted block", async ({


### PR DESCRIPTION
CopyButton now accepts a transform prop, a (code: string) => string function applied to code before it reaches the copy function. The transformed string is also what on:copy reports in detail.code, so listeners see exactly what landed on the clipboard. Default is identity, so existing usage is unaffected.

Two composable helpers ship alongside it in a new src/copy-transforms.js module, exported from the package root: stripPrompts (removes a leading shell/REPL prompt like $  or >  from lines that have one) and stripDiffMarkers (removes a leading + / -  or bare +/- from diff-annotated lines). Both are pure functions users can chain into their own transform.

Added unit tests for the two helpers, extended the CopyButton Playwright CT suite with a transform case, updated CopyButton.svelte.d.ts and index.d.ts/index.js, wired the new module into the package exports map, and documented the feature in the README with a usage example and prop table entry.

Risk is low since the change is additive and the default behavior is byte-identical. The main thing to watch is the exports map entry for copy-transforms in scripts/npm-package.ts, which should be verified against the published package shape test (test:static-app) before release.