### PR TITLE
fix(components): make the highlight action idempotent and reversible

### DIFF
--- a/src/action.js
+++ b/src/action.js
@@ -7,13 +7,32 @@ import hljs from "highlight.js/lib/core";
  * @type {import("svelte/action").Action<HTMLElement, { language: import("./languages").LanguageType<string>; code?: string }>}
  */
 export function highlight(node, parameters) {
+  // Snapshot the pre-action source once: updates that omit `code` fall back
+  // to this instead of `node.textContent`, which after the first highlight
+  // pass holds the already-highlighted (and DOM-normalized) output.
+  const originalText = node.textContent ?? "";
+
   /** @param {{ language: import("./languages").LanguageType<string>; code?: string }} params */
   function apply({ language, code }) {
-    if (!hljs.getLanguage(language.name)) {
-      hljs.registerLanguage(language.name, language.register);
+    const source = code ?? originalText;
+    let value;
+
+    try {
+      if (!hljs.getLanguage(language.name)) {
+        hljs.registerLanguage(language.name, language.register);
+      }
+      value = hljs.highlight(source, { language: language.name }).value;
+    } catch (error) {
+      if (import.meta.env?.DEV) {
+        console.warn(
+          `[svelte-highlight] failed to highlight with language "${language.name}"; leaving content unchanged.`,
+          error,
+        );
+      }
+      return;
     }
-    const source = code ?? node.textContent ?? "";
-    node.innerHTML = hljs.highlight(source, { language: language.name }).value;
+
+    node.innerHTML = value;
     node.classList.add("hljs");
   }
 
@@ -21,5 +40,9 @@ export function highlight(node, parameters) {
 
   return {
     update: apply,
+    destroy() {
+      node.classList.remove("hljs");
+      node.textContent = originalText;
+    },
   };
 }

--- a/tests/e2e/HighlightAction.omittedCode.test.svelte
+++ b/tests/e2e/HighlightAction.omittedCode.test.svelte
@@ -1,0 +1,14 @@
+<script>
+  import { highlight } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  let tick = 0;
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<button type="button" on:click={() => (tick += 1)}>Update</button>
+
+<pre
+><code use:highlight={{ language: javascript, tick }}>const s = 1;</code></pre>

--- a/tests/e2e/HighlightAction.registerThrows.test.svelte
+++ b/tests/e2e/HighlightAction.registerThrows.test.svelte
@@ -1,0 +1,22 @@
+<script>
+  import hljs from "highlight.js/lib/core";
+  import { highlight } from "svelte-highlight";
+
+  // highlight.js swallows registration errors in its default "safe mode" and
+  // falls back to a plaintext grammar. Disable that so a broken grammar
+  // actually throws, proving the action's own guard - not hljs's internal
+  // safety net - is what keeps the element intact.
+  hljs.debugMode();
+
+  const source = "const s = 1;";
+
+  /** @type {import("svelte-highlight/languages").LanguageType<string>} */
+  const broken = {
+    name: "broken-grammar",
+    register: () => {
+      throw new Error("broken grammar");
+    },
+  };
+</script>
+
+<pre><code use:highlight={{ language: broken, code: source }}></code></pre>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -9,6 +9,8 @@ import CopyButton from "./CopyButton.test.svelte";
 import CopyButtonTransform from "./CopyButton.transform.test.svelte";
 import FileTabs from "./FileTabs.test.svelte";
 import Highlight from "./Highlight.test.svelte";
+import HighlightActionOmittedCode from "./HighlightAction.omittedCode.test.svelte";
+import HighlightActionRegisterThrows from "./HighlightAction.registerThrows.test.svelte";
 import HighlightAction from "./HighlightAction.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
@@ -242,6 +244,67 @@ test("highlight action", async ({ mount, page }) => {
   await page.getByRole("button", { name: "Update" }).click();
   await expect(code.locator(".hljs-keyword").first()).toHaveText("function");
   await expect(code.locator(".hljs-title").first()).toHaveText("hello");
+});
+
+test("highlight action - idempotent when `code` is omitted", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightActionOmittedCode);
+
+  const code = page.locator("pre code.hljs");
+  await expect(code).toBeVisible();
+  await expect(code.locator(".hljs-keyword").first()).toHaveText("const");
+
+  // Simulate the element's `textContent` drifting away from the original
+  // source, e.g. because a previous highlight pass (or unrelated DOM edit)
+  // already ran.
+  await code.evaluate((el) => {
+    el.textContent = "not the original source";
+  });
+
+  // Updating without `code` should re-highlight the snapshot captured on
+  // init, not the element's current (mutated) `textContent`.
+  const button = page.getByRole("button", { name: "Update" });
+  await button.click();
+  await expect(code).toHaveText("const s = 1;");
+  await expect(code.locator(".hljs-keyword").first()).toHaveText("const");
+
+  await button.click();
+  await expect(code).toHaveText("const s = 1;");
+});
+
+test("highlight action - grammar errors don't escape and leave content unchanged", async ({
+  mount,
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  await mount(HighlightActionRegisterThrows);
+
+  const code = page.locator("pre code");
+  await expect(code).toHaveText("");
+  await expect(code).not.toHaveClass(/hljs/);
+  expect(errors).toEqual([]);
+});
+
+test("highlight action - destroy restores the original content", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(HighlightActionOmittedCode);
+
+  const code = page.locator("pre code.hljs");
+  await expect(code.locator(".hljs-keyword").first()).toHaveText("const");
+  // Grab a handle before unmounting: Svelte removes the element from the
+  // DOM on unmount, so it won't be reachable via `page.locator` afterward.
+  const handle = await code.elementHandle();
+
+  await component.unmount();
+
+  expect(await handle?.evaluate((el) => el.innerHTML)).toBe("const s = 1;");
+  expect(await handle?.evaluate((el) => el.className)).toBe("");
 });
 
 test("HighlightAuto", async ({ mount, page }) => {


### PR DESCRIPTION
## Summary
- Wrap the `hljs` registration/highlight calls in `highlight` (`src/action.js`) in try/catch: on failure (e.g. a broken grammar's `register` throws), leave the element's content unchanged and warn in dev instead of letting the error escape.
- Snapshot the element's original source text once on init and highlight from that snapshot on subsequent updates instead of `node.textContent`, which after the first highlight pass holds the already-highlighted (DOM-mutated) output — fixes non-idempotent re-highlighting when `code` is omitted.
- Add a `destroy` cleanup that removes the `hljs` class and restores the original `textContent`, so progressive enhancement is reversible.

## Test plan
- [x] New Playwright CT tests in `tests/e2e/e2e.test.ts` (using `HighlightAction.omittedCode.test.svelte` and `HighlightAction.registerThrows.test.svelte`):
  - idempotent re-highlighting when `code` is omitted, even if `textContent` drifts
  - grammar registration errors don't escape and leave content unchanged
  - `destroy` restores the original (un-highlighted) content
- [x] Verified all three new tests fail against the pre-fix `action.js` and pass with the fix
- [x] Full CT suite (`bunx playwright test`, chromium) — 56/56 passing
- [x] Unit suite (`bun run test:unit`) — 802/802 passing
- [x] `bun run test:types` — no errors