### PR TITLE
perf(components): repaint only changed lines in HighlightEditable

### DIFF
--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -13,6 +13,7 @@
 
   import hljs from "highlight.js/lib/core";
   import { createEventDispatcher, onMount } from "svelte";
+  import { splitLines } from "./split-lines.js";
 
   const dispatch = createEventDispatcher();
   const TRAILING_NEWLINE = /\n$/;
@@ -24,6 +25,14 @@
   let composing = false;
   let mounted = false;
   let restoringSelection = false;
+
+  // One <span> per line, painted incrementally (see `renderLines`).
+  /** @type {HTMLSpanElement[]} */
+  let lineEls = [];
+  /** @type {number[]} Rendered (plain-text) length of each line element. */
+  let lineLengths = [];
+  /** @type {string[]} Line HTML currently reflected in `lineEls`. */
+  let renderedLines = [];
 
   // Tracks `code` so parent updates vs local edits can be distinguished.
   let internalCode = code;
@@ -56,12 +65,8 @@
     return sel ? sel.end : null;
   }
 
-  function nodeAtOffset(offset) {
-    const walker = document.createTreeWalker(
-      editor,
-      NodeFilter.SHOW_TEXT,
-      null,
-    );
+  function nodeAtOffset(offset, root = editor) {
+    const walker = document.createTreeWalker(root, NodeFilter.SHOW_TEXT, null);
     let count = 0;
     for (let node = walker.nextNode(); node; node = walker.nextNode()) {
       const next = count + node.textContent.length;
@@ -84,12 +89,12 @@
     else range[side === "Start" ? "setStart" : "setEnd"](node, offset);
   }
 
-  function setSelection(start, end) {
-    const from = nodeAtOffset(start);
+  function setSelection(start, end, root = editor) {
+    const from = nodeAtOffset(start, root);
     if (!from) return;
     const range = document.createRange();
     setRangeBoundary(range, "Start", from.node, from.offset);
-    const to = end != null && end !== start ? nodeAtOffset(end) : null;
+    const to = end != null && end !== start ? nodeAtOffset(end, root) : null;
     if (to) setRangeBoundary(range, "End", to.node, to.offset);
     else range.collapse(true);
     const selection = window.getSelection();
@@ -97,16 +102,93 @@
     selection.addRange(range);
   }
 
+  // Character offset (in the same space as getSelectionRange/setSelection)
+  // where line `index` starts.
+  function lineStartOffset(index) {
+    let start = index; // one "\n" separator per preceding line
+    for (let i = 0; i < index; i++) start += lineLengths[i];
+    return start;
+  }
+
+  // Patches `editor` to match `lines` (one <span> per line, joined by literal
+  // "\n" text nodes so caret offset math stays identical to a flat paint).
+  // Only lines whose HTML actually changed touch the DOM. Returns the index
+  // of the single changed line when nothing else shifted (used to scope
+  // caret restoration), or null.
+  function renderLines(lines) {
+    // Some browsers can place a native selection boundary just outside a
+    // line's <span> (e.g. Firefox collapsing a select-all there); typing at
+    // that point inserts a stray sibling text node our diffing never touches.
+    // Detect the drift by child count and self-heal with a full rebuild.
+    const expectedChildren = lineEls.length === 0 ? 0 : lineEls.length * 2 - 1;
+    if (editor.childNodes.length !== expectedChildren) {
+      editor.textContent = "";
+      lineEls = [];
+      lineLengths = [];
+      renderedLines = [];
+    }
+
+    const prevLen = lineEls.length;
+    const newLen = lines.length;
+    const commonLen = Math.min(prevLen, newLen);
+
+    let changedIndex = null;
+    let changedCount = 0;
+    for (let i = 0; i < commonLen; i++) {
+      if (renderedLines[i] === lines[i]) continue;
+      lineEls[i].innerHTML = lines[i];
+      lineLengths[i] = lineEls[i].textContent.length;
+      changedIndex = i;
+      changedCount++;
+    }
+
+    for (let i = prevLen; i < newLen; i++) {
+      if (lineEls.length > 0) editor.appendChild(document.createTextNode("\n"));
+      const span = document.createElement("span");
+      span.innerHTML = lines[i];
+      editor.appendChild(span);
+      lineEls.push(span);
+      lineLengths.push(span.textContent.length);
+    }
+
+    while (lineEls.length > newLen) {
+      editor.removeChild(lineEls.pop());
+      lineLengths.pop();
+      // Drop the separator that used to precede the removed line.
+      if (lineEls.length > 0) editor.removeChild(editor.lastChild);
+    }
+
+    renderedLines = lines;
+    return prevLen === newLen && changedCount === 1 ? changedIndex : null;
+  }
+
   function paint() {
     const html = hljs.highlight(code, { language: language.name }).value;
     // Trailing empty line needs a phantom `\n` for caret placement.
-    editor.innerHTML = code === "" || code.endsWith("\n") ? `${html}\n` : html;
+    const paintHtml =
+      code === "" || code.endsWith("\n") ? `${html}\n` : html;
+    return renderLines(splitLines(paintHtml));
   }
 
   function renderAt(start, end) {
-    paint();
+    const changedIndex = paint();
     if (start == null) return;
     restoringSelection = true;
+    if (changedIndex != null) {
+      const lineStart = lineStartOffset(changedIndex);
+      const lineEnd = lineStart + lineLengths[changedIndex];
+      const inLine = (offset) =>
+        offset == null || (offset >= lineStart && offset <= lineEnd);
+      if (start >= lineStart && start <= lineEnd && inLine(end)) {
+        setSelection(
+          start - lineStart,
+          end == null ? end : end - lineStart,
+          lineEls[changedIndex],
+        );
+        restoringSelection = false;
+        return;
+      }
+    }
     setSelection(start, end);
     restoringSelection = false;
   }

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -166,8 +166,7 @@
   function paint() {
     const html = hljs.highlight(code, { language: language.name }).value;
     // Trailing empty line needs a phantom `\n` for caret placement.
-    const paintHtml =
-      code === "" || code.endsWith("\n") ? `${html}\n` : html;
+    const paintHtml = code === "" || code.endsWith("\n") ? `${html}\n` : html;
     return renderLines(splitLines(paintHtml));
   }
 

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -14,6 +14,7 @@
   import hljs from "highlight.js/lib/core";
   import { createEventDispatcher, onMount } from "svelte";
   import { splitLines } from "./split-lines.js";
+  import { diffText } from "./text-diff.js";
 
   const dispatch = createEventDispatcher();
   const TRAILING_NEWLINE = /\n$/;
@@ -205,17 +206,28 @@
     const sel = getSelectionRange();
     if (!sel) return;
     const top = undoStack[undoStack.length - 1];
-    if (top.code !== code) return;
+    if (top.resultLength !== code.length) return;
     undoStack[undoStack.length - 1] = {
-      code: top.code,
-      start: sel.start,
-      end: sel.end,
+      ...top,
+      selectionAfter: { start: sel.start, end: sel.end },
     };
   }
 
-  /** @type {Array<{ code: string; start: number; end: number }>} */
+  /**
+   * @typedef {{ start: number; end: number }} Selection
+   * @typedef {{
+   *   start: number;
+   *   removed: string;
+   *   inserted: string;
+   *   resultLength: number;
+   *   selectionBefore: Selection;
+   *   selectionAfter: Selection;
+   * }} HistoryEntry
+   */
+
+  /** @type {HistoryEntry[]} */
   let undoStack = [];
-  /** @type {Array<{ code: string; start: number; end: number }>} */
+  /** @type {HistoryEntry[]} */
   let redoStack = [];
   let lastRecord = 0;
 
@@ -223,7 +235,7 @@
     const future = redoStack.slice().reverse();
     dispatch("history", {
       entries: [...undoStack, ...future].map((snap) => ({
-        size: snap.code.length,
+        size: snap.resultLength,
       })),
       index: undoStack.length - 1,
       canUndo: canUndo(),
@@ -231,14 +243,46 @@
     });
   }
 
+  /** @returns {HistoryEntry} */
+  function makeEntry(before, after, selectionBefore, selectionAfter) {
+    const { start, removed, inserted } = diffText(before, after);
+    return {
+      start,
+      removed,
+      inserted,
+      resultLength: after.length,
+      selectionBefore,
+      selectionAfter,
+    };
+  }
+
+  // The code an entry transformed *from*, given the code it produced.
+  function beforeCodeOf(entry, resultCode) {
+    return (
+      resultCode.slice(0, entry.start) +
+      entry.removed +
+      resultCode.slice(entry.start + entry.inserted.length)
+    );
+  }
+
   // Coalesce typing within 250ms; Enter/Tab/paste pass coalesce=false.
-  function pushHistory(snap, coalesce) {
+  function pushHistory(previousCode, newCode, selectionAfter, coalesce) {
     redoStack = [];
     const now = Date.now();
+    const top = undoStack[undoStack.length - 1];
+
     if (coalesce && undoStack.length > 1 && now - lastRecord < 250) {
-      undoStack[undoStack.length - 1] = snap;
+      const burstStart = beforeCodeOf(top, previousCode);
+      undoStack[undoStack.length - 1] = makeEntry(
+        burstStart,
+        newCode,
+        top.selectionBefore,
+        selectionAfter,
+      );
     } else {
-      undoStack.push(snap);
+      undoStack.push(
+        makeEntry(previousCode, newCode, top.selectionAfter, selectionAfter),
+      );
       const limit = Math.max(1, historyLimit);
       if (undoStack.length > limit) {
         undoStack.splice(0, undoStack.length - limit);
@@ -248,25 +292,37 @@
     emitHistory();
   }
 
-  function applySnapshot(snap) {
-    code = snap.code;
-    internalCode = snap.code;
+  function applyHistoryMove(newCode, selection) {
+    code = newCode;
+    internalCode = newCode;
     dispatch("change", { code });
     emitHistory();
-    renderAt(snap.start, snap.end);
+    renderAt(selection.start, selection.end);
   }
 
   function commit(value, start, end, coalesce) {
+    const previousCode = code;
     code = value;
     internalCode = value;
     dispatch("change", { code });
-    pushHistory({ code: value, start, end }, coalesce);
+    pushHistory(
+      previousCode,
+      value,
+      { start, end: end == null ? start : end },
+      coalesce,
+    );
     renderAt(start, end);
   }
 
   function syncExternal() {
+    const previousCode = internalCode;
     internalCode = code;
-    pushHistory({ code, start: code.length, end: code.length }, false);
+    pushHistory(
+      previousCode,
+      code,
+      { start: code.length, end: code.length },
+      false,
+    );
     paint();
   }
 
@@ -327,15 +383,20 @@
 
   export function undo() {
     if (undoStack.length <= 1) return;
-    redoStack.push(undoStack.pop());
-    applySnapshot(undoStack[undoStack.length - 1]);
+    const entry = undoStack.pop();
+    redoStack.push(entry);
+    applyHistoryMove(beforeCodeOf(entry, code), entry.selectionBefore);
   }
 
   export function redo() {
     if (redoStack.length === 0) return;
-    const snap = redoStack.pop();
-    undoStack.push(snap);
-    applySnapshot(snap);
+    const entry = redoStack.pop();
+    const nextCode =
+      code.slice(0, entry.start) +
+      entry.inserted +
+      code.slice(entry.start + entry.removed.length);
+    undoStack.push(entry);
+    applyHistoryMove(nextCode, entry.selectionAfter);
   }
 
   export function focus() {
@@ -364,10 +425,16 @@
 
   export function setCode(value) {
     if (value === code) return;
+    const previousCode = code;
     internalCode = value;
     code = value;
     dispatch("change", { code });
-    pushHistory({ code: value, start: value.length, end: value.length }, false);
+    pushHistory(
+      previousCode,
+      value,
+      { start: value.length, end: value.length },
+      false,
+    );
     paint();
   }
 
@@ -415,12 +482,13 @@
       runNativeHistory(redo);
       return;
     }
+    const previousCode = code;
     // innerText keeps contenteditable line breaks; textContent doesn't.
     code = editor.innerText.replace(TRAILING_NEWLINE, "");
     internalCode = code;
     const caret = getCaretOffset() ?? code.length;
     dispatch("change", { code });
-    pushHistory({ code, start: caret, end: caret }, true);
+    pushHistory(previousCode, code, { start: caret, end: caret }, true);
     renderAt(caret);
   }
 
@@ -493,7 +561,16 @@
 
   onMount(() => {
     paint();
-    undoStack = [{ code, start: 0, end: 0 }];
+    undoStack = [
+      {
+        start: 0,
+        removed: "",
+        inserted: code,
+        resultLength: code.length,
+        selectionBefore: { start: 0, end: 0 },
+        selectionAfter: { start: 0, end: 0 },
+      },
+    ];
     mounted = true;
     emitHistory();
 

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -200,6 +200,7 @@
   }
 
   function syncCaretToHistory() {
+    if (!editor.contains(document.activeElement)) return;
     if (restoringSelection || composing || undoStack.length === 0) return;
     const sel = getSelectionRange();
     if (!sel) return;
@@ -469,6 +470,18 @@
     dispatch("blur", { code: getCode() });
   }
 
+  // Selection changes can only affect this editor while it holds focus, so
+  // only pay for the document-wide listener (range clone + full-content
+  // toString()) during that window instead of for the component's whole
+  // lifetime.
+  function onFocusIn() {
+    document.addEventListener("selectionchange", syncCaretToHistory);
+  }
+
+  function onFocusOut() {
+    document.removeEventListener("selectionchange", syncCaretToHistory);
+  }
+
   function onCompositionStart() {
     composing = true;
   }
@@ -490,7 +503,8 @@
     editor.addEventListener("paste", onPaste);
     editor.addEventListener("mouseup", syncCaretToHistory);
     editor.addEventListener("keyup", syncCaretToHistory);
-    document.addEventListener("selectionchange", syncCaretToHistory);
+    editor.addEventListener("focusin", onFocusIn);
+    editor.addEventListener("focusout", onFocusOut);
     editor.addEventListener("blur", onBlur);
     editor.addEventListener("compositionstart", onCompositionStart);
     editor.addEventListener("compositionend", onCompositionEnd);
@@ -502,6 +516,8 @@
       editor.removeEventListener("paste", onPaste);
       editor.removeEventListener("mouseup", syncCaretToHistory);
       editor.removeEventListener("keyup", syncCaretToHistory);
+      editor.removeEventListener("focusin", onFocusIn);
+      editor.removeEventListener("focusout", onFocusOut);
       document.removeEventListener("selectionchange", syncCaretToHistory);
       editor.removeEventListener("blur", onBlur);
       editor.removeEventListener("compositionstart", onCompositionStart);

--- a/src/text-diff.d.ts
+++ b/src/text-diff.d.ts
@@ -1,0 +1,8 @@
+/**
+ * Diffs two strings down to a common-prefix/suffix trim, on Unicode code
+ * point boundaries.
+ */
+export declare function diffText(
+  before: string,
+  after: string,
+): { start: number; removed: string; inserted: string };

--- a/src/text-diff.js
+++ b/src/text-diff.js
@@ -1,0 +1,46 @@
+const HIGH_SURROGATE_MIN = 0xd800;
+const HIGH_SURROGATE_MAX = 0xdbff;
+const LOW_SURROGATE_MIN = 0xdc00;
+const LOW_SURROGATE_MAX = 0xdfff;
+
+/** @param {number} code */
+function isHighSurrogate(code) {
+  return code >= HIGH_SURROGATE_MIN && code <= HIGH_SURROGATE_MAX;
+}
+
+/** @param {number} code */
+function isLowSurrogate(code) {
+  return code >= LOW_SURROGATE_MIN && code <= LOW_SURROGATE_MAX;
+}
+
+/**
+ * Diffs two strings down to a common-prefix/suffix trim. Trims on Unicode
+ * code points (never splitting a surrogate pair between the shared prefix
+ * or suffix and the changed middle).
+ * @param {string} before
+ * @param {string} after
+ * @returns {{ start: number; removed: string; inserted: string }}
+ */
+export function diffText(before, after) {
+  const minLength = Math.min(before.length, after.length);
+
+  let prefix = 0;
+  while (prefix < minLength && before[prefix] === after[prefix]) prefix++;
+  if (isHighSurrogate(before.charCodeAt(prefix - 1))) prefix--;
+
+  let suffix = 0;
+  const maxSuffix = minLength - prefix;
+  while (
+    suffix < maxSuffix &&
+    before[before.length - 1 - suffix] === after[after.length - 1 - suffix]
+  ) {
+    suffix++;
+  }
+  if (isLowSurrogate(before.charCodeAt(before.length - suffix))) suffix--;
+
+  return {
+    start: prefix,
+    removed: before.slice(prefix, before.length - suffix),
+    inserted: after.slice(prefix, after.length - suffix),
+  };
+}

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -790,6 +790,62 @@ test("HighlightEditable - focus outline uses the --outline-color variable", asyn
   await expect(editor).toHaveCSS("outline-color", "rgb(255, 0, 0)");
 });
 
+test("HighlightEditable - only repaints the edited line, leaving others' DOM connected", async ({
+  mount,
+  page,
+}) => {
+  const lines = Array.from({ length: 20 }, (_, i) => `line ${i}`).join("\n");
+  await mount(HighlightEditable, { props: { initialCode: lines } });
+
+  const editor = page.locator("[contenteditable='true']");
+  const firstLine = editor.locator("> span").first();
+  const handle = await firstLine.elementHandle();
+
+  // Click directly into the last line (rather than select-all + collapse)
+  // so the caret lands inside that line's element.
+  await editor.locator("> span").last().click();
+  await page.keyboard.type("!");
+
+  const code = await page.getByTestId("code").getAttribute("data-value");
+  expect(code).toHaveLength(lines.length + 1);
+  // Line 0's element survives the edit: only the last line's DOM was
+  // touched, proving the repaint didn't rebuild the whole document.
+  expect(await handle?.evaluate((el) => el.isConnected)).toBe(true);
+});
+
+test("HighlightEditable - handles bursts of typing on a large document within budget", async ({
+  mount,
+  page,
+}) => {
+  test.slow();
+  const lines = Array.from({ length: 2000 }, (_, i) => `line ${i}`).join("\n");
+  await mount(HighlightEditable, { props: { initialCode: lines } });
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowRight"); // collapse caret to the end
+
+  // Dispatched in-page (not via Playwright's per-key round trip) so the
+  // measurement reflects our own repaint/caret-restore cost, not IPC
+  // overhead. This is a coarse smoke check, not a tight perf budget: it
+  // catches an O(document) regression (e.g. a full innerHTML rebuild) for a
+  // 2,000-line document without being flaky on ordinary keystroke cost.
+  const elapsed = await editor.evaluate(() => {
+    const start = performance.now();
+    for (let i = 0; i < 50; i++) {
+      document.execCommand("insertText", false, "x");
+    }
+    return performance.now() - start;
+  });
+
+  expect(elapsed).toBeLessThan(5000);
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    `${lines}${"x".repeat(50)}`,
+  );
+});
+
 test("Typewriter - animates then settles to the full highlighted content", async ({
   mount,
   page,

--- a/tests/highlight-editable-ssr.test.ts
+++ b/tests/highlight-editable-ssr.test.ts
@@ -17,9 +17,11 @@ async function compileForServer() {
     filename: "HighlightEditable.svelte",
   });
 
+  // Written alongside the component (not in tests/) so its relative
+  // imports (e.g. "./split-lines.js") resolve.
   const outPath = path.join(
     import.meta.dir,
-    ".tmp-highlight-editable.server.js",
+    "../src/.tmp-highlight-editable.server.js",
   );
   fs.writeFileSync(outPath, js.code);
   try {

--- a/tests/text-diff.test.ts
+++ b/tests/text-diff.test.ts
@@ -1,0 +1,73 @@
+import { diffText } from "../src/text-diff.js";
+
+describe("diffText", () => {
+  it("returns an empty diff for identical strings", () => {
+    expect(diffText("abc", "abc")).toEqual({
+      start: 3,
+      removed: "",
+      inserted: "",
+    });
+  });
+
+  it("trims a pure insert to just the inserted text", () => {
+    expect(diffText("ab", "aXb")).toEqual({
+      start: 1,
+      removed: "",
+      inserted: "X",
+    });
+  });
+
+  it("trims a pure delete to just the removed text", () => {
+    expect(diffText("aXb", "ab")).toEqual({
+      start: 1,
+      removed: "X",
+      inserted: "",
+    });
+  });
+
+  it("treats a full replacement as one span with no shared prefix/suffix", () => {
+    expect(diffText("abc", "xyz")).toEqual({
+      start: 0,
+      removed: "abc",
+      inserted: "xyz",
+    });
+  });
+
+  it("does not split a surrogate pair shared between prefix and change", () => {
+    // "\u{1F600}" (😀) and "\u{1F605}" (😅) share a leading high surrogate.
+    const before = "a\u{1F600}";
+    const after = "a\u{1F605}";
+    const diff = diffText(before, after);
+
+    expect(diff).toEqual({ start: 1, removed: "\u{1F600}", inserted: "\u{1F605}" });
+    expect(before.slice(diff.start, diff.start + diff.removed.length)).toBe(
+      "\u{1F600}",
+    );
+  });
+
+  it("does not split a surrogate pair shared between change and suffix", () => {
+    // Two different emoji that happen to share the same low surrogate unit.
+    const before = "A😀";
+    const after = "B𐈀";
+    const diff = diffText(before, after);
+
+    expect(diff).toEqual({
+      start: 0,
+      removed: "A😀",
+      inserted: "B𐈀",
+    });
+  });
+
+  it("reconstructs both strings via the returned splice", () => {
+    const before = "const a = 1;";
+    const after = "const abc = 12;";
+    const { start, removed, inserted } = diffText(before, after);
+
+    expect(before.slice(0, start) + removed + before.slice(start + removed.length)).toBe(
+      before,
+    );
+    expect(
+      before.slice(0, start) + inserted + before.slice(start + removed.length),
+    ).toBe(after);
+  });
+});

--- a/tests/text-diff.test.ts
+++ b/tests/text-diff.test.ts
@@ -39,7 +39,11 @@ describe("diffText", () => {
     const after = "a\u{1F605}";
     const diff = diffText(before, after);
 
-    expect(diff).toEqual({ start: 1, removed: "\u{1F600}", inserted: "\u{1F605}" });
+    expect(diff).toEqual({
+      start: 1,
+      removed: "\u{1F600}",
+      inserted: "\u{1F605}",
+    });
     expect(before.slice(diff.start, diff.start + diff.removed.length)).toBe(
       "\u{1F600}",
     );
@@ -63,9 +67,9 @@ describe("diffText", () => {
     const after = "const abc = 12;";
     const { start, removed, inserted } = diffText(before, after);
 
-    expect(before.slice(0, start) + removed + before.slice(start + removed.length)).toBe(
-      before,
-    );
+    expect(
+      before.slice(0, start) + removed + before.slice(start + removed.length),
+    ).toBe(before);
     expect(
       before.slice(0, start) + inserted + before.slice(start + removed.length),
     ).toBe(after);


### PR DESCRIPTION
HighlightEditable re-highlighted and rebuilt its entire DOM on every keystroke, ran a document-level selectionchange listener for its whole lifetime, and kept full-text copies in its undo stack. This addresses all three.

Painting now diffs span-safe per-line HTML fragments (via splitLines) against the previous render and patches only the lines whose HTML changed, so a typical keystroke touches one line element instead of rebuilding the whole document. Caret restoration also short-circuits to a scoped walk within the single changed line when possible, instead of re-walking the full document tree. Along the way this surfaced a real Firefox quirk: a native select-all collapse can land the caret just outside a line's wrapping span, and typing there used to insert a stray sibling text node the diff never reconciled, silently duplicating characters. Added a cheap self-heal (child-count check that triggers a full rebuild) to catch that drift.

The selectionchange listener is now attached on focusin and removed on focusout, since selection changes elsewhere on the page can't affect this editor anyway.

The undo/redo stack now stores prefix/suffix-trimmed splice diffs (start/removed/inserted) instead of full document copies, bounding memory by edit size rather than document size times historyLimit. Undo and redo reconstruct text via reverse/forward splice against the live code value. The diffing helper trims on Unicode code points so surrogate pairs are never split. The on:history entries shape is unchanged externally (still {size}), just backed by the entry's result length instead of a stored full copy.

Risk is concentrated in the caret/selection math, since contenteditable behavior is notoriously browser-specific; the existing Playwright CT suite (caret preservation, undo/redo, IME, paste, tab handling) passed across Chromium, Firefox, and WebKit throughout, plus two new tests covering DOM stability and a large-document perf smoke case. Watch for any regressions in caret placement on edge cases not covered by the suite, particularly around composition/IME and native undo across other browsers.