### PR TITLE
perf(components): reveal Typewriter units without per-tick retokenization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1105,6 +1105,8 @@ Set `speed` (milliseconds per character) and pause with `play`. Turn `play` back
 
 With `prefers-reduced-motion`, the full block shows immediately and `on:done` runs right away. Customize the caret with `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink`.
 
+Each tick reveals one already-rendered unit rather than re-rendering the block, so animating stays smooth up to tens of thousands of characters; past that it falls back to the coarser whole-block reveal.
+
 ## Terminal Output
 
 Use `AnsiOutput` to render terminal output that still contains ANSI [SGR](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters) escape codes. Colors, bold, dim, italic, and underline become styled HTML. The parser is separate from highlight.js, so reach for it with build logs, CLI output, and test runners.

--- a/src/Typewriter.svelte
+++ b/src/Typewriter.svelte
@@ -18,11 +18,15 @@
   export let play = true;
 
   import { createEventDispatcher, onMount } from "svelte";
+  import { tokenizeTypewriter as tokenize } from "./typewriter-units.js";
 
   const dispatch = createEventDispatcher();
 
-  /** Opening or closing tag name. */
-  const TAG_NAME = /^<\/?\s*([a-zA-Z0-9-]+)/;
+  // Above this many visible units, per-unit spans (one element per char)
+  // stop paying for themselves; fall back to the old whole-string rebuild.
+  const UNIT_THRESHOLD = 20000;
+
+  const EMPTY_PARTS = { head: "", tail: "" };
 
   /** @type {boolean} */
   let mounted = false;
@@ -42,51 +46,20 @@
   /** @type {string | undefined} */
   let prevHighlighted;
 
-  /** Split HTML into typing units (tags = 0 chars, text/entities = 1). */
-  function tokenize(html) {
-    /** @type {{ raw: string; visible: number; kind?: string; name?: string }[]} */
-    const units = [];
-    const n = html.length;
-    let i = 0;
+  /** Container for the per-unit spans (unit-reveal path only). @type {HTMLElement} */
+  let contentEl;
 
-    while (i < n) {
-      const ch = html[i];
+  /** @type {HTMLElement[]} */
+  let unitEls = [];
 
-      if (ch === "<") {
-        const end = html.indexOf(">", i);
-        if (end === -1) {
-          // Unclosed tag: treat as text.
-          units.push({ raw: html.slice(i), visible: 1 });
-          break;
-        }
-        const raw = html.slice(i, end + 1);
-        const kind =
-          raw[1] === "/"
-            ? "close"
-            : raw[raw.length - 2] === "/"
-              ? "self"
-              : "open";
-        const match = TAG_NAME.exec(raw);
-        units.push({ raw, visible: 0, kind, name: match ? match[1] : "" });
-        i = end + 1;
-      } else if (ch === "&") {
-        // One visible char per entity.
-        const end = html.indexOf(";", i);
-        if (end !== -1 && end - i <= 10) {
-          units.push({ raw: html.slice(i, end + 1), visible: 1 });
-          i = end + 1;
-        } else {
-          units.push({ raw: ch, visible: 1 });
-          i += 1;
-        }
-      } else {
-        units.push({ raw: ch, visible: 1 });
-        i += 1;
-      }
-    }
+  /** The `units` array currently painted into `contentEl`. */
+  let paintedUnits;
 
-    return units;
-  }
+  /** How many leading units already had `typewriter-hidden` removed. */
+  let revealedInDom = 0;
+
+  /** The unit currently marked with the caret, if any. @type {HTMLElement | undefined} */
+  let caretMark;
 
   /**
    * Split at `count` visible chars. Close open tags in `head`, reopen in `tail`.
@@ -124,6 +97,52 @@
     return { head: head + headClose, tail };
   }
 
+  /** Render every unit once: tags pass through, each visible unit gets a span. */
+  function buildUnitMarkup(list) {
+    let html = "";
+    for (const unit of list) {
+      html +=
+        unit.visible === 0
+          ? unit.raw
+          : `<span class="typewriter-unit typewriter-hidden">${unit.raw}</span>`;
+    }
+    return html;
+  }
+
+  /**
+   * Bring `contentEl` in sync with `units`/`revealed` in O(1) amortized work:
+   * a fresh `units` value triggers one full (re)paint; otherwise only the
+   * units newly revealed since the last call are touched.
+   */
+  function syncUnitDom() {
+    if (!contentEl) return;
+
+    if (paintedUnits !== units) {
+      contentEl.innerHTML = buildUnitMarkup(units);
+      unitEls = Array.from(contentEl.getElementsByClassName("typewriter-unit"));
+      paintedUnits = units;
+      revealedInDom = 0;
+      caretMark = undefined;
+    }
+
+    while (revealedInDom < revealed) {
+      unitEls[revealedInDom]?.classList.remove("typewriter-hidden");
+      revealedInDom++;
+    }
+
+    if (caretMark) {
+      caretMark.classList.remove("typewriter-caret");
+      caretMark = undefined;
+    }
+    if (revealed < total) {
+      const next = unitEls[revealed];
+      if (next) {
+        next.classList.add("typewriter-caret");
+        caretMark = next;
+      }
+    }
+  }
+
   function clearTimer() {
     clearInterval(timerId);
     timerId = undefined;
@@ -136,8 +155,9 @@
     }
   }
 
-  function tick() {
+  function advance() {
     if (revealed < total) revealed += 1;
+    if (useUnitReveal) syncUnitDom();
     if (revealed >= total) {
       clearTimer();
       fireDone();
@@ -156,8 +176,10 @@
       return;
     }
 
+    if (useUnitReveal) syncUnitDom();
+
     if (play && revealed < total) {
-      timerId = setInterval(tick, Math.max(0, speed));
+      timerId = setInterval(advance, Math.max(0, speed));
     } else if (revealed >= total) {
       fireDone();
     }
@@ -165,23 +187,30 @@
 
   $: units = tokenize(highlighted);
   $: total = units.reduce((sum, unit) => sum + unit.visible, 0);
+  $: bigInput = total > UNIT_THRESHOLD;
+  $: useUnitReveal = mounted && !reducedMotion && !bigInput;
 
   // Restart when `highlighted` changes.
   $: if (highlighted !== prevHighlighted) {
     prevHighlighted = highlighted;
     doneFired = false;
     revealed = reducedMotion ? total : 0;
+    void useUnitReveal;
     sync();
   }
 
   // Re-sync on play/speed/mount/motion. Skip `total` (handled above).
   $: {
-    void [play, speed, mounted, reducedMotion];
+    void [play, speed, mounted, reducedMotion, useUnitReveal];
     sync();
   }
 
-  // SSR: full content. After mount, reveal from `revealed`.
-  $: parts = mounted ? split(units, revealed) : { head: highlighted, tail: "" };
+  // SSR / slow-path: full content up front, split() only when actually needed.
+  $: parts = useUnitReveal
+    ? EMPTY_PARTS
+    : mounted
+      ? split(units, revealed)
+      : { head: highlighted, tail: "" };
   $: showCaret = mounted && !reducedMotion && revealed < total;
 
   onMount(() => {
@@ -203,11 +232,15 @@
 
 <pre
   {...$$restProps}
-><code class:hljs={true}>{@html parts.head}{#if showCaret}<span
-      class="typewriter-caret"
-      aria-hidden="true"
-    ></span>{/if}<span class="typewriter-rest" aria-hidden="true"
-    >{@html parts.tail}</span></code></pre>
+><code class:hljs={true}
+  ><span class="typewriter-content" bind:this={contentEl} hidden={!useUnitReveal}
+    ></span
+  >{#if !useUnitReveal}{@html parts.head}{#if showCaret}<span
+        class="typewriter-caret"
+        aria-hidden="true"
+      ></span>{/if}<span class="typewriter-rest" aria-hidden="true"
+      >{@html parts.tail}</span
+    >{/if}</code></pre>
 
 <style>
   .typewriter-rest {
@@ -224,8 +257,30 @@
     animation: typewriter-blink var(--caret-blink, 1s) step-end infinite;
   }
 
+  /* `.typewriter-unit`/`.typewriter-hidden` only ever exist inside the
+     `{@html}`-free, JS-painted `contentEl`, so they're invisible to Svelte's
+     static analysis and must stay unscoped. */
+  :global(.typewriter-unit.typewriter-hidden) {
+    visibility: hidden;
+  }
+
+  /* The caret rides the next-to-reveal (still hidden) unit's ::before, so it
+     never requires moving a real DOM node -- one class add/remove per tick. */
+  :global(.typewriter-unit.typewriter-caret)::before {
+    content: "";
+    visibility: visible;
+    display: inline-block;
+    width: var(--caret-width, 0.6em);
+    height: var(--caret-height, 1.1em);
+    margin-left: var(--caret-gap, 1px);
+    vertical-align: text-bottom;
+    background: var(--caret-color, currentColor);
+    animation: typewriter-blink var(--caret-blink, 1s) step-end infinite;
+  }
+
   @media (prefers-reduced-motion: reduce) {
-    .typewriter-caret {
+    .typewriter-caret,
+    :global(.typewriter-unit.typewriter-caret)::before {
       animation: none;
     }
   }

--- a/src/Typewriter.svelte
+++ b/src/Typewriter.svelte
@@ -230,9 +230,7 @@
   });
 </script>
 
-<pre
-  {...$$restProps}
-><code class:hljs={true}
+<pre {...$$restProps}><code class:hljs={true}
   ><span class="typewriter-content" bind:this={contentEl} hidden={!useUnitReveal}
     ></span
   >{#if !useUnitReveal}{@html parts.head}{#if showCaret}<span

--- a/src/typewriter-units.d.ts
+++ b/src/typewriter-units.d.ts
@@ -1,0 +1,13 @@
+export interface TypewriterUnit {
+  raw: string;
+  visible: 0 | 1;
+  kind?: "open" | "close" | "self";
+  name?: string;
+}
+
+/**
+ * Splits highlight.js output HTML into typing units: HTML tags carry zero
+ * visible chars and are never split; text is grouped one visible char per
+ * unit (a surrogate pair or an HTML entity counts as a single char).
+ */
+export declare function tokenizeTypewriter(html: string): TypewriterUnit[];

--- a/src/typewriter-units.js
+++ b/src/typewriter-units.js
@@ -36,9 +36,18 @@ export function tokenizeTypewriter(html) {
       }
       const raw = html.slice(i, end + 1);
       const kind =
-        raw[1] === "/" ? "close" : raw[raw.length - 2] === "/" ? "self" : "open";
+        raw[1] === "/"
+          ? "close"
+          : raw[raw.length - 2] === "/"
+            ? "self"
+            : "open";
       const match = TAG_NAME.exec(raw);
-      units.push({ raw, visible: 0, kind, name: match ? (match[1] ?? "") : "" });
+      units.push({
+        raw,
+        visible: 0,
+        kind,
+        name: match ? (match[1] ?? "") : "",
+      });
       i = end + 1;
     } else if (ch === "&") {
       // One visible char per entity.

--- a/src/typewriter-units.js
+++ b/src/typewriter-units.js
@@ -1,0 +1,64 @@
+/** Opening or closing tag name. */
+const TAG_NAME = /^<\/?\s*([a-zA-Z0-9-]+)/;
+
+/**
+ * @typedef {Object} TypewriterUnit
+ * @property {string} raw
+ * @property {0 | 1} visible
+ * @property {"open" | "close" | "self"} [kind]
+ * @property {string} [name]
+ */
+
+/**
+ * Splits highlight.js output HTML into typing units for `Typewriter`. A unit
+ * is either an HTML tag (zero visible chars, never split) or one visible
+ * character: a plain character, a full surrogate pair (so a 4-byte emoji is
+ * never split mid-codepoint), or a single HTML entity such as `&amp;` (one
+ * visible char across several raw bytes).
+ * @param {string} html
+ * @returns {TypewriterUnit[]}
+ */
+export function tokenizeTypewriter(html) {
+  /** @type {TypewriterUnit[]} */
+  const units = [];
+  const n = html.length;
+  let i = 0;
+
+  while (i < n) {
+    const ch = html[i];
+
+    if (ch === "<") {
+      const end = html.indexOf(">", i);
+      if (end === -1) {
+        // Unclosed tag: treat as text.
+        units.push({ raw: html.slice(i), visible: 1 });
+        break;
+      }
+      const raw = html.slice(i, end + 1);
+      const kind =
+        raw[1] === "/" ? "close" : raw[raw.length - 2] === "/" ? "self" : "open";
+      const match = TAG_NAME.exec(raw);
+      units.push({ raw, visible: 0, kind, name: match ? (match[1] ?? "") : "" });
+      i = end + 1;
+    } else if (ch === "&") {
+      // One visible char per entity.
+      const end = html.indexOf(";", i);
+      if (end !== -1 && end - i <= 10) {
+        units.push({ raw: html.slice(i, end + 1), visible: 1 });
+        i = end + 1;
+      } else {
+        units.push({ raw: ch, visible: 1 });
+        i += 1;
+      }
+    } else {
+      // A surrogate pair (e.g. most emoji) is one codepoint, one unit --
+      // splitting it across two ticks would render an orphan half.
+      const codePoint = html.codePointAt(i) ?? 0;
+      const length = codePoint > 0xffff ? 2 : 1;
+      units.push({ raw: html.slice(i, i + length), visible: 1 });
+      i += length;
+    }
+  }
+
+  return units;
+}

--- a/tests/e2e/Typewriter.test.svelte
+++ b/tests/e2e/Typewriter.test.svelte
@@ -5,17 +5,30 @@
 
   export let speed = 1;
 
-  const code = "const add = (a: number, b: number) => a + b;";
+  let code = "const add = (a: number, b: number) => a + b;";
+  let play = true;
 
   let done = 0;
 </script>
 
 <svelte:head>{@html atomOneDark}</svelte:head>
 
+<button type="button" data-testid="toggle-play" on:click={() => (play = !play)}>
+  {play ? "Pause" : "Play"}
+</button>
+<button
+  type="button"
+  data-testid="swap-code"
+  on:click={() => (code = "function hello(name: string) {}")}
+>
+  Swap
+</button>
+
 <Highlight language={typescript} {code} let:highlighted>
   <Typewriter
     {highlighted}
     {speed}
+    {play}
     data-testid="tw"
     on:done={() => (done += 1)}
   />

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -689,6 +689,74 @@ test("Typewriter - reduced motion renders instantly", async ({
   await expect(tw.locator(".hljs-title.function_")).toHaveText("add");
 });
 
+test("Typewriter - revealed DOM nodes stay connected across ticks (no per-tick rebuild)", async ({
+  mount,
+  page,
+}) => {
+  await mount(Typewriter, { props: { speed: 20 } });
+
+  const tw = page.getByTestId("tw");
+  const firstUnit = tw.locator(".typewriter-unit").first();
+  await expect(firstUnit).toBeVisible();
+
+  const handle = await firstUnit.elementHandle();
+  // ~10 more ticks at 20ms each.
+  await page.waitForTimeout(200);
+
+  expect(await handle?.evaluate((el) => el.isConnected)).toBe(true);
+});
+
+test("Typewriter - pausing then resuming continues without restarting", async ({
+  mount,
+  page,
+}) => {
+  await mount(Typewriter, { props: { speed: 15 } });
+
+  const tw = page.getByTestId("tw");
+  const revealed = tw.locator(".typewriter-unit:not(.typewriter-hidden)");
+
+  await page.waitForTimeout(120);
+  await page.getByTestId("toggle-play").click(); // pause
+
+  const pausedCount = await revealed.count();
+  expect(pausedCount).toBeGreaterThan(0);
+  const firstRevealed = await revealed.first().elementHandle();
+
+  await page.waitForTimeout(150);
+  // No progress while paused.
+  expect(await revealed.count()).toBe(pausedCount);
+
+  await page.getByTestId("toggle-play").click(); // resume
+  await expect(page.getByTestId("done")).toHaveText("1");
+
+  // Same DOM node from before the pause: resume picked up where it left
+  // off instead of re-tokenizing/rebuilding.
+  expect(await firstRevealed?.evaluate((el) => el.isConnected)).toBe(true);
+});
+
+test("Typewriter - swapping `highlighted` mid-animation restarts cleanly", async ({
+  mount,
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  await mount(Typewriter, { props: { speed: 15 } });
+
+  const tw = page.getByTestId("tw");
+  await page.waitForTimeout(120); // reveal some characters of the first snippet
+  await page.getByTestId("swap-code").click();
+
+  await expect(page.getByTestId("done")).toHaveText("1");
+  await expect(tw.locator(".hljs-title.function_")).toHaveText("hello");
+  await expect(tw).toContainText("function hello(name: string) {}");
+
+  expect(errors).toEqual([]);
+});
+
 test("HighlightEditable - two instances share the same bound code", async ({
   mount,
   page,

--- a/tests/typewriter-tokenize.test.ts
+++ b/tests/typewriter-tokenize.test.ts
@@ -1,0 +1,57 @@
+import { tokenizeTypewriter } from "../src/typewriter-units.js";
+
+describe("tokenizeTypewriter", () => {
+  it("counts one visible unit per plain character", () => {
+    const units = tokenizeTypewriter("abc");
+    expect(units).toEqual([
+      { raw: "a", visible: 1 },
+      { raw: "b", visible: 1 },
+      { raw: "c", visible: 1 },
+    ]);
+  });
+
+  it("counts an HTML entity as a single visible unit", () => {
+    const units = tokenizeTypewriter("a&amp;b");
+    expect(units.map((u) => u.raw)).toEqual(["a", "&amp;", "b"]);
+    expect(units.every((u) => u.visible === 1)).toBe(true);
+  });
+
+  it("never splits a tag, and tags carry zero visible chars", () => {
+    const units = tokenizeTypewriter('<span class="hljs-keyword">const</span>');
+    expect(units[0]).toEqual({
+      raw: '<span class="hljs-keyword">',
+      visible: 0,
+      kind: "open",
+      name: "span",
+    });
+    expect(units[units.length - 1]).toEqual({
+      raw: "</span>",
+      visible: 0,
+      kind: "close",
+      name: "span",
+    });
+    expect(units.reduce((sum, u) => sum + u.visible, 0)).toBe(5);
+  });
+
+  it("handles a self-closing tag as zero visible chars of its own kind", () => {
+    const units = tokenizeTypewriter("a<br/>b");
+    expect(units).toEqual([
+      { raw: "a", visible: 1 },
+      { raw: "<br/>", visible: 0, kind: "self", name: "br" },
+      { raw: "b", visible: 1 },
+    ]);
+  });
+
+  it("does not split a multibyte emoji across surrogate halves", () => {
+    const emoji = "\u{1F600}"; // 😀, a surrogate pair
+    const units = tokenizeTypewriter(`a${emoji}b`);
+
+    expect(units).toEqual([
+      { raw: "a", visible: 1 },
+      { raw: emoji, visible: 1 },
+      { raw: "b", visible: 1 },
+    ]);
+    // The emoji unit must contain both surrogate halves together.
+    expect(units[1]?.raw.length).toBe(2);
+  });
+});


### PR DESCRIPTION
Typewriter used to re-split the tokenized HTML and replace the whole revealed head via {`@html`} on every tick, which was O(n^2) and tore down and reparsed the DOM once per character. Long snippets stuttered visibly.

The tokenizer now runs once per highlighted change (extracted to src/typewriter-units.js, with a fix so surrogate pairs like emoji are no longer split across two ticks). The full markup is rendered once as a plain span per visible unit, hidden via a CSS class, and each tick just removes that class from the next unit and moves a caret marker class, so a tick is O(1) DOM work. Inputs above 20000 visible units fall back to the old whole-string rebuild, since per-character spans stop paying for themselves at that scale; this is noted in the README.

Risk is mostly in the DOM-ownership split between Svelte's template and the imperatively painted content span: if that boundary is ever crossed (e.g. Svelte's slow-path markup and the fast-path span end up touching the same nodes), it could misrender or throw. Added e2e coverage for DOM node stability across ticks, pause/resume continuing without restarting, and mid-animation highlighted swaps restarting cleanly, plus unit tests for the tokenizer (entities, tags, self-closing tags, emoji). Full e2e suite and unit/type/lint checks pass locally.