### PR TITLE
fix(languages): grammar correctness batch (svelte, solidity, kql, zig, just, astro, hcl)

### DIFF
--- a/scripts/custom-languages/astro.js
+++ b/scripts/custom-languages/astro.js
@@ -16,6 +16,12 @@ function defineAstro(hljs) {
         excludeBegin: true,
         excludeEnd: true,
         relevance: 100,
+        /** @type {import("highlight.js").ModeCallback} */
+        "on:begin": (match, response) => {
+          if (match.index !== 0) {
+            response.ignoreMatch();
+          }
+        },
       },
       {
         begin: /^---\s*$/m,

--- a/scripts/custom-languages/hcl.js
+++ b/scripts/custom-languages/hcl.js
@@ -35,13 +35,13 @@ function defineHcl(hljs) {
     contains: [hljs.BACKSLASH_ESCAPE, INTERPOLATION],
   };
 
-  const HEREDOC = {
+  const HEREDOC = hljs.END_SAME_AS_BEGIN({
     className: "string",
-    begin: /<<-?\s*(["']?)(\w+)\1/,
-    end: /^\s*\w+\s*$/,
+    begin: /<<-?\s*(\w+)\s*\n/,
+    end: /^\s*(\w+)\s*$/,
     contains: [INTERPOLATION],
     relevance: 10,
-  };
+  });
 
   return {
     name: "HCL",

--- a/scripts/custom-languages/just.js
+++ b/scripts/custom-languages/just.js
@@ -22,7 +22,7 @@ function defineJust(hljs) {
     end: /\]/,
     contains: [
       {
-        className: "meta-keyword",
+        className: "keyword",
         begin: /[a-zA-Z][\w-]*/,
       },
       STRING,

--- a/scripts/custom-languages/kql.js
+++ b/scripts/custom-languages/kql.js
@@ -94,6 +94,7 @@ function defineKql(hljs) {
     aliases: ["kql", "kusto"],
     case_insensitive: false,
     keywords: {
+      $pattern: "[\\w.]+",
       keyword: KQL_KEYWORDS,
       operator: KQL_OPERATORS,
       built_in: KQL_FUNCTIONS,

--- a/scripts/custom-languages/solidity.js
+++ b/scripts/custom-languages/solidity.js
@@ -13,7 +13,7 @@ const SOLIDITY_LITERALS =
 
 const SOLIDITY_BUILT_INS =
   "msg block tx abi require assert keccak256 sha256 ripemd160 ecrecover " +
-  "addmod mulgmod gasleft blockhash now";
+  "addmod mulmod gasleft blockhash now";
 
 const SOLIDITY_TYPE = {
   className: "type",

--- a/scripts/custom-languages/svelte.js
+++ b/scripts/custom-languages/svelte.js
@@ -9,22 +9,22 @@ const SVELTE_DIRECTIVES =
 const TS_LANG = "(?:ts|typescript)";
 const SCRIPT_TS_BEGIN = new RegExp(
   String.raw`<script(?=[^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
-  "gm",
+  "m",
 );
 const SCRIPT_JS_MODULE_BEGIN = new RegExp(
   String.raw`<script(?=[^>]*(?:\scontext=["']module["']|\smodule\b))(?![^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
-  "gm",
+  "m",
 );
 const SCRIPT_JS_BEGIN = new RegExp(
   String.raw`<script(?![^>]*\slang=["']${TS_LANG}["'])[^>]*>`,
-  "gm",
+  "m",
 );
 
 /** @param {import("highlight.js").HLJSApi} hljs */
 function defineSvelte(hljs) {
   const runePattern = {
     begin: new RegExp(
-      String.raw`\$(?:${RUNE_NAMES})(?:\.(?:${RUNE_SUFFIXES}))?(?=\s|\(|,|;|\)|\}|$)`,
+      String.raw`\$(?:${RUNE_NAMES})(?:\.(?:${RUNE_SUFFIXES}))?(?=\s|\(|,|;|\)|\}|<|$)`,
     ),
     className: "keyword",
     relevance: 10,

--- a/scripts/custom-languages/zig.js
+++ b/scripts/custom-languages/zig.js
@@ -4,12 +4,12 @@ const ZIG_KEYWORDS =
   "error test and or orelse unreachable async await suspend resume " +
   "nosuspend export extern packed align allowzero volatile linksection " +
   "threadlocal usingnamespace asm anytype noalias callconv opaque " +
-  "anyframe fn";
+  "anyframe";
 
 const ZIG_LITERALS = "true false null undefined";
 
 const ZIG_TYPES =
-  "bool void type anyerror anytype noreturn comptime_int comptime_float " +
+  "bool void type anyerror anytype anyopaque noreturn comptime_int comptime_float " +
   "isize usize c_char c_short c_ushort c_int c_uint c_long c_ulong " +
   "c_longlong c_ulonglong c_longdouble f16 f32 f64 f80 f128";
 

--- a/tests/astro-language.test.ts
+++ b/tests/astro-language.test.ts
@@ -28,6 +28,16 @@ const globalWildcardSnippet = `<style is:global>
 const directiveAttrsSnippet = `<div set:html={html} />
 <span class:list={["badge", { active }]}>Status</span>`;
 
+const strayFenceSnippet = `---
+export const title = "Hello";
+---
+
+<div>{title}</div>
+
+---
+
+<p>after the hr</p>`;
+
 test("astro highlights frontmatter as TypeScript", () => {
   hljs.registerLanguage(astro.name, astro.register);
 
@@ -95,6 +105,20 @@ test("astro highlights colon attributes inside tags", () => {
   expect(result).not.toContain('<span class="hljs-variable">set:html</span>');
   expect(result).not.toContain('hljs-tag">]}&gt;');
   expect(result).toContain('language-javascript">{[<span class="hljs-string">');
+});
+
+test("astro does not open a new frontmatter region at a stray --- mid-document", () => {
+  hljs.registerLanguage(astro.name, astro.register);
+
+  const result = hljs.highlight(strayFenceSnippet, {
+    language: "astro",
+  }).value;
+
+  const typescriptRegionCount = (result.match(/language-typescript/g) ?? [])
+    .length;
+
+  expect(typescriptRegionCount).toBe(1);
+  expect(result).toContain("after the hr");
 });
 
 test("html alone does not highlight Astro frontmatter or client directives", () => {

--- a/tests/hcl-language.test.ts
+++ b/tests/hcl-language.test.ts
@@ -45,6 +45,12 @@ test("hcl highlights heredoc strings", () => {
   expect(result).toContain("hljs-string");
 });
 
+test("hcl heredoc only closes at the matching delimiter", () => {
+  const result = highlight("x = <<EOT\ntrue\nstill string\nEOT");
+
+  expect(result).toContain("true\nstill string");
+});
+
 test("hcl highlights hash and slash comments", () => {
   const result = highlight("# a comment\n// another\nx = 1");
 

--- a/tests/just-language.test.ts
+++ b/tests/just-language.test.ts
@@ -49,8 +49,15 @@ test("just highlights attributes", () => {
   const result = highlight('[private]\n_setup:\n    echo "setup"');
 
   expect(result).toContain(
-    '<span class="hljs-meta">[<span class="hljs-meta-keyword">private</span>]</span>',
+    '<span class="hljs-meta">[<span class="hljs-keyword">private</span>]</span>',
   );
+});
+
+test("just emits v11 meta scopes for directives, not the v10 meta-keyword class", () => {
+  const result = highlight('[private]\n_setup:\n    echo "setup"');
+
+  expect(result).toContain("hljs-meta");
+  expect(result).not.toContain("hljs-meta-keyword");
 });
 
 test("just highlights comments", () => {

--- a/tests/kql-language.test.ts
+++ b/tests/kql-language.test.ts
@@ -79,6 +79,12 @@ test("kql highlights hyphenated tabular operators", () => {
   expect(result).toContain('<span class="hljs-keyword">mv-expand</span>');
 });
 
+test("kql highlights dotted hint keywords", () => {
+  const result = highlight("T | join hint.strategy=broadcast U");
+
+  expect(result).toContain('<span class="hljs-keyword">hint.strategy</span>');
+});
+
 test("kql highlights let statements and variables", () => {
   const result = highlight(
     "let threshold = 5;\nPerf | where CounterValue > threshold",

--- a/tests/solidity-language.test.ts
+++ b/tests/solidity-language.test.ts
@@ -48,6 +48,12 @@ test("solidity highlights built-in globals", () => {
   expect(result).toContain('<span class="hljs-built_in">msg</span>');
 });
 
+test("solidity highlights the mulmod builtin", () => {
+  const result = highlight("mulmod(a, b, m);");
+
+  expect(result).toContain('<span class="hljs-built_in">mulmod</span>');
+});
+
 test("solidity scopes constructor/fallback/receive with the same declaration construct as function", () => {
   // constructor/fallback/receive now join the "function modifier event error"
   // beginKeywords list, so they're parsed by the same title-highlighting construct

--- a/tests/svelte-language.test.ts
+++ b/tests/svelte-language.test.ts
@@ -62,6 +62,11 @@ const langTypescriptSnippet = `<script lang="typescript">
   let count: number = 0;
 </script>`;
 
+const typedRuneSnippet = `<script lang="ts">
+  let count = $state<number>(0);
+  let items = $derived<Item[]>([]);
+</script>`;
+
 const declarationTagsSnippet = `<script lang="ts">
   type Box = { width: number; height: number };
 
@@ -183,6 +188,17 @@ test("svelte highlights dotted rune suffixes as a single keyword", () => {
   expect(result).toContain('<span class="hljs-keyword">$effect.root</span>');
   expect(result).toContain('<span class="hljs-keyword">$props.id</span>');
   expect(result).toContain('<span class="hljs-keyword">$inspect.trace</span>');
+});
+
+test("svelte highlights typed rune calls", () => {
+  hljs.registerLanguage(svelte.name, svelte.register);
+
+  const result = hljs.highlight(typedRuneSnippet, {
+    language: "svelte",
+  }).value;
+
+  expect(result).toContain('<span class="hljs-keyword">$state</span>');
+  expect(result).toContain('<span class="hljs-keyword">$derived</span>');
 });
 
 test("svelte highlights bare $store subscriptions without parens", () => {

--- a/tests/zig-language.test.ts
+++ b/tests/zig-language.test.ts
@@ -46,6 +46,12 @@ test("zig highlights literals", () => {
   expect(result).toContain('<span class="hljs-literal">undefined</span>');
 });
 
+test("zig highlights the anyopaque type", () => {
+  const result = highlight("fn f(p: *anyopaque) void {}");
+
+  expect(result).toContain('<span class="hljs-type">anyopaque</span>');
+});
+
 test("zig highlights optional and error-union type modifiers", () => {
   const result = highlight(
     "fn foo() ?u32 {\n  return null;\n}\nfn bar() anyerror!void {\n  return;\n}",

--- a/www/preview/hcl-preview-snippets.ts
+++ b/www/preview/hcl-preview-snippets.ts
@@ -74,6 +74,22 @@ resource "aws_security_group" "this" {
 }`,
   },
   {
+    title: "Heredoc with bare words in the body",
+    description:
+      "a bare word line (e.g. true) no longer closes the heredoc early",
+    code: `resource "aws_instance" "web" {
+  user_data = <<EOT
+#!/bin/bash
+ENABLE_LOGGING=true
+if $ENABLE_LOGGING; then
+  echo "logging enabled"
+fi
+true
+still inside the heredoc
+EOT
+}`,
+  },
+  {
     title: "Nested interpolation",
     // biome-ignore lint/suspicious/noTemplateCurlyInString: literal ${} syntax under illustration
     description: "${...} expressions containing their own {} literals",

--- a/www/preview/kql-preview-snippets.ts
+++ b/www/preview/kql-preview-snippets.ts
@@ -27,6 +27,17 @@ SecurityEvent
 | render columnchart`,
   },
   {
+    title: "Join hints",
+    description: "hint.strategy and hint.shufflekey on a join",
+    code: `SigninLogs
+| join hint.strategy=broadcast (
+    IdentityInfo | project AccountUPN, Department
+) on $left.UserPrincipalName == $right.AccountUPN
+| join hint.shufflekey=UserPrincipalName kind=leftouter (
+    AuditLogs | summarize LastAudit = max(TimeGenerated) by UserPrincipalName
+) on UserPrincipalName`,
+  },
+  {
     title: "Parsing and reshaping logs",
     description: "mv-expand, parse, and string functions",
     code: `Event

--- a/www/preview/solidity-preview-snippets.ts
+++ b/www/preview/solidity-preview-snippets.ts
@@ -53,6 +53,29 @@ contract Token {
 }`,
   },
   {
+    title: "Modular arithmetic builtins",
+    description: "addmod, mulmod, and keccak256 globals",
+    code: `pragma solidity ^0.8.24;
+
+contract ModExp {
+  function powMod(uint256 base, uint256 exp, uint256 m) public pure returns (uint256 result) {
+    result = 1;
+    base = base % m;
+    while (exp > 0) {
+      if (exp % 2 == 1) {
+        result = mulmod(result, base, m);
+      }
+      base = mulmod(base, base, m);
+      exp /= 2;
+    }
+  }
+
+  function commitmentHash(uint256 a, uint256 b, uint256 m) public pure returns (bytes32) {
+    return keccak256(abi.encodePacked(addmod(a, b, m)));
+  }
+}`,
+  },
+  {
     title: "Interface and library",
     description: "interface, library, is, ether, assembly",
     code: `pragma solidity ^0.8.24;

--- a/www/preview/svelte-preview-snippets.ts
+++ b/www/preview/svelte-preview-snippets.ts
@@ -94,6 +94,20 @@ export const sveltePreviewSnippets: SveltePreviewSnippet[] = [
 </script>`,
   },
   {
+    title: "Typed rune calls",
+    description: "$state<T>(...) and $derived<T>(...) with explicit generics",
+    code: `<script lang="ts">
+  type Item = { id: number; label: string };
+
+  let count = $state<number>(0);
+  let items = $derived<Item[]>(
+    Array.from({ length: count }, (_, id) => ({ id, label: \`Item \${id}\` })),
+  );
+</script>
+
+<p>{items.length} items</p>`,
+  },
+  {
     title: "Legacy directives",
     description:
       "on:, bind:, class:, use:, transition:, and let: prop directives",

--- a/www/preview/zig-preview-snippets.ts
+++ b/www/preview/zig-preview-snippets.ts
@@ -57,6 +57,19 @@ const banner =
 ;`,
   },
   {
+    title: "C interop with anyopaque",
+    description: "anyopaque, the 0.10+ replacement for c_void",
+    code: `const std = @import("std");
+
+extern fn c_alloc(size: usize) *anyopaque;
+extern fn c_free(ptr: *anyopaque) void;
+
+fn withOpaqueHandle(handle: *anyopaque) void {
+    const bytes: [*]u8 = @ptrCast(handle);
+    std.debug.print("first byte: {d}\\n", .{bytes[0]});
+}`,
+  },
+  {
     title: "Optional types",
     description: "?T optional prefix alongside !T error unions",
     code: `fn find(items: []const i32, target: i32) ?usize {


### PR DESCRIPTION
## Summary
Seven independent grammar-correctness fixes across custom `hljs` languages, each with a regression test:

- **svelte** — rune lookahead omitted `<`, so `$state<T>(...)`/`$derived<T>(...)` fell through to the TS sub-grammar; also dropped the dead `g` flag on the script-tag `begin` regexes.
- **solidity** — `mulgmod` typo in the built-ins list (should be `mulmod`).
- **kql** — no `$pattern` override meant dotted keywords like `hint.strategy`/`hint.shufflekey` could never match the default `\w+` keyword pattern.
- **zig** — `fn` was duplicated in the keyword list; added `anyopaque` (the 0.10+ replacement for `c_void`) to the types list.
- **just** — `meta-keyword` is a v10-only class; v11 themes style `.hljs-meta .hljs-keyword` instead, so directives like `[private]` rendered unstyled. Restructured to a nested `keyword` scope inside the existing `meta` mode.
- **astro** — hljs compiles all `begin` patterns with the `m` flag, so `^---\s*\n` matched at any line start; a stray `---` mid-document (e.g. a markdown hr) opened a bogus TypeScript frontmatter region. Added an `on:begin` callback that ignores the match unless it starts at index 0.
- **hcl** — heredoc `end: /^\s*\w+\s*$/` closed at the first bare word on its own line rather than the matching delimiter, so a lone `true` inside a heredoc body terminated the string early. Switched to `hljs.END_SAME_AS_BEGIN` so the region only closes on the exact matching delimiter.

Also includes `docs(preview):` commits adding a showcase snippet to the `www/` preview page for each fix that has one (svelte, solidity, kql, zig, hcl). `just`'s existing preview already exercises the fixed code path (no new content to show), and `astro` has no preview page today.

## Test plan
- [x] `bun run build:lib` — regenerated `src/languages/*` from `scripts/custom-languages/*`
- [x] `bun run fix` — lint/format clean
- [x] `bun run test:unit` — 706/706 pass, 0 golden-snapshot diffs (the golden suite only covers built-in hljs languages, not these custom grammars)
- [x] `bun run test:types` — clean
- [x] Manually verified the astro and hcl fixes reproduce/resolve their respective bugs by reverting each in isolation and confirming the new regression test fails without the fix