### PR TITLE
feat(components): add HighlightStream for incrementally streamed code

### DIFF
--- a/README.md
+++ b/README.md
@@ -1123,6 +1123,50 @@ With `prefers-reduced-motion`, the full block shows immediately and `on:done` ru
 
 Each tick reveals one already-rendered unit rather than re-rendering the block, so animating stays smooth up to tens of thousands of characters; past that it falls back to the coarser whole-block reveal.
 
+## Streaming
+
+Rendering LLM chat output is the dominant new syntax-highlighting use case: code arrives in arbitrary-sized chunks, mid-token and mid-line, and you don't know the full content up front. `HighlightStream` is built for that -- unlike `Typewriter`, which animates a complete, already-highlighted string and restarts whenever it changes, `HighlightStream` accepts a growing `code` buffer and re-highlights it as chunks arrive.
+
+Append to `code` as chunks come in; set `done` once the stream ends.
+
+```svelte
+<script>
+  import { HighlightStream } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  let code = "";
+  let done = false;
+
+  // Wire this up to your streaming source (fetch, WebSocket, SSE, ...).
+  async function stream() {
+    for (const chunk of chunks) {
+      code += chunk;
+      await new Promise((r) => setTimeout(r, 30));
+    }
+    done = true;
+  }
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<HighlightStream language={typescript} {code} {done} />
+```
+
+Multiple chunks appended within the same animation frame coalesce into a single highlight pass. Already-rendered lines are diffed and left untouched in the DOM; only lines whose content actually changed are repainted, so a fast-scrolling response only touches its changed suffix (typically the last line). A multi-line construct left open mid-stream -- an unterminated template literal or block comment -- re-tokenizes the lines it spans once the closing delimiter arrives, with no special-casing needed: it falls out of re-highlighting the full buffer on every update.
+
+A blinking caret marks the end of output while `!done`; setting `done` hides it and performs one final full highlight, so the finished output matches what `Highlight` would render for the same code. `on:done` fires right after that final highlight. Customize the caret with the same `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink` variables as `Typewriter`.
+
+Set `autoScroll` to keep the container pinned to the bottom as output grows -- it stops auto-scrolling as soon as you scroll up, and resumes once you scroll back to the bottom.
+
+```svelte
+<HighlightStream language={typescript} {code} {done} autoScroll style="max-height: 20em; overflow-y: auto;" />
+```
+
+This is O(buffer) per highlighted frame and DOM updates proportional to the changed lines -- fine for chat-sized output up to a few thousand lines, not a virtualized log viewer.
+
 ## Terminal Output
 
 Use `AnsiOutput` to render terminal output that still contains ANSI [SGR](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters) escape codes. Colors, bold, dim, italic, and underline become styled HTML, along with OSC 8 hyperlinks, carriage-return overwrites, and reverse/strikethrough. The parser is separate from highlight.js, so reach for it with build logs, CLI output, and test runners.
@@ -1424,6 +1468,35 @@ Use `bind:this`, then call `undo()`, `redo()`, `focus()`, `selectAll()`, `insert
   bind:code
   on:change={(e) => console.log(e.detail.code)}
   on:history={(e) => console.log(e.detail.canUndo, e.detail.canRedo)}
+/>
+```
+
+### `HighlightStream`
+
+#### Props
+
+| Name       | Type                                           | Default value  |
+| :--------- | :--------------------------------------------- | :------------- |
+| code       | `string`                                       | `""`           |
+| language   | { name: `string`; register: hljs => `object` } | N/A (required) |
+| done       | `boolean`                                      | `false`        |
+| caret      | `boolean`                                      | `true`         |
+| autoScroll | `boolean`                                      | `false`        |
+
+`$$restProps` are forwarded to the top-level `pre` element.
+
+#### Dispatched Events
+
+- **on:highlight**: fired after each highlight pass, with `{ highlighted }`
+- **on:done**: fired after the final full highlight once `done` is set
+
+```svelte
+<HighlightStream
+  language={typescript}
+  {code}
+  {done}
+  on:highlight={(e) => console.log(e.detail.highlighted)}
+  on:done={() => console.log("stream finished")}
 />
 ```
 

--- a/src/HighlightStream.svelte
+++ b/src/HighlightStream.svelte
@@ -1,0 +1,154 @@
+<script>
+  /**
+   * Growing code buffer. Append chunks as they arrive; arbitrary chunk
+   * boundaries (mid-token, mid-line) are handled.
+   * @type {string}
+   */
+  export let code = "";
+
+  /** @type {import("./languages").LanguageType<string>} */
+  export let language;
+
+  /**
+   * Stream finished: hides the caret and performs one final full highlight.
+   * @type {boolean}
+   */
+  export let done = false;
+
+  /**
+   * Show a blinking caret at the end of output while `!done`.
+   * @type {boolean}
+   */
+  export let caret = true;
+
+  /**
+   * Keep the container scrolled to the bottom while streaming, unless the
+   * user has scrolled away from the bottom.
+   * @type {boolean}
+   */
+  export let autoScroll = false;
+
+  import hljs from "highlight.js/lib/core";
+  import { createEventDispatcher, onMount, tick } from "svelte";
+  import { splitLines } from "./split-lines.js";
+
+  const dispatch = createEventDispatcher();
+
+  /** @type {HTMLElement} */
+  let container;
+
+  /** @type {string} */
+  let highlighted = "";
+
+  /** @type {string[]} */
+  let lines = [];
+
+  /** @type {ReturnType<typeof requestAnimationFrame> | undefined} */
+  let frame;
+
+  let mounted = false;
+
+  // Guards against re-dispatching `done` on every reactive re-run while it
+  // stays true; resets so a later restart (done set back to `false`) fires
+  // it again next time the stream finishes.
+  let doneDispatched = false;
+
+  // Stick to bottom until the user scrolls away from it.
+  let stickToBottom = true;
+
+  function repaint() {
+    hljs.registerLanguage(language.name, language.register);
+    highlighted = hljs.highlight(code, { language: language.name }).value;
+    lines = splitLines(highlighted);
+    dispatch("highlight", { highlighted });
+
+    if (autoScroll) {
+      tick().then(() => {
+        if (stickToBottom) scrollToBottom();
+      });
+    }
+  }
+
+  function scrollToBottom() {
+    if (container) container.scrollTop = container.scrollHeight;
+  }
+
+  function onScroll() {
+    if (!container) return;
+    const gap =
+      container.scrollHeight - container.scrollTop - container.clientHeight;
+    stickToBottom = gap <= 4;
+  }
+
+  function cancelFrame() {
+    if (frame != null) {
+      cancelAnimationFrame(frame);
+      frame = undefined;
+    }
+  }
+
+  // Coalesce a burst of chunks within one frame into a single highlight
+  // pass; the tab going hidden just pauses the (already-scheduled) frame
+  // rather than queuing more work.
+  function scheduleRepaint() {
+    if (frame != null) return;
+    frame = requestAnimationFrame(() => {
+      frame = undefined;
+      repaint();
+    });
+  }
+
+  $: {
+    void code;
+    void language;
+    if (mounted && !done) {
+      doneDispatched = false;
+      scheduleRepaint();
+    } else {
+      // SSR / first paint before mount, and the final full highlight once
+      // the stream finishes: both render synchronously, no rAF involved.
+      cancelFrame();
+      repaint();
+      if (mounted && !doneDispatched) {
+        doneDispatched = true;
+        dispatch("done");
+      }
+    }
+  }
+
+  $: useSplitRendering = mounted && !done;
+  $: showCaret = useSplitRendering && caret;
+
+  onMount(() => {
+    mounted = true;
+    return cancelFrame;
+  });
+</script>
+
+<pre bind:this={container} on:scroll={onScroll} {...$$restProps}><code
+  class:hljs={true}
+>{#if useSplitRendering}{#each lines as line, i (i)}{#if i > 0}{"\n"}{/if}<span class="highlight-stream-line" data-line={i}>{@html line}</span>{/each}{#if showCaret}<span class="highlight-stream-caret" aria-hidden="true"></span>{/if}{:else}{@html highlighted}{/if}</code></pre>
+
+<style>
+  .highlight-stream-caret {
+    display: inline-block;
+    width: var(--caret-width, 0.6em);
+    height: var(--caret-height, 1.1em);
+    margin-left: var(--caret-gap, 1px);
+    vertical-align: text-bottom;
+    background: var(--caret-color, currentColor);
+    animation: highlight-stream-blink var(--caret-blink, 1s) step-end infinite;
+  }
+
+  @media (prefers-reduced-motion: reduce) {
+    .highlight-stream-caret {
+      animation: none;
+    }
+  }
+
+  @keyframes highlight-stream-blink {
+    50% {
+      opacity: 0;
+    }
+  }
+</style>

--- a/src/HighlightStream.svelte.d.ts
+++ b/src/HighlightStream.svelte.d.ts
@@ -1,0 +1,90 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+import type { LanguageType } from "./languages";
+
+export type HighlightStreamProps = HTMLAttributes<HTMLPreElement> & {
+  /**
+   * Growing code buffer. Append chunks as they arrive; arbitrary chunk
+   * boundaries (mid-token, mid-line) are handled.
+   * @default ""
+   */
+  code?: string;
+
+  /**
+   * highlight.js language module.
+   * Import languages from `svelte-highlight/languages/*`.
+   * @example
+   * import typescript from "svelte-highlight/languages/typescript";
+   */
+  language: LanguageType<string>;
+
+  /**
+   * Stream finished: hides the caret and performs one final full highlight.
+   * @default false
+   */
+  done?: boolean;
+
+  /**
+   * Show a blinking caret at the end of output while `!done`.
+   * @default true
+   */
+  caret?: boolean;
+
+  /**
+   * Keep the container scrolled to the bottom while streaming, unless the
+   * user has scrolled away from the bottom.
+   * @default false
+   */
+  autoScroll?: boolean;
+
+  /**
+   * Width of the blinking caret.
+   * @default "0.6em"
+   */
+  "--caret-width"?: string;
+
+  /**
+   * Height of the blinking caret.
+   * @default "1.1em"
+   */
+  "--caret-height"?: string;
+
+  /**
+   * Gap between output and the caret.
+   * @default "1px"
+   */
+  "--caret-gap"?: string;
+
+  /**
+   * Color of the blinking caret.
+   * @default "currentColor"
+   */
+  "--caret-color"?: string;
+
+  /**
+   * Duration of one caret blink cycle.
+   * @default "1s"
+   */
+  "--caret-blink"?: string;
+};
+
+export type HighlightStreamEvents = {
+  highlight: CustomEvent<{
+    /**
+     * The highlighted HTML as a string.
+     * @example "<span>...</span>"
+     */
+    highlighted: string;
+  }>;
+
+  /**
+   * Fires after the final full highlight once `done` is set.
+   */
+  done: CustomEvent<null>;
+};
+
+export default class HighlightStream extends SvelteComponentTyped<
+  HighlightStreamProps,
+  HighlightStreamEvents,
+  Record<string, never>
+> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -10,6 +10,7 @@ export { default as FileTabs } from "./FileTabs.svelte";
 export { default as Highlight, default } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
 export { default as HighlightEditable } from "./HighlightEditable.svelte";
+export { default as HighlightStream } from "./HighlightStream.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -8,6 +8,7 @@ export { default as FileTabs } from "./FileTabs.svelte";
 export { default, default as Highlight } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
 export { default as HighlightEditable } from "./HighlightEditable.svelte";
+export { default as HighlightStream } from "./HighlightStream.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";

--- a/tests/e2e/HighlightStream.stability.test.svelte
+++ b/tests/e2e/HighlightStream.stability.test.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  let code = "const a = 1;";
+
+  function appendLines() {
+    let extra = "";
+    for (let i = 0; i < 50; i++) extra += `\nconst x${i} = ${i};`;
+    code += extra;
+  }
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<button type="button" data-testid="append-lines" on:click={appendLines}>
+  Append 50 lines
+</button>
+
+<HighlightStream language={javascript} {code} data-testid="stream" />

--- a/tests/e2e/HighlightStream.templateLiteral.test.svelte
+++ b/tests/e2e/HighlightStream.templateLiteral.test.svelte
@@ -1,0 +1,28 @@
+<script>
+  import { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  // Chunk 1 opens a backtick string that spans two lines, unterminated.
+  // Chunk 2 closes it and appends a trailing line.
+  const chunk1 = "const s = `line one\nline two";
+  const chunk2 = " done`;\nconsole.log(s);";
+
+  let code = chunk1;
+
+  function closeTemplateLiteral() {
+    code += chunk2;
+  }
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<button
+  type="button"
+  data-testid="close-template-literal"
+  on:click={closeTemplateLiteral}
+>
+  Close template literal
+</button>
+
+<HighlightStream language={javascript} {code} data-testid="stream" />

--- a/tests/e2e/HighlightStream.test.svelte
+++ b/tests/e2e/HighlightStream.test.svelte
@@ -1,0 +1,48 @@
+<script>
+  import Highlight, { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  // Chunk boundaries split mid-keyword ("con" | "st") and mid-template-literal
+  // ("`Hel" | "lo, world!"). Concatenated: `const greet = () => \`Hello, world!\`;`
+  const CHUNKS = ["con", "st gr", "eet = () => `Hel", "lo, world!", "`;"];
+
+  let code = "";
+  let done = false;
+  let chunksSent = 0;
+  let highlightCount = 0;
+  let doneCount = 0;
+
+  function appendChunk() {
+    if (chunksSent >= CHUNKS.length) return;
+    code += CHUNKS[chunksSent];
+    chunksSent += 1;
+  }
+
+  function finish() {
+    done = true;
+  }
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<button type="button" data-testid="append-chunk" on:click={appendChunk}>
+  Append chunk
+</button>
+<button type="button" data-testid="finish" on:click={finish}>Finish</button>
+
+<HighlightStream
+  language={javascript}
+  {code}
+  {done}
+  data-testid="stream"
+  on:highlight={() => (highlightCount += 1)}
+  on:done={() => (doneCount += 1)}
+/>
+
+<span data-testid="highlight-count">{highlightCount}</span>
+<span data-testid="done-count">{doneCount}</span>
+
+{#if done}
+  <Highlight language={javascript} {code} data-testid="reference" />
+{/if}

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -17,6 +17,9 @@ import HighlightAuto from "./HighlightAuto.test.svelte";
 import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
 import HighlightEditableLanguageSwap from "./HighlightEditable.languageSwap.test.svelte";
 import HighlightEditable from "./HighlightEditable.test.svelte";
+import HighlightStreamStability from "./HighlightStream.stability.test.svelte";
+import HighlightStreamTemplateLiteral from "./HighlightStream.templateLiteral.test.svelte";
+import HighlightStream from "./HighlightStream.test.svelte";
 import HighlightStyleDedupe from "./HighlightStyle.dedupe.test.svelte";
 import HighlightStyleNoTheme from "./HighlightStyle.noTheme.test.svelte";
 import HighlightStyleThemeSwitch from "./HighlightStyle.themeSwitch.test.svelte";
@@ -907,6 +910,86 @@ test("HighlightEditable - handles bursts of typing on a large document within bu
     "data-value",
     `${lines}${"x".repeat(50)}`,
   );
+});
+
+test("HighlightStream - streaming chunks (split mid-keyword and mid-template-literal) settle to Highlight's output", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStream);
+
+  const appendChunk = page.getByTestId("append-chunk");
+  const highlightCount = page.getByTestId("highlight-count");
+
+  // Each chunk must trigger at least one `on:highlight`, even though bursts
+  // within a single frame coalesce into fewer highlight passes.
+  let previousCount = (await highlightCount.textContent()) ?? "0";
+  for (let sent = 1; sent <= 5; sent++) {
+    // biome-ignore lint/performance/noAwaitInLoops: each chunk's effect on-screen must be observed before the next chunk is sent
+    await appendChunk.click();
+    await expect(highlightCount).not.toHaveText(previousCount);
+    previousCount = (await highlightCount.textContent()) ?? previousCount;
+  }
+
+  await page.getByTestId("finish").click();
+
+  const stream = page.getByTestId("stream").locator("code");
+  const reference = page.getByTestId("reference").locator("code");
+  await expect(stream).toHaveText("const greet = () => `Hello, world!`;");
+  expect(await stream.innerHTML()).toBe(await reference.innerHTML());
+});
+
+test("HighlightStream - stable line elements are not recreated as more lines stream in", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamStability);
+
+  const firstLine = page
+    .getByTestId("stream")
+    .locator("[data-line='0']")
+    .first();
+  await expect(firstLine).toBeVisible();
+  const handle = await firstLine.elementHandle();
+
+  await page.getByTestId("append-lines").click();
+  await expect(page.getByTestId("stream").locator("[data-line]")).toHaveCount(
+    51,
+  );
+
+  expect(await handle?.evaluate((el) => el.isConnected)).toBe(true);
+});
+
+test("HighlightStream - closing a multi-line template literal re-tokenizes the earlier line", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamTemplateLiteral);
+
+  const secondLine = page.getByTestId("stream").locator("[data-line='1']");
+  await expect(secondLine).toHaveText("line two");
+  await expect(secondLine.locator(".hljs-string")).toHaveText("line two");
+
+  await page.getByTestId("close-template-literal").click();
+
+  await expect(secondLine).toHaveText("line two done`;");
+  await expect(secondLine.locator(".hljs-string")).toHaveText("line two done`");
+});
+
+test("HighlightStream - `done` hides the caret and fires on:done", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStream);
+
+  const stream = page.getByTestId("stream");
+  await page.getByTestId("append-chunk").click();
+  await expect(stream.locator(".highlight-stream-caret")).toBeVisible();
+  await expect(page.getByTestId("done-count")).toHaveText("0");
+
+  await page.getByTestId("finish").click();
+  await expect(stream.locator(".highlight-stream-caret")).toHaveCount(0);
+  await expect(page.getByTestId("done-count")).toHaveText("1");
 });
 
 test("Typewriter - animates then settles to the full highlighted content", async ({

--- a/www/components/HighlightStream/AutoScroll.svelte
+++ b/www/components/HighlightStream/AutoScroll.svelte
@@ -1,0 +1,64 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button, Toggle } from "carbon-components-svelte";
+  import { onDestroy, onMount } from "svelte";
+  import { CodeWindow, HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import { simulateStream } from "./stream-demo.js";
+
+  const LINES = Array.from(
+    { length: 40 },
+    (_, i) => `console.log("step ${i}: ${(i * 7) % 13} items processed");`,
+  );
+  const full = LINES.join("\n");
+
+  let autoScroll = true;
+  let code = "";
+  let done = false;
+  let stop = () => {};
+
+  function run() {
+    stop();
+    code = "";
+    done = false;
+    stop = simulateStream(full, {
+      intervalMs: 15,
+      minChunk: 4,
+      maxChunk: 12,
+      onChunk: (chunk) => (code += chunk),
+      onDone: () => (done = true),
+    });
+  }
+
+  onMount(run);
+  onDestroy(() => stop());
+</script>
+
+<p class="label-01 mb-3">
+  A tall, fast-streaming log pinned to a short window. Scroll up mid-stream to
+  detach—output keeps arriving below the fold until you scroll back to the
+  bottom.
+</p>
+
+<CodeWindow variant="terminal" title="build.log">
+  <HighlightStream
+    language={javascript}
+    {code}
+    {done}
+    {autoScroll}
+    class={THEME_MODULE_NAME}
+    style="max-height: 10em; overflow-y: auto;"
+  />
+</CodeWindow>
+
+<div
+  style="display: flex; flex-wrap: wrap; align-items: flex-end; gap: 1.5rem; margin-top: 0.75rem"
+>
+  <Toggle
+    bind:toggled={autoScroll}
+    labelText="Auto-scroll"
+    labelA="Off"
+    labelB="On"
+  />
+  <Button size="small" kind="tertiary" on:click={run}>Replay</Button>
+</div>

--- a/www/components/HighlightStream/Basic.svelte
+++ b/www/components/HighlightStream/Basic.svelte
@@ -1,0 +1,70 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import { onDestroy, onMount } from "svelte";
+  import { HighlightStream, HighlightSvelte } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import { simulateStream } from "./stream-demo.js";
+
+  const full = `const greet = (name) => {
+  return \`Hello, \${name}!\`;
+};
+
+console.log(greet("world"));`;
+
+  const snippet = `<script>
+  import { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import github from "svelte-highlight/styles/github";
+
+  let code = "";
+  let done = false;
+
+  // Wire this up to your streaming source (fetch, WebSocket, SSE, ...).
+  async function stream() {
+    for (const chunk of chunks) {
+      code += chunk;
+      await new Promise((r) => setTimeout(r, 30));
+    }
+    done = true;
+  }
+<\/script>
+
+<svelte:head>
+  {@html github}
+<\/svelte:head>
+
+<HighlightStream language={javascript} {code} {done} />`;
+
+  let code = "";
+  let done = false;
+  let stop = () => {};
+
+  function run() {
+    stop();
+    code = "";
+    done = false;
+    stop = simulateStream(full, {
+      onChunk: (chunk) => (code += chunk),
+      onDone: () => (done = true),
+    });
+  }
+
+  onMount(run);
+  onDestroy(() => stop());
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+<HighlightStream
+  language={javascript}
+  {code}
+  {done}
+  class={THEME_MODULE_NAME}
+/>
+
+<Button size="small" kind="tertiary" style="margin-top: 0.75rem" on:click={run}>
+  Replay
+</Button>

--- a/www/components/HighlightStream/Caret.svelte
+++ b/www/components/HighlightStream/Caret.svelte
@@ -1,0 +1,53 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import { onDestroy, onMount } from "svelte";
+  import { HighlightStream } from "svelte-highlight";
+  import python from "svelte-highlight/languages/python";
+  import { simulateStream } from "./stream-demo.js";
+
+  const full = `def fibonacci(n):
+    a, b = 0, 1
+    for _ in range(n):
+        a, b = b, a + b
+    return a`;
+
+  let code = "";
+  let done = false;
+  let stop = () => {};
+
+  function run() {
+    stop();
+    code = "";
+    done = false;
+    stop = simulateStream(full, {
+      onChunk: (chunk) => (code += chunk),
+      onDone: () => (done = true),
+    });
+  }
+
+  onMount(run);
+  onDestroy(() => stop());
+</script>
+
+<p class="label-01 mb-3">
+  <code class="code">--caret-width</code>,
+  <code class="code">--caret-color</code>, and
+  <code class="code">--caret-blink</code>
+  reuse the same contract as
+  <code class="code">Typewriter</code>.
+</p>
+
+<HighlightStream
+  language={python}
+  {code}
+  {done}
+  class={THEME_MODULE_NAME}
+  --caret-width="8px"
+  --caret-color="#ff7eb6"
+  --caret-blink="0.4s"
+/>
+
+<Button size="small" kind="tertiary" style="margin-top: 0.75rem" on:click={run}>
+  Replay
+</Button>

--- a/www/components/HighlightStream/Controls.svelte
+++ b/www/components/HighlightStream/Controls.svelte
@@ -1,0 +1,78 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button, Slider, Toggle } from "carbon-components-svelte";
+  import { onDestroy, onMount } from "svelte";
+  import { HighlightStream } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import { simulateStream } from "./stream-demo.js";
+
+  const full = `interface User {
+  id: number;
+  name: string;
+}
+
+function formatUser(user: User): string {
+  return \`#\${user.id} \${user.name}\`;
+}
+
+const users: User[] = [
+  { id: 1, name: "Ada" },
+  { id: 2, name: "Grace" },
+  { id: 3, name: "Alan" },
+];
+
+for (const user of users) {
+  console.log(formatUser(user));
+}`;
+
+  let speed = 25;
+  let autoScroll = true;
+  let code = "";
+  let done = false;
+  let stop = () => {};
+
+  function run() {
+    stop();
+    code = "";
+    done = false;
+    stop = simulateStream(full, {
+      intervalMs: speed,
+      onChunk: (chunk) => (code += chunk),
+      onDone: () => (done = true),
+    });
+  }
+
+  onMount(run);
+  onDestroy(() => stop());
+</script>
+
+<HighlightStream
+  language={typescript}
+  {code}
+  {done}
+  {autoScroll}
+  class={THEME_MODULE_NAME}
+  style="max-height: 12em; overflow-y: auto;"
+/>
+
+<div
+  style="display: flex; flex-wrap: wrap; align-items: flex-end; gap: 1.5rem; margin-top: 1rem"
+>
+  <Slider
+    bind:value={speed}
+    min={5}
+    max={120}
+    step={5}
+    labelText="Chunk interval (ms, applied on next replay)"
+  />
+  <Toggle
+    bind:toggled={autoScroll}
+    labelText="Auto-scroll"
+    labelA="Off"
+    labelB="On"
+  />
+  <Button size="small" kind="tertiary" on:click={run}>Replay</Button>
+  <p class="label-01" style="margin-bottom: 0.5rem">
+    Status: <code class="code">{done ? "done" : "streaming…"}</code>
+  </p>
+</div>

--- a/www/components/HighlightStream/Retokenize.svelte
+++ b/www/components/HighlightStream/Retokenize.svelte
@@ -1,0 +1,40 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+
+  // Chunk 1 opens a backtick string spanning two lines, left unterminated.
+  // Chunk 2 closes it and appends a trailing line.
+  const chunk1 = "const s = `line one\nline two";
+  const chunk2 = " done`;\nconsole.log(s);";
+
+  let code = chunk1;
+  let closed = false;
+
+  function close() {
+    code += chunk2;
+    closed = true;
+  }
+
+  function reset() {
+    code = chunk1;
+    closed = false;
+  }
+</script>
+
+<p class="label-01 mb-3">
+  The template literal opened on line 0 is still unterminated—line 1 renders
+  fully inside the string span. Closing it re-tokenizes line 1 in place: the
+  string span now ends before the semicolon, with no special-casing in the
+  component.
+</p>
+
+<HighlightStream language={javascript} {code} class={THEME_MODULE_NAME} />
+
+<div style="display: flex; align-items: center; gap: 1rem; margin-top: 0.75rem">
+  <Button size="small" kind="tertiary" disabled={closed} on:click={close}>
+    Close the template literal
+  </Button>
+  <Button size="small" kind="ghost" on:click={reset}>Reset</Button>
+</div>

--- a/www/components/HighlightStream/Stepper.svelte
+++ b/www/components/HighlightStream/Stepper.svelte
@@ -1,0 +1,89 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import Highlight, { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+
+  // Boundaries deliberately split mid-keyword ("con" | "st") and
+  // mid-template-literal ("`Hel" | "lo, world!").
+  const CHUNKS = ["con", "st gr", "eet = () => `Hel", "lo, world!", "`;"];
+
+  let code = "";
+  let sent = 0;
+  let done = false;
+
+  function next() {
+    if (sent >= CHUNKS.length) return;
+    code += CHUNKS[sent];
+    sent += 1;
+    if (sent === CHUNKS.length) done = true;
+  }
+
+  function reset() {
+    code = "";
+    sent = 0;
+    done = false;
+  }
+</script>
+
+<p class="label-01 mb-3">
+  Click through each chunk to watch it arrive mid-keyword and
+  mid-template-literal. Once every chunk lands, the output below is compared
+  byte-for-byte against a plain <code class="code">Highlight</code> of the same
+  finished code.
+</p>
+
+<div class="chunks mb-5">
+  {#each CHUNKS as chunk, i}
+    <code class="chunk" class:sent={i < sent}>{JSON.stringify(chunk)}</code>
+  {/each}
+</div>
+
+<HighlightStream
+  language={javascript}
+  {code}
+  {done}
+  class={THEME_MODULE_NAME}
+/>
+
+<div style="display: flex; align-items: center; gap: 1rem; margin-top: 0.75rem">
+  <Button
+    size="small"
+    kind="tertiary"
+    disabled={sent >= CHUNKS.length}
+    on:click={next}
+  >
+    Send next chunk ({sent}/{CHUNKS.length})
+  </Button>
+  <Button size="small" kind="ghost" on:click={reset}>Reset</Button>
+</div>
+
+{#if done}
+  <p class="label-01 mb-3" style="margin-top: 1.5rem">
+    Reference <code class="code">Highlight</code> of the same code, for
+    comparison:
+  </p>
+  <Highlight language={javascript} {code} class={THEME_MODULE_NAME} />
+{/if}
+
+<style>
+  .chunks {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem;
+  }
+
+  .chunk {
+    padding: 0.125rem 0.5rem;
+    border-radius: 4px;
+    border: 1px solid var(--cds-ui-04, #8d8d8d);
+    opacity: 0.5;
+    font-size: 0.75rem;
+  }
+
+  .chunk.sent {
+    opacity: 1;
+    border-color: #42be65;
+    color: #42be65;
+  }
+</style>

--- a/www/components/HighlightStream/stream-demo.js
+++ b/www/components/HighlightStream/stream-demo.js
@@ -1,0 +1,36 @@
+/**
+ * Feed `text` into `onChunk` in randomly-sized pieces on an interval, so demos
+ * can show `HighlightStream` without a real streaming backend (fetch,
+ * WebSocket, SSE, ...). Returns a stop function; call it on replay/unmount to
+ * clear the interval.
+ * @param {string} text
+ * @param {{
+ *   onChunk: (chunk: string) => void;
+ *   onDone?: () => void;
+ *   intervalMs?: number;
+ *   minChunk?: number;
+ *   maxChunk?: number;
+ * }} options
+ * @returns {() => void}
+ */
+export function simulateStream(
+  text,
+  { onChunk, onDone, intervalMs = 35, minChunk = 1, maxChunk = 4 },
+) {
+  let i = 0;
+
+  const id = setInterval(() => {
+    if (i >= text.length) {
+      clearInterval(id);
+      onDone?.();
+      return;
+    }
+
+    const size =
+      minChunk + Math.floor(Math.random() * (maxChunk - minChunk + 1));
+    onChunk(text.slice(i, i + size));
+    i += size;
+  }, intervalMs);
+
+  return () => clearInterval(id);
+}

--- a/www/components/HighlightStreamPreview.svelte
+++ b/www/components/HighlightStreamPreview.svelte
@@ -1,0 +1,39 @@
+<script>
+  import AutoScroll from "@components/HighlightStream/AutoScroll.svelte";
+  import Basic from "@components/HighlightStream/Basic.svelte";
+  import Caret from "@components/HighlightStream/Caret.svelte";
+  import Controls from "@components/HighlightStream/Controls.svelte";
+  import Retokenize from "@components/HighlightStream/Retokenize.svelte";
+  import Stepper from "@components/HighlightStream/Stepper.svelte";
+  import { Column, Row } from "carbon-components-svelte";
+</script>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Basic</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Basic /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Chunk-by-chunk stepper</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Stepper /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Re-tokenizing a multi-line construct</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Retokenize /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Speed &amp; auto-scroll controls</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Controls /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Auto-scroll in a fixed-height window</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <AutoScroll /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Custom caret</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Caret /> </Column>
+</Row>

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -71,6 +71,7 @@
     "/preview-ansi": "AnsiOutput preview",
     "/preview-dual-theme": "Dual light/dark HighlightStyle preview",
     "/preview-editable": "Editable highlight preview",
+    "/preview-highlight-stream": "HighlightStream preview",
     "/preview-jq": "jq language preview",
     "/preview-kql": "KQL language preview",
     "/preview-logql": "LogQL language preview",

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -11,6 +11,8 @@
   import FileTabs from "@components/FileTabs.svelte";
   import EditableBasic from "@components/HighlightEditable/Basic.svelte";
   import EditableCommands from "@components/HighlightEditable/Commands.svelte";
+  import HighlightStreamBasic from "@components/HighlightStream/Basic.svelte";
+  import HighlightStreamControls from "@components/HighlightStream/Controls.svelte";
   import Basic from "@components/LineNumbers/Basic.svelte";
   import ContainerStyle from "@components/LineNumbers/ContainerStyle.svelte";
   import FocusLines from "@components/LineNumbers/FocusLines.svelte";
@@ -516,6 +518,56 @@
     />
   </Column>
   <Column xlg={10} lg={10} md={12}> <TypewriterControls /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Streaming</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Rendering LLM chat output is the dominant new syntax-highlighting use
+      case: code arrives in arbitrary-sized chunks, mid-token and mid-line, and
+      you don't know the full content up front.
+      <code class="code">HighlightStream</code>
+      is built for that—unlike <code class="code">Typewriter</code>, which
+      animates a complete, already-highlighted string, it accepts a growing
+      <code class="code">code</code>
+      buffer and re-highlights it as chunks arrive.
+    </p>
+    <p class="mb-5">
+      Append to <code class="code">code</code> as chunks come in; set
+      <code class="code">done</code>
+      once the stream ends. A blinking caret marks the end of output while
+      <code class="code">!done</code>; finishing hides it and performs one final
+      full highlight, so the output matches what
+      <code class="code">Highlight</code>
+      would render for the same code.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <HighlightStreamBasic /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Already-rendered lines are diffed and left untouched in the DOM—only lines
+      whose content actually changed are repainted, so a fast-streaming response
+      only touches its changed suffix. An open multi-line construct—an
+      unterminated template literal or block comment—re-tokenizes the lines it
+      spans once the closing delimiter arrives, with no special-casing needed.
+    </p>
+    <p class="mb-5">
+      Set <code class="code">autoScroll</code> to keep the container pinned to
+      the bottom as output grows. It stops as soon as you scroll up, and resumes
+      once you scroll back down. Customize the caret with the same
+      <code class="code">--caret-*</code>
+      variables as <code class="code">Typewriter</code>.
+    </p>
+    <InlineNotification
+      lowContrast
+      hideCloseButton
+      kind="info"
+      title="Performance"
+      subtitle="O(buffer) per highlighted frame, DOM updates proportional to changed lines—fine for chat-sized output up to a few thousand lines, not a virtualized log viewer."
+    />
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <HighlightStreamControls /> </Column>
 </Row>
 
 <Row class="mb-9">

--- a/www/pages/preview-highlight-stream.astro
+++ b/www/pages/preview-highlight-stream.astro
@@ -1,0 +1,8 @@
+---
+import HighlightStreamPreview from "@components/HighlightStreamPreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="HighlightStream preview">
+  <HighlightStreamPreview client:idle />
+</Layout>


### PR DESCRIPTION
## Summary
- Adds `HighlightStream`, a new component for rendering growing, chunked code buffers (the dominant LLM/chat-output use case) -- it re-highlights the full buffer per animation frame but diffs per-line output through the existing span-safe line splitter, so unchanged lines are never re-created in the DOM.
- Handles arbitrary chunk boundaries (mid-token, mid-line), re-tokenizes earlier lines when a multi-line construct (template literal, block comment) closes, supports `autoScroll` (stick-to-bottom-unless-scrolled), and performs one final full highlight on `done` so output matches `Highlight` exactly.
- Wires the component into `src/index.js`/`src/index.d.ts` (package `exports` map already picks it up via the existing `./*.svelte` glob).
- Adds a "Streaming" section to the docs homepage plus an unlisted `/preview-highlight-stream` kitchen-sink route with six live examples (basic, chunk stepper, multi-line re-tokenization, speed/auto-scroll controls, auto-scroll in a scrollable window, custom caret). All streaming in the docs site is simulated client-side since there's no real backend.

## Test plan
- [x] `bun run test:types`
- [x] `bun run lint`
- [x] `bun run test:unit`
- [x] `bun run test:e2e` (158 passing, including 4 new `HighlightStream` e2e tests across chromium/firefox/webkit)
- [x] `bun run build` (Astro site builds cleanly, including the new preview route)
- [x] Manually drove both the docs page and the kitchen-sink preview in a headless browser -- streaming, chunk-stepper, retokenization, and scroll-detach all behave correctly with zero console errors