### PR TITLE
feat(components): handle OSC, carriage returns, and more SGR in parseAnsi

### DIFF
--- a/README.md
+++ b/README.md
@@ -1107,7 +1107,7 @@ With `prefers-reduced-motion`, the full block shows immediately and `on:done` ru
 
 ## Terminal Output
 
-Use `AnsiOutput` to render terminal output that still contains ANSI [SGR](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters) escape codes. Colors, bold, dim, italic, and underline become styled HTML. The parser is separate from highlight.js, so reach for it with build logs, CLI output, and test runners.
+Use `AnsiOutput` to render terminal output that still contains ANSI [SGR](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters) escape codes. Colors, bold, dim, italic, and underline become styled HTML, along with OSC 8 hyperlinks, carriage-return overwrites, and reverse/strikethrough. The parser is separate from highlight.js, so reach for it with build logs, CLI output, and test runners.
 
 ```svelte
 <script>

--- a/src/AnsiOutput.svelte
+++ b/src/AnsiOutput.svelte
@@ -111,6 +111,8 @@
 
   /** Foreground CSS, with auto-contrast override when needed. */
   function foregroundCss(segment) {
+    // Concealed text is rendered transparent (layout and copy text stay).
+    if (segment.conceal) return "transparent";
     if (autoContrast && segment.bg) {
       const bg = colorToRgb(segment.bg);
       const fg = segment.fg
@@ -129,6 +131,7 @@
     if (segment.dim) names.push("dim");
     if (segment.italic) names.push("italic");
     if (segment.underline) names.push("underline");
+    if (segment.strikethrough) names.push("strikethrough");
     return names.length ? names.join(" ") : undefined;
   }
 
@@ -147,13 +150,16 @@
     text: segment.text,
     class: classNames(segment),
     style: inlineStyle(segment),
+    link: segment.link,
   }));
 </script>
 
 <pre class="ansi" {...$$restProps}><code
-    >{#each segments as segment}<span class={segment.class} style={segment.style}
+    >{#each segments as segment}{#if segment.link}<a href={segment.link} rel="noopener noreferrer" class={segment.class} style={segment.style}
+        >{segment.text}</a
+      >{:else}<span class={segment.class} style={segment.style}
         >{segment.text}</span
-      >{/each}</code
+      >{/if}{/each}</code
   ></pre>
 
 <style>
@@ -187,7 +193,20 @@
     font-style: italic;
   }
 
-  .underline {
+  .ansi a {
+    color: inherit;
+    text-decoration: none;
+  }
+
+  .ansi .underline {
     text-decoration: underline;
+  }
+
+  .ansi .strikethrough {
+    text-decoration: line-through;
+  }
+
+  .ansi .underline.strikethrough {
+    text-decoration: underline line-through;
   }
 </style>

--- a/src/ansi.d.ts
+++ b/src/ansi.d.ts
@@ -16,6 +16,9 @@ export type AnsiStyle = {
   dim?: boolean | undefined;
   italic?: boolean | undefined;
   underline?: boolean | undefined;
+  reverse?: boolean | undefined;
+  strikethrough?: boolean | undefined;
+  conceal?: boolean | undefined;
   fg?: AnsiColor | undefined;
   bg?: AnsiColor | undefined;
 };
@@ -28,8 +31,14 @@ export type AnsiSegment = {
   dim?: boolean;
   italic?: boolean;
   underline?: boolean;
+  /** Strikethrough (SGR 9). */
+  strikethrough?: boolean;
+  /** Text is present for layout/copy but rendered invisible (SGR 8). */
+  conceal?: boolean;
   fg?: AnsiColor;
   bg?: AnsiColor;
+  /** OSC 8 hyperlink target for this run, if any. */
+  link?: string;
 };
 
 /** Parse ANSI SGR escape codes into styled segments. Malformed input is dropped. */

--- a/src/ansi.js
+++ b/src/ansi.js
@@ -58,6 +58,9 @@ function applySgr(style, params) {
       style.dim = undefined;
       style.italic = undefined;
       style.underline = undefined;
+      style.reverse = undefined;
+      style.strikethrough = undefined;
+      style.conceal = undefined;
       style.fg = undefined;
       style.bg = undefined;
     } else if (code === 1) {
@@ -68,6 +71,22 @@ function applySgr(style, params) {
       style.italic = true;
     } else if (code === 4) {
       style.underline = true;
+    } else if (code === 21) {
+      // Spec says "double underline"; several emitters instead use 21 as
+      // "bold off". We follow the spec and treat it as underline.
+      style.underline = true;
+    } else if (code === 7) {
+      style.reverse = true;
+    } else if (code === 27) {
+      style.reverse = undefined;
+    } else if (code === 8) {
+      style.conceal = true;
+    } else if (code === 28) {
+      style.conceal = undefined;
+    } else if (code === 9) {
+      style.strikethrough = true;
+    } else if (code === 29) {
+      style.strikethrough = undefined;
     } else if (code === 22) {
       style.bold = undefined;
       style.dim = undefined;
@@ -117,17 +136,26 @@ function applySgr(style, params) {
  * Build a segment from `text` and active fields in `style`.
  * @param {string} text
  * @param {AnsiStyle} style
+ * @param {string} [link]
  * @returns {AnsiSegment}
  */
-function toSegment(text, style) {
+function toSegment(text, style, link) {
   /** @type {AnsiSegment} */
   const segment = { text };
   if (style.bold) segment.bold = true;
   if (style.dim) segment.dim = true;
   if (style.italic) segment.italic = true;
   if (style.underline) segment.underline = true;
-  if (style.fg) segment.fg = style.fg;
-  if (style.bg) segment.bg = style.bg;
+  if (style.strikethrough) segment.strikethrough = true;
+  if (style.conceal) segment.conceal = true;
+  // Reverse video swaps fg/bg on the emitted segment. `style.fg`/`style.bg`
+  // themselves are untouched, so a later SGR 27 (reverse off) restores the
+  // original mapping for text that follows.
+  const fg = style.reverse ? style.bg : style.fg;
+  const bg = style.reverse ? style.fg : style.bg;
+  if (fg) segment.fg = fg;
+  if (bg) segment.bg = bg;
+  if (link) segment.link = link;
   return segment;
 }
 
@@ -147,11 +175,39 @@ export function parseAnsi(text) {
   /** @type {AnsiStyle} */
   const style = {};
   let buffer = "";
+  /** @type {string | undefined} */
+  let link;
 
   const flush = () => {
     if (buffer) {
-      segments.push(toSegment(buffer, style));
+      segments.push(toSegment(buffer, style, link));
       buffer = "";
+    }
+  };
+
+  /**
+   * Handle a lone `\r`: per-line overwrite semantics. Full last-write-wins
+   * per character cell is overkill for a text renderer, so we use a
+   * simplification: discard everything back to the start of the current
+   * line (the last `\n`) so that subsequent text rebuilds the line fresh.
+   */
+  const resetLine = () => {
+    const bufferBreak = buffer.lastIndexOf("\n");
+    if (bufferBreak !== -1) {
+      buffer = buffer.slice(0, bufferBreak + 1);
+      return;
+    }
+    buffer = "";
+    let last = segments.pop();
+    while (last !== undefined) {
+      const segmentBreak = last.text.lastIndexOf("\n");
+      if (segmentBreak === -1) {
+        last = segments.pop();
+        continue;
+      }
+      last.text = last.text.slice(0, segmentBreak + 1);
+      segments.push(last);
+      return;
     }
   };
 
@@ -186,6 +242,58 @@ export function parseAnsi(text) {
       }
       // Non-SGR CSI sequences (cursor moves, etc.) are skipped.
       i = j + 1;
+      continue;
+    }
+
+    if (ch === ESC && text[i + 1] === "]") {
+      // Read an OSC sequence: body up to a BEL or ST (`ESC \`) terminator.
+      let j = i + 2;
+      let terminatorLength = 0;
+      while (j < text.length) {
+        if (text[j] === "\x07") {
+          terminatorLength = 1;
+          break;
+        }
+        if (text[j] === ESC && text[j + 1] === "\\") {
+          terminatorLength = 2;
+          break;
+        }
+        j += 1;
+      }
+
+      if (terminatorLength === 0) {
+        // Unterminated: drop the rest.
+        break;
+      }
+
+      const body = text.slice(i + 2, j);
+      const firstSemi = body.indexOf(";");
+      const command = firstSemi === -1 ? body : body.slice(0, firstSemi);
+      if (command === "8" && firstSemi !== -1) {
+        // OSC 8 hyperlink: `8;params;uri`. An empty uri closes the link.
+        const rest = body.slice(firstSemi + 1);
+        const secondSemi = rest.indexOf(";");
+        if (secondSemi !== -1) {
+          flush();
+          const uri = rest.slice(secondSemi + 1);
+          link = uri || undefined;
+        }
+      }
+      // Other OSC sequences (title/icon sets, unknown commands) carry no
+      // rendered state: strip them silently.
+      i = j + terminatorLength;
+      continue;
+    }
+
+    if (ch === "\r") {
+      if (text[i + 1] === "\n") {
+        // Treat \r\n as \n.
+        buffer += "\n";
+        i += 2;
+        continue;
+      }
+      resetLine();
+      i += 1;
       continue;
     }
 

--- a/tests/ansi.test.ts
+++ b/tests/ansi.test.ts
@@ -122,4 +122,70 @@ describe("parseAnsi", () => {
       { text: "x", bold: true, fg: { name: "red" } },
     ]);
   });
+
+  it("parses an OSC 8 hyperlink into a segment with a link field", () => {
+    expect(
+      parseAnsi(`${ESC}]8;;https://example.com${ESC}\\text${ESC}]8;;${ESC}\\`),
+    ).toEqual([{ text: "text", link: "https://example.com" }]);
+  });
+
+  it("terminates an OSC 8 hyperlink with a BEL", () => {
+    expect(parseAnsi(`${ESC}]8;;https://example.com\x07text${ESC}]8;;\x07`)).toEqual([
+      { text: "text", link: "https://example.com" },
+    ]);
+  });
+
+  it("strips an OSC 2 title-set sequence, leaving surrounding text intact", () => {
+    expect(parseAnsi(`before${ESC}]2;My Title${ESC}\\after`)).toEqual([
+      { text: "beforeafter" },
+    ]);
+  });
+
+  it("collapses carriage-return overwrites to the final frame", () => {
+    expect(parseAnsi("building 50%\rbuilding 100%\rdone")).toEqual([
+      { text: "done" },
+    ]);
+  });
+
+  it("treats \\r\\n as a plain newline", () => {
+    expect(parseAnsi("a\r\nb")).toEqual([{ text: "a\nb" }]);
+  });
+
+  it("applies reverse video by swapping fg/bg in the parsed segment", () => {
+    expect(parseAnsi(`${ESC}[7;31mx`)).toEqual([
+      { text: "x", bg: { name: "red" } },
+    ]);
+  });
+
+  it("clears reverse video on SGR 27", () => {
+    expect(parseAnsi(`${ESC}[7;31mA${ESC}[27mB`)).toEqual([
+      { text: "A", bg: { name: "red" } },
+      { text: "B", fg: { name: "red" } },
+    ]);
+  });
+
+  it("parses strikethrough and clears it on SGR 29", () => {
+    expect(parseAnsi(`${ESC}[9mA${ESC}[29mB`)).toEqual([
+      { text: "A", strikethrough: true },
+      { text: "B" },
+    ]);
+  });
+
+  it("parses conceal and clears it on SGR 28", () => {
+    expect(parseAnsi(`${ESC}[8mA${ESC}[28mB`)).toEqual([
+      { text: "A", conceal: true },
+      { text: "B" },
+    ]);
+  });
+
+  it("treats SGR 21 as underline", () => {
+    expect(parseAnsi(`${ESC}[21mx`)).toEqual([{ text: "x", underline: true }]);
+  });
+
+  it("drops an unterminated OSC sequence without throwing", () => {
+    expect(() => parseAnsi(`${ESC}]8;;https://example.com`)).not.toThrow();
+    expect(parseAnsi(`ok${ESC}]8;;https://example.com`)).toEqual([
+      { text: "ok" },
+    ]);
+  });
 });

--- a/tests/ansi.test.ts
+++ b/tests/ansi.test.ts
@@ -130,9 +130,9 @@ describe("parseAnsi", () => {
   });
 
   it("terminates an OSC 8 hyperlink with a BEL", () => {
-    expect(parseAnsi(`${ESC}]8;;https://example.com\x07text${ESC}]8;;\x07`)).toEqual([
-      { text: "text", link: "https://example.com" },
-    ]);
+    expect(
+      parseAnsi(`${ESC}]8;;https://example.com\x07text${ESC}]8;;\x07`),
+    ).toEqual([{ text: "text", link: "https://example.com" }]);
   });
 
   it("strips an OSC 2 title-set sequence, leaving surrounding text intact", () => {

--- a/tests/e2e/AnsiOutput.link.test.svelte
+++ b/tests/e2e/AnsiOutput.link.test.svelte
@@ -1,0 +1,10 @@
+<script lang="ts">
+  import { AnsiOutput } from "svelte-highlight";
+
+  const ESC = "\x1b";
+
+  // An OSC 8 hyperlink wrapping "docs".
+  const text = `see ${ESC}]8;;https://example.com${ESC}\\docs${ESC}]8;;${ESC}\\ for more`;
+</script>
+
+<AnsiOutput {text} data-testid="ansi" />

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/experimental-ct-svelte";
 import AnsiOutputContrast from "./AnsiOutput.contrast.test.svelte";
+import AnsiOutputLink from "./AnsiOutput.link.test.svelte";
 import AnsiOutput from "./AnsiOutput.test.svelte";
 import CodeWindow from "./CodeWindow.test.svelte";
 import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
@@ -126,6 +127,17 @@ test("AnsiOutput - auto-contrast keeps low-contrast spans readable", async ({
     "color",
     "rgb(229, 229, 229)",
   );
+});
+
+test("AnsiOutput - OSC 8 hyperlink renders as an anchor", async ({
+  mount,
+  page,
+}) => {
+  await mount(AnsiOutputLink);
+
+  const link = page.getByTestId("ansi").locator("a");
+  await expect(link).toHaveText("docs");
+  await expect(link).toHaveAttribute("href", "https://example.com");
 });
 
 test("Highlight", async ({ mount, page }) => {


### PR DESCRIPTION
Real-world CLI output (npm, cargo, CI tools) was breaking AnsiOutput in three ways: OSC sequences leaked as visible garbage since only CSI codes were parsed, carriage-return progress-bar frames rendered concatenated instead of overwritten, and SGR codes 7, 9, 8 (reverse, strikethrough, conceal) were silently ignored.

parseAnsi now recognizes OSC sequences terminated by BEL or ST, stripping them from output text. OSC 8 hyperlinks specifically surface as an optional link field on the spanned segment, which AnsiOutput renders as an anchor with rel="noopener noreferrer". A lone carriage return now discards the current line's accumulated text back to the last newline, so \r-driven overwrites (progress bars, spinners) show only the final frame; \r\n is treated as a plain \n. Reverse video swaps fg/bg on the emitted segment (so it composes with the existing autoContrast logic unchanged), strikethrough and conceal are new segment fields that AnsiOutput turns into a line-through decoration and transparent text respectively.

The parseAnsi return shape stays backward compatible: new fields only, nothing renamed, and output for previously-supported input is unchanged. Added unit test coverage for the new OSC, carriage-return, and SGR behaviors, plus a component test verifying an OSC 8 link renders as a real anchor.

Risk is contained to AnsiOutput/parseAnsi consumers. The main things to watch are the carriage-return line-reset heuristic (it discards whole segments/lines rather than doing per-cell overwrite, which is a simplification) and the new anchor rendering path for hyperlinked segments, which changes the DOM structure for any text containing OSC 8 links.