### PR TITLE
fix(components): coerce non-string code before highlighting

### DIFF
--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -23,7 +23,8 @@
 
   $: {
     hljs.registerLanguage(language.name, language.register);
-    highlighted = hljs.highlight(code, { language: language.name }).value;
+    const source = typeof code === "string" ? code : String(code ?? "");
+    highlighted = hljs.highlight(source, { language: language.name }).value;
   }
 </script>
 

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -30,7 +30,7 @@
   });
 
   $: ({ value: highlighted, language = "" } = hljs.highlightAuto(
-    code,
+    typeof code === "string" ? code : String(code ?? ""),
     languageNames,
   ));
 </script>

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -22,7 +22,8 @@
 
   $: {
     hljs.registerLanguage(svelte.name, svelte.register);
-    highlighted = hljs.highlight(code, { language: svelte.name }).value;
+    const source = typeof code === "string" ? code : String(code ?? "");
+    highlighted = hljs.highlight(source, { language: svelte.name }).value;
   }
 </script>
 

--- a/tests/highlight-non-string-code.test.ts
+++ b/tests/highlight-non-string-code.test.ts
@@ -1,0 +1,72 @@
+import fs from "node:fs";
+import path from "node:path";
+import { plugin } from "bun";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+import typescript from "../src/languages/typescript.js";
+
+plugin({
+  name: "svelte-server-compile",
+  setup(build) {
+    build.onLoad({ filter: /\.svelte$/ }, ({ path: filePath }) => {
+      const source = fs.readFileSync(filePath, "utf-8");
+      const { js } = compile(source, {
+        generate: "server",
+        filename: path.basename(filePath),
+      });
+      return { contents: js.code, loader: "js" };
+    });
+  },
+});
+
+const srcDir = path.join(import.meta.dir, "../src");
+
+describe("non-string code does not crash hljs during SSR", () => {
+  it("Highlight renders a number without throwing", async () => {
+    const { default: Highlight } = await import(
+      path.join(srcDir, "Highlight.svelte")
+    );
+
+    const { body } = render(Highlight, {
+      props: { language: typescript, code: 42 },
+    });
+
+    expect(body).toContain("42");
+  });
+
+  it("Highlight renders undefined code as empty output without throwing", async () => {
+    const { default: Highlight } = await import(
+      path.join(srcDir, "Highlight.svelte")
+    );
+
+    expect(() =>
+      render(Highlight, {
+        props: { language: typescript, code: undefined },
+      }),
+    ).not.toThrow();
+  });
+
+  it("HighlightAuto renders a number without throwing", async () => {
+    const { default: HighlightAuto } = await import(
+      path.join(srcDir, "HighlightAuto.svelte")
+    );
+
+    expect(() =>
+      render(HighlightAuto, {
+        props: { code: 42 },
+      }),
+    ).not.toThrow();
+  });
+
+  it("HighlightSvelte renders a number without throwing", async () => {
+    const { default: HighlightSvelte } = await import(
+      path.join(srcDir, "HighlightSvelte.svelte")
+    );
+
+    expect(() =>
+      render(HighlightSvelte, {
+        props: { code: 42 },
+      }),
+    ).not.toThrow();
+  });
+});


### PR DESCRIPTION
## Summary
- `code` is typed `any` on `Highlight`, `HighlightAuto`, and `HighlightSvelte`, but `hljs.highlight`/`highlightAuto` throw `value.replace is not a function` when given non-string input — crashing render, including SSR.
- Coerce `code` to a string (`typeof code === "string" ? code : String(code ?? "")`) immediately before passing it to hljs in all three components.

## Test plan
- [x] `tests/highlight-non-string-code.test.ts` — SSR-renders `Highlight`, `HighlightAuto`, and `HighlightSvelte` with numeric and `undefined` `code` props and asserts no throw.
- [x] `bun run test:unit` — 806 pass, 0 fail.
- [x] `bun run fix` — no lint/format changes needed.