### PR TITLE
fix(components): recompute `HighlightStyle` scope class on theme change

### DIFF
--- a/src/HighlightStyle.svelte
+++ b/src/HighlightStyle.svelte
@@ -1,4 +1,31 @@
+<script context="module">
+  const isBrowser = typeof document !== "undefined";
+
+  /** @type {Map<string, number>} */
+  const refCounts = new Map();
+
+  /** @param {string} key */
+  function acquire(key) {
+    if (!isBrowser) return true;
+    const count = refCounts.get(key) ?? 0;
+    refCounts.set(key, count + 1);
+    return count === 0;
+  }
+
+  /** @param {string | undefined} key */
+  function release(key) {
+    if (!isBrowser || key === undefined) return;
+    const count = refCounts.get(key) ?? 0;
+    if (count <= 1) {
+      refCounts.delete(key);
+    } else {
+      refCounts.set(key, count - 1);
+    }
+  }
+</script>
+
 <script>
+  import { onMount } from "svelte";
   import { dualStyle, scopeClassFor, scopeStyle } from "./scoped.js";
 
   /**
@@ -25,15 +52,45 @@
   export let mode = "auto";
 
   /** Scope class for prefixed selectors. */
-  export let scopeClass = scopeClassFor(theme ?? `${light}${dark}`);
+  export let scopeClass = undefined;
 
-  $: style =
-    light !== undefined && dark !== undefined
+  // Captured once: a consumer-supplied scopeClass is honored for the
+  // lifetime of the instance instead of being overwritten by the hash below.
+  const hasOwnScopeClass = scopeClass !== undefined;
+
+  $: hasTheme =
+    theme !== undefined || (light !== undefined && dark !== undefined);
+
+  $: if (!hasOwnScopeClass) {
+    scopeClass = scopeClassFor(theme ?? `${light}${dark}`);
+  }
+
+  $: style = hasTheme
+    ? light !== undefined && dark !== undefined
       ? dualStyle(light, dark, scopeClass, mode)
-      : scopeStyle(theme, scopeClass);
+      : scopeStyle(theme, scopeClass)
+    : "";
+
+  let registeredKey;
+  let shouldRender = false;
+
+  $: {
+    const key = style ? `${scopeClass}::${style}` : undefined;
+    if (key !== registeredKey) {
+      release(registeredKey);
+      registeredKey = key;
+      shouldRender = key !== undefined && acquire(key);
+    }
+  }
+
+  onMount(() => () => release(registeredKey));
 </script>
 
-<svelte:head> {@html style} </svelte:head>
+<svelte:head
+  >{#if shouldRender}
+    {@html style}
+  {/if}</svelte:head
+>
 
 <div class={scopeClass} {...$$restProps}>
   <slot {scopeClass} />

--- a/tests/e2e/HighlightStyle.dedupe.test.svelte
+++ b/tests/e2e/HighlightStyle.dedupe.test.svelte
@@ -1,0 +1,19 @@
+<script>
+  import Highlight, { HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import a11yDark from "svelte-highlight/styles/a11y-dark";
+
+  const code = "const add = (a, b) => a + b;";
+</script>
+
+<HighlightStyle theme={a11yDark}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>
+
+<HighlightStyle theme={a11yDark}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>
+
+<HighlightStyle theme={a11yDark}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>

--- a/tests/e2e/HighlightStyle.noTheme.test.svelte
+++ b/tests/e2e/HighlightStyle.noTheme.test.svelte
@@ -1,0 +1,10 @@
+<script>
+  import Highlight, { HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code = "const add = (a, b) => a + b;";
+</script>
+
+<HighlightStyle>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>

--- a/tests/e2e/HighlightStyle.themeSwitch.test.svelte
+++ b/tests/e2e/HighlightStyle.themeSwitch.test.svelte
@@ -1,0 +1,28 @@
+<script>
+  import Highlight, { HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import a11yDark from "svelte-highlight/styles/a11y-dark";
+  import github from "svelte-highlight/styles/github";
+
+  const code = "const add = (a, b) => a + b;";
+
+  let themeB = a11yDark;
+</script>
+
+<button
+  type="button"
+  data-testid="switch-theme"
+  on:click={() => (themeB = github)}
+>
+  Switch
+</button>
+
+<HighlightStyle theme={a11yDark} data-testid="a" let:scopeClass>
+  <span data-testid="a-scope">{scopeClass}</span>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>
+
+<HighlightStyle theme={themeB} data-testid="b" let:scopeClass>
+  <span data-testid="b-scope">{scopeClass}</span>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -14,6 +14,9 @@ import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestrictio
 import HighlightAuto from "./HighlightAuto.test.svelte";
 import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
 import HighlightEditable from "./HighlightEditable.test.svelte";
+import HighlightStyleDedupe from "./HighlightStyle.dedupe.test.svelte";
+import HighlightStyleNoTheme from "./HighlightStyle.noTheme.test.svelte";
+import HighlightStyleThemeSwitch from "./HighlightStyle.themeSwitch.test.svelte";
 import LangTag from "./LangTag.test.svelte";
 import LineNumbersCssVariables from "./LineNumbers.cssVariables.test.svelte";
 import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test.svelte";
@@ -45,6 +48,55 @@ test("Scoped styles - two themes coexist without bleed", async ({
   // a11y-dark keyword is #dcc6e0; github keyword is #d73a49.
   await expect(keywordA).toHaveCSS("color", "rgb(220, 198, 224)");
   await expect(keywordB).toHaveCSS("color", "rgb(215, 58, 73)");
+});
+
+test("HighlightStyle - recomputes scope class when theme changes at runtime", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStyleThemeSwitch);
+
+  const scopeA = await page.getByTestId("a-scope").textContent();
+  const scopeBeforeSwitch = await page.getByTestId("b-scope").textContent();
+  expect(scopeA).toBe(scopeBeforeSwitch);
+
+  await page.getByTestId("switch-theme").click();
+
+  const scopeAfterSwitch = await page.getByTestId("b-scope").textContent();
+  expect(scopeAfterSwitch).not.toBe(scopeA);
+
+  const a = page.getByTestId("a").locator(".hljs").first();
+  const b = page.getByTestId("b").locator(".hljs").first();
+
+  // a11y-dark background is #2b2b2b; github background is #ffffff.
+  await expect(a).toHaveCSS("background-color", "rgb(43, 43, 43)");
+  await expect(b).toHaveCSS("background-color", "rgb(255, 255, 255)");
+});
+
+test("HighlightStyle - dedupes head injection for instances sharing a theme", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(HighlightStyleDedupe);
+
+  await expect(page.locator("style")).toHaveCount(1);
+
+  await component.unmount();
+
+  await expect(page.locator("style")).toHaveCount(0);
+});
+
+test("HighlightStyle - renders nothing when no theme is provided", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStyleNoTheme);
+
+  const headText = await page
+    .locator("head")
+    .evaluate((head) => head.textContent ?? "");
+  expect(headText).not.toContain("undefined");
+  await expect(page.locator("style")).toHaveCount(0);
 });
 
 test("CodeWindow - renders each variant wrapping a Highlight", async ({


### PR DESCRIPTION
The scope class was hashed from the theme once at init while the injected CSS recomputed reactively, so two blocks that mounted with the same theme and later diverged shared one scope class with conflicting stylesheets: both themes applied to both blocks.

Also dedupes head injection (one <style> per scope class, refcounted in the browser) and renders nothing with a dev warning when no theme is provided instead of injecting the literal string "undefined".