### PR TITLE
feat(components): `HighlightAuto` detects custom grammars

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,26 @@ You can restrict [language auto-detection](https://highlightjs.readthedocs.io/en
 <HighlightAuto {code} languageNames={["javascript", "typescript"]} />
 ```
 
+### Detecting Custom Grammars
+
+The 52 custom grammars shipped in `svelte-highlight/languages/*` (Svelte, Astro, Vue, Zig, Gleam, …) are otherwise invisible to `HighlightAuto` — they're only registered on `highlight.js` as a side effect of a `Highlight` component using them first. Pass them to the `languages` prop to register and consider them during detection:
+
+```svelte
+<script>
+  import { HighlightAuto } from "svelte-highlight";
+  import svelte from "svelte-highlight/languages/svelte";
+  import github from "svelte-highlight/styles/github";
+
+  const code = `{#each items as item}\n  <li>{item}</li>\n{/each}`;
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<HighlightAuto {code} languages={[svelte]} />
+```
+
 ## Line Numbers
 
 Use the `LineNumbers` component to render the highlighted code with line numbers.
@@ -1356,11 +1376,14 @@ Arrow keys move between tabs; `Home` and `End` jump to the first and last. The m
 
 #### Props
 
-| Name      | Type             | Default value  |
-| :-------- | :--------------- | :------------- |
-| code      | `any`            | N/A (required) |
-| languages | `LanguageName[]` | `undefined`    |
-| langtag   | `boolean`        | `false`        |
+| Name          | Type                     | Default value  |
+| :------------ | :----------------------- | :------------- |
+| code          | `any`                    | N/A (required) |
+| languageNames | `LanguageName[]`         | `undefined`    |
+| languages     | `LanguageType<string>[]` | `undefined`    |
+| langtag       | `boolean`                | `false`        |
+
+`languageNames` restricts detection to a subset of built-in language names (see [Limiting Language Detection](#limiting-language-detection)). `languages` registers and considers custom grammar objects from `svelte-highlight/languages/*` (see [Detecting Custom Grammars](#detecting-custom-grammars)).
 
 `$$restProps` are forwarded to the top-level `pre` element.
 
@@ -1389,6 +1412,13 @@ import type { LanguageName } from "svelte-highlight";
      * @example "css"
      */
     console.log(e.detail.language);
+
+    /**
+     * The second-best heuristically detected language, if any. Useful for
+     * building "did you mean" UX.
+     * @example { language: "typescript", relevance: 8 }
+     */
+    console.log(e.detail.secondBest);
   }}
 />
 ```

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -1,4 +1,6 @@
 <script>
+  import hljs from "highlight.js";
+  import { afterUpdate, createEventDispatcher } from "svelte";
   import LangTag from "./LangTag.svelte";
 
   /** @type {any} */
@@ -7,14 +9,15 @@
   /** @type {(import("./languages").LanguageName | (string & {}))[] | undefined} */
   export let languageNames = undefined;
 
+  /** @type {import("./languages").LanguageType<string>[] | undefined} */
+  export let languages = undefined;
+
   /** @type {boolean} */
   export let langtag = false;
 
-  import hljs from "highlight.js";
-  import { afterUpdate, createEventDispatcher } from "svelte";
-
   /**
-   * @typedef {{ highlighted: string; language: string; }} HighlightEventDetail
+   * @typedef {{ language?: string; relevance: number }} SecondBest
+   * @typedef {{ highlighted: string; language: string; secondBest?: { language: string; relevance: number } }} HighlightEventDetail
    * @type {import("svelte").EventDispatcher<{ highlight: HighlightEventDetail}>}
    */
   const dispatch = createEventDispatcher();
@@ -25,14 +28,45 @@
   /** @type {string} */
   let language = "";
 
+  /** @type {SecondBest | undefined} */
+  let secondBest = undefined;
+
   afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted, language });
+    if (highlighted)
+      dispatch("highlight", {
+        highlighted,
+        language,
+        ...(secondBest
+          ? {
+              secondBest: {
+                language: secondBest.language ?? "",
+                relevance: secondBest.relevance,
+              },
+            }
+          : {}),
+      });
   });
 
-  $: ({ value: highlighted, language = "" } = hljs.highlightAuto(
-    code,
-    languageNames,
-  ));
+  $: {
+    if (languages) {
+      for (const language of languages) {
+        hljs.registerLanguage(language.name, language.register);
+      }
+    }
+
+    const subset = languageNames
+      ? [
+          ...languageNames,
+          ...(languages?.map((language) => language.name) ?? []),
+        ]
+      : undefined;
+
+    ({
+      value: highlighted,
+      language = "",
+      secondBest = undefined,
+    } = hljs.highlightAuto(code, subset));
+  }
 </script>
 
 <slot {highlighted} {langtag} languageName={language}>

--- a/src/HighlightAuto.svelte.d.ts
+++ b/src/HighlightAuto.svelte.d.ts
@@ -1,7 +1,7 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 import type { LangtagProps } from "./Highlight.svelte";
-import type { LanguageName } from "./languages";
+import type { LanguageName, LanguageType } from "./languages";
 
 export type HighlightAutoProps = HTMLAttributes<HTMLPreElement> &
   LangtagProps & {
@@ -11,11 +11,22 @@ export type HighlightAutoProps = HTMLAttributes<HTMLPreElement> &
     code: any;
 
     /**
-     * Languages to consider for auto-detection.
+     * Built-in language names to consider for auto-detection.
      * This can improve performance and accuracy.
      * @example ["javascript", "typescript"]
      */
     languageNames?: (LanguageName | (string & {}))[];
+
+    /**
+     * Custom grammars (e.g. `svelte-highlight/languages/*`) to register and
+     * consider for auto-detection. Custom grammars are otherwise invisible
+     * to `HighlightAuto` unless a `Highlight` component registered them first.
+     * @example
+     * import svelte from "svelte-highlight/languages/svelte";
+     * // ...
+     * languages={[svelte]}
+     */
+    languages?: LanguageType<string>[];
   };
 
 export type HighlightAutoEvents = {
@@ -31,6 +42,12 @@ export type HighlightAutoEvents = {
      * @example "css"
      */
     language: string;
+
+    /**
+     * The second-best heuristically detected language, if any.
+     * @example { language: "typescript", relevance: 8 }
+     */
+    secondBest?: { language: string; relevance: number };
   }>;
 };
 

--- a/tests/e2e/HighlightAuto.customLanguages.test.svelte
+++ b/tests/e2e/HighlightAuto.customLanguages.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { HighlightAuto } from "svelte-highlight";
+  import svelte from "svelte-highlight/languages/svelte";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code =
+    "{#each items as item}\n  <li>{item}</li>\n{/each}\n\n{#if $state(active)}\n  <p>{item}</p>\n{/if}";
+
+  let detectedLanguage = "";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<HighlightAuto
+  {code}
+  languages={[svelte]}
+  langtag
+  on:highlight={(e) => (detectedLanguage = e.detail.language)}
+/>
+
+<output data-testid="detected-language">{detectedLanguage}</output>

--- a/tests/e2e/HighlightAuto.secondBest.test.svelte
+++ b/tests/e2e/HighlightAuto.secondBest.test.svelte
@@ -1,0 +1,24 @@
+<script lang="ts">
+  import { HighlightAuto } from "svelte-highlight";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const x = 42;";
+
+  let secondBestLanguage = "";
+  let hasSecondBest = false;
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<HighlightAuto
+  {code}
+  languageNames={["javascript", "typescript"]}
+  langtag
+  on:highlight={(e) => {
+    hasSecondBest = e.detail.secondBest !== undefined;
+    secondBestLanguage = e.detail.secondBest?.language ?? "";
+  }}
+/>
+
+<output data-testid="has-second-best">{hasSecondBest}</output>
+<output data-testid="second-best-language">{secondBestLanguage}</output>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -10,7 +10,9 @@ import CopyButtonTransform from "./CopyButton.transform.test.svelte";
 import FileTabs from "./FileTabs.test.svelte";
 import Highlight from "./Highlight.test.svelte";
 import HighlightAction from "./HighlightAction.test.svelte";
+import HighlightAutoCustomLanguages from "./HighlightAuto.customLanguages.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
+import HighlightAutoSecondBest from "./HighlightAuto.secondBest.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
 import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
 import HighlightEditable from "./HighlightEditable.test.svelte";
@@ -364,6 +366,30 @@ test("Auto-highlighting with language restriction", async ({ mount, page }) => {
   // Should have JavaScript highlighting
   await expect(page.locator(".hljs-keyword")).toBeVisible();
   await expect(page.locator(".hljs-number")).toHaveText("42");
+});
+
+test("Auto-highlighting detects a custom grammar via the languages prop", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightAutoCustomLanguages);
+
+  await expect(page.locator("pre")).toHaveAttribute("data-language", "svelte");
+  await expect(page.getByTestId("detected-language")).toHaveText("svelte");
+
+  // Svelte-specific markup is highlighted, confirming the grammar was
+  // registered (not just guessed as a close built-in match).
+  await expect(page.getByText("$state", { exact: true })).toBeVisible();
+});
+
+test("Auto-highlighting surfaces secondBest for an ambiguous snippet", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightAutoSecondBest);
+
+  await expect(page.getByTestId("has-second-best")).toHaveText("true");
+  await expect(page.getByTestId("second-best-language")).not.toHaveText("");
 });
 
 test("LangTag", async ({ mount, page }) => {

--- a/tests/highlight-auto-detect.test.ts
+++ b/tests/highlight-auto-detect.test.ts
@@ -1,0 +1,13 @@
+import hljs from "highlight.js/lib/core";
+import svelte from "../src/languages/svelte";
+
+hljs.registerLanguage(svelte.name, svelte.register);
+
+test("highlightAuto detects a registered custom grammar within a subset", () => {
+  const code =
+    "<script>\n  let count = $state(0);\n</script>\n\n{#each items as item}\n  <li>{item}</li>\n{/each}";
+
+  const result = hljs.highlightAuto(code, ["svelte", "javascript", "html"]);
+
+  expect(result.language).toBe("svelte");
+});


### PR DESCRIPTION
The 52 custom grammars register on highlight.js/lib/core only as a side effect of <Highlight> usage, so highlightAuto never considered them: languageNames={["svelte"]} silently did nothing. Adds a languages prop accepting {name, register} grammar objects that are registered before detection, and surfaces hljs's secondBest match in the on:highlight event detail.