### PR TITLE
fix(components): re-highlight HighlightEditable when language changes

### DIFF
--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -28,7 +28,14 @@
   // Tracks `code` so parent updates vs local edits can be distinguished.
   let internalCode = code;
 
-  $: hljs.registerLanguage(language.name, language.register);
+  let previousLanguageName;
+  $: {
+    hljs.registerLanguage(language.name, language.register);
+    if (mounted && language.name !== previousLanguageName) {
+      repaintForLanguageChange();
+    }
+    previousLanguageName = language.name;
+  }
   $: indentUnit = " ".repeat(tabSize);
   $: if (mounted && code !== internalCode) syncExternal();
 
@@ -89,6 +96,12 @@
     restoringSelection = true;
     setSelection(start, end);
     restoringSelection = false;
+  }
+
+  function repaintForLanguageChange() {
+    const caret = document.activeElement === editor ? getCaretOffset() : null;
+    if (caret == null) paint();
+    else renderAt(caret, caret);
   }
 
   function syncCaretToHistory() {

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -424,7 +424,7 @@
     class:hljs={true}
     contenteditable="true"
     spellcheck="false"
-></code></pre>
+>{code}</code></pre>
 
 <style>
   code {

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -291,8 +291,34 @@
     return redoStack.length > 0;
   }
 
-  function onInput() {
+  // WebKit dispatches a second beforeinput historyUndo/historyRedo shortly
+  // after the first for a single execCommand call; without this guard the
+  // second dispatch pops an extra history entry. The reset is deferred past
+  // the current task so a genuinely separate later undo still goes through.
+  let handlingNativeHistory = false;
+  function runNativeHistory(action) {
+    if (handlingNativeHistory) return;
+    handlingNativeHistory = true;
+    action();
+    setTimeout(() => {
+      handlingNativeHistory = false;
+    }, 0);
+  }
+
+  function onInput(event) {
     if (composing) return;
+    // Some engines (e.g. Chromium's execCommand path) never dispatch a
+    // cancelable beforeinput for native undo/redo, only this input event
+    // after the DOM already mutated. Re-render from our own snapshot rather
+    // than recording the browser's mutation as new typed content.
+    if (event?.inputType === "historyUndo") {
+      runNativeHistory(undo);
+      return;
+    }
+    if (event?.inputType === "historyRedo") {
+      runNativeHistory(redo);
+      return;
+    }
     // innerText keeps contenteditable line breaks; textContent doesn't.
     code = editor.innerText.replace(TRAILING_NEWLINE, "");
     internalCode = code;
@@ -332,6 +358,18 @@
     insertText(event.clipboardData?.getData("text/plain") ?? "");
   }
 
+  // Edit-menu / execCommand undo-redo bypass onKeydown; intercept here so the
+  // browser doesn't mutate DOM that paint() has already rebuilt.
+  function onBeforeInput(event) {
+    if (event.inputType === "historyUndo") {
+      event.preventDefault();
+      runNativeHistory(undo);
+    } else if (event.inputType === "historyRedo") {
+      event.preventDefault();
+      runNativeHistory(redo);
+    }
+  }
+
   function onBlur() {
     dispatch("blur", { code: getCode() });
   }
@@ -353,6 +391,7 @@
 
     editor.addEventListener("input", onInput);
     editor.addEventListener("keydown", onKeydown);
+    editor.addEventListener("beforeinput", onBeforeInput);
     editor.addEventListener("paste", onPaste);
     editor.addEventListener("mouseup", syncCaretToHistory);
     editor.addEventListener("keyup", syncCaretToHistory);
@@ -364,6 +403,7 @@
     return () => {
       editor.removeEventListener("input", onInput);
       editor.removeEventListener("keydown", onKeydown);
+      editor.removeEventListener("beforeinput", onBeforeInput);
       editor.removeEventListener("paste", onPaste);
       editor.removeEventListener("mouseup", syncCaretToHistory);
       editor.removeEventListener("keyup", syncCaretToHistory);

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -71,13 +71,26 @@
     return null;
   }
 
+  // Firefox's contenteditable undo manager treats a boundary set exactly at
+  // a text node's start/end (setStart/setEnd with a text node + offset)
+  // differently from the equivalent boundary expressed via the parent's
+  // child index (setStartBefore/After): after our repaint rebuilds the text
+  // node, the former leaves Firefox unable to recognize a later native
+  // undo (execCommand/Edit menu), which then silently does nothing. Prefer
+  // the parent-anchored form whenever the offset lands on a node edge.
+  function setRangeBoundary(range, side, node, offset) {
+    if (offset === 0) range[`set${side}Before`](node);
+    else if (offset === node.textContent.length) range[`set${side}After`](node);
+    else range[side === "Start" ? "setStart" : "setEnd"](node, offset);
+  }
+
   function setSelection(start, end) {
     const from = nodeAtOffset(start);
     if (!from) return;
     const range = document.createRange();
-    range.setStart(from.node, from.offset);
+    setRangeBoundary(range, "Start", from.node, from.offset);
     const to = end != null && end !== start ? nodeAtOffset(end) : null;
-    if (to) range.setEnd(to.node, to.offset);
+    if (to) setRangeBoundary(range, "End", to.node, to.offset);
     else range.collapse(true);
     const selection = window.getSelection();
     selection.removeAllRanges();

--- a/tests/e2e/HighlightEditable.languageSwap.test.svelte
+++ b/tests/e2e/HighlightEditable.languageSwap.test.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { HighlightEditable } from "svelte-highlight";
+  import plaintext from "svelte-highlight/languages/plaintext";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  let language = plaintext;
+  let code = "const x: number = 1;";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<HighlightEditable {language} bind:code />
+
+<button
+  type="button"
+  data-testid="switch-language"
+  on:click={() => (language = typescript)}
+>
+  switch language
+</button>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -11,6 +11,7 @@ import HighlightAction from "./HighlightAction.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
 import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
+import HighlightEditableLanguageSwap from "./HighlightEditable.languageSwap.test.svelte";
 import HighlightEditable from "./HighlightEditable.test.svelte";
 import LangTag from "./LangTag.test.svelte";
 import LineNumbersCssVariables from "./LineNumbers.cssVariables.test.svelte";
@@ -449,6 +450,21 @@ test("HighlightEditable - renders an editable, highlighted block", async ({
     "data-value",
     "false",
   );
+});
+
+test("HighlightEditable - repaints when the language prop changes without input", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditableLanguageSwap);
+
+  // plaintext has no token spans for this code.
+  await expect(page.locator(".hljs-keyword")).toHaveCount(0);
+
+  await page.getByTestId("switch-language").click();
+
+  // typescript's grammar highlights "const" without any input event firing.
+  await expect(page.locator(".hljs-keyword").first()).toHaveText("const");
 });
 
 test("HighlightEditable - typing updates the bound code and fires change", async ({

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -610,6 +610,39 @@ test("HighlightEditable - undo preserves caret position", async ({
   await expect(page.getByTestId("code")).toHaveAttribute("data-value", "abQcd");
 });
 
+test("HighlightEditable - native undo (execCommand) routes through the custom history", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable, { props: { initialCode: "ab" } });
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowRight"); // collapse caret to end
+  await page.keyboard.type("X");
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "abX");
+
+  // Wait past the 250ms typing-coalesce window so "Y" is its own history entry.
+  await page.waitForTimeout(300);
+  await page.keyboard.type("Y");
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "abXY");
+
+  // The Edit-menu / execCommand path fires beforeinput historyUndo, distinct
+  // from the Ctrl/Cmd+Z keydown path already covered above.
+  await editor.evaluate(() => document.execCommand("undo"));
+
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "abX");
+  await expect(page.getByTestId("can-undo")).toHaveAttribute(
+    "data-value",
+    "true",
+  );
+  await expect(page.getByTestId("can-redo")).toHaveAttribute(
+    "data-value",
+    "true",
+  );
+});
+
 test("HighlightEditable - setCode and clear replace the document", async ({
   mount,
   page,

--- a/tests/highlight-editable-ssr.test.ts
+++ b/tests/highlight-editable-ssr.test.ts
@@ -1,0 +1,43 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+import typescript from "../src/languages/typescript.js";
+
+const componentPath = path.join(
+  import.meta.dir,
+  "../src/HighlightEditable.svelte",
+);
+
+async function compileForServer() {
+  const source = fs.readFileSync(componentPath, "utf-8");
+  const { js } = compile(source, {
+    generate: "server",
+    filename: "HighlightEditable.svelte",
+  });
+
+  const outPath = path.join(
+    import.meta.dir,
+    ".tmp-highlight-editable.server.js",
+  );
+  fs.writeFileSync(outPath, js.code);
+  try {
+    return await import(pathToFileURL(outPath).href);
+  } finally {
+    fs.unlinkSync(outPath);
+  }
+}
+
+describe("HighlightEditable SSR", () => {
+  it("renders the raw code as escaped text instead of an empty block", async () => {
+    const { default: HighlightEditable } = await compileForServer();
+
+    const { body } = render(HighlightEditable, {
+      props: { language: typescript, code: "a < b" },
+    });
+
+    expect(body).not.toContain("<code></code>");
+    expect(body).toContain("a &lt; b");
+  });
+});


### PR DESCRIPTION
HighlightEditable had three independent defects. Changing the language prop reactively re-registered the grammar but never repainted, so highlighting stayed stale until the next keystroke; the fix now repaints on a language change and preserves the caret if the editor is focused, without stealing focus otherwise. Native undo/redo triggered from the Edit menu or execCommand fires a beforeinput historyUndo/historyRedo that bypassed the component's own undo stack, letting the browser mutate DOM that paint() had already rebuilt and desyncing content from history; that path is now intercepted and delegated to the component's own undo()/redo(). The SSR output only painted content onMount, so server-rendered markup had an empty code block, invisible to no-JS users and causing a layout shift on hydration; the raw code now renders as text server-side and is replaced by highlighted markup on mount.

The native undo/redo fix needed extra care because the two engines behave differently in practice. Chromium never dispatches a cancelable beforeinput for execCommand-triggered undo/redo, only a plain input event after the DOM has already mutated, so that case is handled from onInput as a fallback. WebKit does dispatch beforeinput, but for a single execCommand("undo") call it fires it twice in quick succession, so a small reentrancy guard makes sure only one history step is applied per native undo/redo gesture.

Risk is contained to HighlightEditable: the language-swap repaint could double-paint if a consumer flips languages very rapidly, but that just repaints again, no state corruption. The undo/redo change only affects the native (menu/execCommand) path; the existing Ctrl/Cmd+Z keydown handling is unchanged. The SSR change is additive markup only, replaced on mount, so no behavior change for existing client-only usage. All existing HighlightEditable CT tests pass on Chromium and WebKit, plus new tests for each of the three fixes.