### PR TITLE
feat(components): experimental CSS Custom Highlight engine for editable

### DIFF
--- a/README.md
+++ b/README.md
@@ -665,7 +665,7 @@ Use `bind:this` to call methods on the instance.
 <button on:click={() => editor.clear()}>Clear</button>
 ```
 
-Available methods: `undo`, `redo`, `focus`, `selectAll`, `insert`, `indent`, `outdent`, `setCode`, `clear`, `getCode`, `canUndo`, and `canRedo`.
+Available methods: `undo`, `redo`, `focus`, `selectAll`, `insert`, `indent`, `outdent`, `setCode`, `clear`, `getCode`, `canUndo`, `canRedo`, and `resolvedEngine`.
 
 ### Custom Styles
 
@@ -678,6 +678,30 @@ Customize the focus outline with the `--outline-color`, `--outline-width`, and `
   --outline-color="#42be65"
   --outline-width="2px"
 />
+```
+
+### Experimental: CSS Custom Highlight engine
+
+`engine="css-highlights"` paints tokens with the [CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API) (`CSS.highlights`, `::highlight()`) instead of wrapping them in `<span>`s. The editable `<code>` stays plain text (one `<span>` per line, reused from the default engine's line structure, but with no per-token spans inside), so a repaint never replaces the DOM the caret is sitting in.
+
+Requires Chrome 105+, Safari 17.2+, or Firefox 140+. Where `CSS.highlights` is unavailable, `HighlightEditable` falls back to `engine="dom"` silently; check what actually ran with `editor.resolvedEngine()`.
+
+Pass `theme` (the same theme string you'd give `HighlightStyle`) to generate `::highlight()` rules from it. Only `color`/`background-color` convert — `::highlight()` doesn't support `font-style`/`font-weight`/`text-decoration` across browsers, so bold/italic scopes render in plain color.
+
+`theme` only covers token colors — you still need `HighlightStyle` (or an injected stylesheet) for the base `.hljs` layout rules (padding, overflow, background), exactly as with the default engine.
+
+```svelte
+<script>
+  import { HighlightEditable, HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  let code = "const add = (a: number, b: number) => a + b";
+</script>
+
+<HighlightStyle theme={github}>
+  <HighlightEditable language={typescript} bind:code engine="css-highlights" theme={github} />
+</HighlightStyle>
 ```
 
 ## Language Targeting

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -619,19 +619,15 @@
       return;
     }
     const previousCode = code;
-    // innerText keeps contenteditable line breaks that textContent drops
-    // (e.g. a browser-inserted <br> on Enter) -- but Firefox can return a
-    // stale innerText immediately after editing a text node that was last
-    // written via `textContent` (see setText in paintCssHighlights), losing
-    // the just-typed content. The css-highlights engine builds every line
-    // from a single text node with literal "\n" separators and always
-    // intercepts Enter/paste itself, so textContent is exact there and
-    // sidesteps the staleness.
-    code = (
-      resolvedEngineValue === "css-highlights"
-        ? editor.textContent
-        : editor.innerText
-    ).replace(TRAILING_NEWLINE, "");
+    // textContent (not innerText): innerText forces a synchronous layout
+    // and Firefox can return a stale value immediately after editing a text
+    // node last written via `textContent` (see setText in
+    // paintCssHighlights), losing the just-typed content. The `<pre>`
+    // wrapper's `white-space: pre` means every native text-insertion path
+    // (typing, execCommand insertText, paste/drop as plain text) already
+    // uses literal "\n" characters rather than <br> elements, so
+    // textContent loses nothing textContent would have kept anyway.
+    code = editor.textContent.replace(TRAILING_NEWLINE, "");
     internalCode = code;
     const caret = getCaretOffset() ?? code.length;
     dispatch("change", { code });

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -1,3 +1,10 @@
+<script context="module">
+  let instanceCount = 0;
+  function nextInstanceId() {
+    return ++instanceCount;
+  }
+</script>
+
 <script>
   /** @type {import("./languages").LanguageType<string>} */
   export let language;
@@ -11,13 +18,35 @@
   /** @type {number} Maximum number of undo snapshots retained. */
   export let historyLimit = 200;
 
+  /**
+   * Rendering engine. `"css-highlights"` (experimental) paints tokens via
+   * the CSS Custom Highlight API over plain-text line nodes instead of
+   * wrapping them in `<span>`s, so a repaint never replaces DOM the caret
+   * could be sitting in. Falls back to `"dom"` silently where
+   * `CSS.highlights` is unavailable; check the resolved engine with the
+   * exported `resolvedEngine()` method.
+   * @type {"dom" | "css-highlights"}
+   */
+  export let engine = "dom";
+
+  /**
+   * Theme CSS from `svelte-highlight/styles/<theme>`, used only in
+   * `"css-highlights"` mode to generate `::highlight()` rules. Colors only
+   * (`color`/`background-color`); other declarations are dropped.
+   * @type {string | undefined}
+   */
+  export let theme = undefined;
+
   import hljs from "highlight.js/lib/core";
   import { createEventDispatcher, onMount } from "svelte";
+  import { highlightRules } from "./highlight-theme.js";
   import { splitLines } from "./split-lines.js";
   import { diffText } from "./text-diff.js";
+  import { tokenize } from "./token-ranges.js";
 
   const dispatch = createEventDispatcher();
   const TRAILING_NEWLINE = /\n$/;
+  const instanceId = nextInstanceId();
 
   /** @type {HTMLElement} */
   let editor;
@@ -38,16 +67,37 @@
   // Tracks `code` so parent updates vs local edits can be distinguished.
   let internalCode = code;
 
+  $: resolvedEngineValue =
+    engine === "css-highlights" &&
+    typeof CSS !== "undefined" &&
+    typeof CSS.highlights !== "undefined"
+      ? "css-highlights"
+      : "dom";
+
   let previousLanguageName;
+  let previousEngine;
   $: {
     hljs.registerLanguage(language.name, language.register);
-    if (mounted && language.name !== previousLanguageName) {
+    if (
+      mounted &&
+      (language.name !== previousLanguageName ||
+        resolvedEngineValue !== previousEngine)
+    ) {
+      if (previousEngine === "css-highlights") clearCssHighlights();
       repaintForLanguageChange();
     }
     previousLanguageName = language.name;
+    previousEngine = resolvedEngineValue;
   }
   $: indentUnit = " ".repeat(tabSize);
   $: if (mounted && code !== internalCode) syncExternal();
+  $: cssHighlightStyle =
+    resolvedEngineValue === "css-highlights" && theme !== undefined
+      ? `<style>${highlightRules(theme).replaceAll(
+          "::highlight(hljs-",
+          `::highlight(hljs-${instanceId}-`,
+        )}</style>`
+      : "";
 
   function getSelectionRange() {
     const selection = window.getSelection();
@@ -111,12 +161,20 @@
     return start;
   }
 
+  const setHtml = (el, line) => {
+    el.innerHTML = line;
+  };
+  const setText = (el, line) => {
+    el.textContent = line;
+  };
+
   // Patches `editor` to match `lines` (one <span> per line, joined by literal
   // "\n" text nodes so caret offset math stays identical to a flat paint).
-  // Only lines whose HTML actually changed touch the DOM. Returns the index
-  // of the single changed line when nothing else shifted (used to scope
-  // caret restoration), or null.
-  function renderLines(lines) {
+  // Only lines whose content actually changed touch the DOM (assigned via
+  // `setContent`: innerHTML for the "dom" engine, textContent for
+  // "css-highlights"). Returns the index of the single changed line when
+  // nothing else shifted (used to scope caret restoration), or null.
+  function renderLines(lines, setContent) {
     // Some browsers can place a native selection boundary just outside a
     // line's <span> (e.g. Firefox collapsing a select-all there); typing at
     // that point inserts a stray sibling text node our diffing never touches.
@@ -127,6 +185,7 @@
       lineEls = [];
       lineLengths = [];
       renderedLines = [];
+      clearCssHighlights();
     }
 
     const prevLen = lineEls.length;
@@ -137,7 +196,7 @@
     let changedCount = 0;
     for (let i = 0; i < commonLen; i++) {
       if (renderedLines[i] === lines[i]) continue;
-      lineEls[i].innerHTML = lines[i];
+      setContent(lineEls[i], lines[i]);
       lineLengths[i] = lineEls[i].textContent.length;
       changedIndex = i;
       changedCount++;
@@ -146,7 +205,7 @@
     for (let i = prevLen; i < newLen; i++) {
       if (lineEls.length > 0) editor.appendChild(document.createTextNode("\n"));
       const span = document.createElement("span");
-      span.innerHTML = lines[i];
+      setContent(span, lines[i]);
       editor.appendChild(span);
       lineEls.push(span);
       lineLengths.push(span.textContent.length);
@@ -155,6 +214,8 @@
     while (lineEls.length > newLen) {
       editor.removeChild(lineEls.pop());
       lineLengths.pop();
+      clearLineHighlights(lineHighlightRanges.length - 1);
+      lineHighlightRanges.pop();
       // Drop the separator that used to precede the removed line.
       if (lineEls.length > 0) editor.removeChild(editor.lastChild);
     }
@@ -163,11 +224,82 @@
     return prevLen === newLen && changedCount === 1 ? changedIndex : null;
   }
 
+  /** @type {Map<string, InstanceType<typeof Highlight>>} scope -> registered Highlight. */
+  let cssHighlights = new Map();
+  /** @type {{ scope: string; range: Range }[][]} Ranges registered per line. */
+  let lineHighlightRanges = [];
+
+  function cssHighlightFor(scope) {
+    let highlight = cssHighlights.get(scope);
+    if (!highlight) {
+      highlight = new Highlight();
+      cssHighlights.set(scope, highlight);
+      CSS.highlights.set(`hljs-${instanceId}-${scope}`, highlight);
+    }
+    return highlight;
+  }
+
+  function clearLineHighlights(index) {
+    const previous = lineHighlightRanges[index];
+    if (!previous) return;
+    for (const { scope, range } of previous) {
+      cssHighlights.get(scope)?.delete(range);
+    }
+  }
+
+  function clearCssHighlights() {
+    for (const scope of cssHighlights.keys()) {
+      CSS.highlights.delete(`hljs-${instanceId}-${scope}`);
+    }
+    cssHighlights = new Map();
+    lineHighlightRanges = [];
+  }
+
+  // Rebuilds only line `index`'s Highlight Range registrations from
+  // `tokenRanges` (absolute offsets into the full document); the line's text
+  // node itself is untouched by this, so it never disturbs the caret.
+  function paintLineHighlights(index, tokenRanges) {
+    clearLineHighlights(index);
+    const textNode = lineEls[index].firstChild;
+    const next = [];
+    if (textNode) {
+      const lineStart = lineStartOffset(index);
+      const lineEnd = lineStart + lineLengths[index];
+      for (const token of tokenRanges) {
+        if (token.end <= lineStart || token.start >= lineEnd) continue;
+        const start = Math.max(token.start, lineStart) - lineStart;
+        const end = Math.min(token.end, lineEnd) - lineStart;
+        if (start === end) continue;
+        const range = new Range();
+        range.setStart(textNode, start);
+        range.setEnd(textNode, end);
+        cssHighlightFor(token.scope).add(range);
+        next.push({ scope: token.scope, range });
+      }
+    }
+    lineHighlightRanges[index] = next;
+  }
+
+  function paintCssHighlights() {
+    const changedIndex = renderLines(code.split("\n"), setText);
+    const tokenRanges = tokenize(code, language.name);
+
+    if (changedIndex == null) {
+      for (let i = 0; i < lineEls.length; i++) {
+        paintLineHighlights(i, tokenRanges);
+      }
+    } else {
+      paintLineHighlights(changedIndex, tokenRanges);
+    }
+    return changedIndex;
+  }
+
   function paint() {
+    if (resolvedEngineValue === "css-highlights") return paintCssHighlights();
     const html = hljs.highlight(code, { language: language.name }).value;
     // Trailing empty line needs a phantom `\n` for caret placement.
     const paintHtml = code === "" || code.endsWith("\n") ? `${html}\n` : html;
-    return renderLines(splitLines(paintHtml));
+    return renderLines(splitLines(paintHtml), setHtml);
   }
 
   function renderAt(start, end) {
@@ -453,6 +585,11 @@
     return redoStack.length > 0;
   }
 
+  /** The engine actually in use: `engine`, or `"dom"` if it was requested but unsupported. */
+  export function resolvedEngine() {
+    return resolvedEngineValue;
+  }
+
   // WebKit dispatches a second beforeinput historyUndo/historyRedo shortly
   // after the first for a single execCommand call; without this guard the
   // second dispatch pops an extra history entry. The reset is deferred past
@@ -482,8 +619,19 @@
       return;
     }
     const previousCode = code;
-    // innerText keeps contenteditable line breaks; textContent doesn't.
-    code = editor.innerText.replace(TRAILING_NEWLINE, "");
+    // innerText keeps contenteditable line breaks that textContent drops
+    // (e.g. a browser-inserted <br> on Enter) -- but Firefox can return a
+    // stale innerText immediately after editing a text node that was last
+    // written via `textContent` (see setText in paintCssHighlights), losing
+    // the just-typed content. The css-highlights engine builds every line
+    // from a single text node with literal "\n" separators and always
+    // intercepts Enter/paste itself, so textContent is exact there and
+    // sidesteps the staleness.
+    code = (
+      resolvedEngineValue === "css-highlights"
+        ? editor.textContent
+        : editor.innerText
+    ).replace(TRAILING_NEWLINE, "");
     internalCode = code;
     const caret = getCaretOffset() ?? code.length;
     dispatch("change", { code });
@@ -598,9 +746,16 @@
       editor.removeEventListener("blur", onBlur);
       editor.removeEventListener("compositionstart", onCompositionStart);
       editor.removeEventListener("compositionend", onCompositionEnd);
+      clearCssHighlights();
     };
   });
 </script>
+
+<svelte:head
+  >{#if cssHighlightStyle}
+    {@html cssHighlightStyle}
+  {/if}</svelte:head
+>
 
 <pre
   style:overflow-x="var(--overflow-x, auto)"

--- a/src/HighlightEditable.svelte.d.ts
+++ b/src/HighlightEditable.svelte.d.ts
@@ -30,6 +30,31 @@ export type HighlightEditableProps = HTMLAttributes<HTMLPreElement> & {
   historyLimit?: number;
 
   /**
+   * Rendering engine. `"css-highlights"` (experimental) paints tokens via
+   * the CSS Custom Highlight API (`CSS.highlights`) over plain-text line
+   * nodes instead of wrapping them in `<span>`s, so a repaint never
+   * replaces DOM the caret could be sitting in. Falls back to `"dom"`
+   * silently where `CSS.highlights` is unavailable (Chrome 105+,
+   * Safari 17.2+, Firefox 140+); check what was actually used with the
+   * `resolvedEngine()` method.
+   *
+   * Colors only: `::highlight()` doesn't support `font-style`/
+   * `font-weight`/`text-decoration` across browsers, so bold/italic scopes
+   * render plain in this mode.
+   * @default "dom"
+   */
+  engine?: "dom" | "css-highlights";
+
+  /**
+   * Theme CSS from `svelte-highlight/styles/<theme>`, used only in
+   * `"css-highlights"` mode to generate `::highlight()` rules. Colors only
+   * (`color`/`background-color`); other declarations are dropped.
+   * @example
+   * import a11yDark from "svelte-highlight/styles/a11y-dark";
+   */
+  theme?: string;
+
+  /**
    * Color of the focus outline.
    * @default "#4589ff"
    */
@@ -110,4 +135,10 @@ export default class HighlightEditable extends SvelteComponentTyped<
 
   /** Whether a redo step is available. */
   canRedo(): boolean;
+
+  /**
+   * The engine actually in use: `engine`, or `"dom"` if `"css-highlights"`
+   * was requested but `CSS.highlights` is unavailable.
+   */
+  resolvedEngine(): "dom" | "css-highlights";
 }

--- a/src/HighlightStyle.svelte
+++ b/src/HighlightStyle.svelte
@@ -1,31 +1,29 @@
 <script context="module">
+  import { writable } from "svelte/store";
+
   const isBrowser = typeof document !== "undefined";
 
-  /** @type {Map<string, number>} */
-  const refCounts = new Map();
+  // Instances sharing a key queue up in registration order; only the oldest
+  // still-mounted instance renders the `<style>`. A store (rather than a
+  // plain ref count) means that when that instance unmounts, the remaining
+  // subscribers reactively re-derive a new owner instead of the tag being
+  // dropped while siblings still need it.
+  /** @type {Map<string, import("svelte/store").Writable<symbol[]>>} */
+  const registries = new Map();
 
   /** @param {string} key */
-  function acquire(key) {
-    if (!isBrowser) return true;
-    const count = refCounts.get(key) ?? 0;
-    refCounts.set(key, count + 1);
-    return count === 0;
-  }
-
-  /** @param {string | undefined} key */
-  function release(key) {
-    if (!isBrowser || key === undefined) return;
-    const count = refCounts.get(key) ?? 0;
-    if (count <= 1) {
-      refCounts.delete(key);
-    } else {
-      refCounts.set(key, count - 1);
+  function registryFor(key) {
+    let registry = registries.get(key);
+    if (!registry) {
+      registry = writable([]);
+      registries.set(key, registry);
     }
+    return registry;
   }
 </script>
 
 <script>
-  import { onMount } from "svelte";
+  import { onDestroy } from "svelte";
   import { dualStyle, scopeClassFor, scopeStyle } from "./scoped.js";
 
   /**
@@ -71,19 +69,29 @@
       : scopeStyle(theme, scopeClass)
     : "";
 
+  const token = Symbol();
   let registeredKey;
-  let shouldRender = false;
+  /** @type {import("svelte/store").Writable<symbol[]> | undefined} */
+  let registry;
+
+  function unregister() {
+    registry?.update((owners) => owners.filter((owner) => owner !== token));
+  }
 
   $: {
     const key = style ? `${scopeClass}::${style}` : undefined;
     if (key !== registeredKey) {
-      release(registeredKey);
+      unregister();
       registeredKey = key;
-      shouldRender = key !== undefined && acquire(key);
+      registry = isBrowser && key !== undefined ? registryFor(key) : undefined;
+      registry?.update((owners) => [...owners, token]);
     }
   }
 
-  onMount(() => () => release(registeredKey));
+  $: owners = $registry ?? [];
+  $: shouldRender = !isBrowser || owners[0] === token;
+
+  onDestroy(unregister);
 </script>
 
 <svelte:head

--- a/src/highlight-theme.d.ts
+++ b/src/highlight-theme.d.ts
@@ -1,0 +1,7 @@
+/**
+ * Convert a theme's `.hljs-<scope>` color/background-color rules into
+ * `::highlight(hljs-<scope>)` rules. Font-style, font-weight, and any
+ * property other than color/background-color are dropped (the API's
+ * cross-browser envelope), as are compound and descendant selectors.
+ */
+export function highlightRules(theme: string): string;

--- a/src/highlight-theme.js
+++ b/src/highlight-theme.js
@@ -1,0 +1,176 @@
+/**
+ * Convert a highlight.js theme's `.hljs-<scope>` class rules into
+ * `::highlight(hljs-<scope>)` rules for the CSS Custom Highlight API, used
+ * by the `HighlightEditable` "css-highlights" engine.
+ *
+ * `::highlight()` only supports `color`/`background-color` across browsers
+ * (no `text-decoration`/`text-shadow` everywhere), so every other
+ * declaration is dropped. Compound (`.hljs-title.class_`) and descendant
+ * (`.hljs-meta .hljs-keyword`) selectors have no `::highlight()` equivalent
+ * and are dropped too; only single-class `.hljs-<scope>` selectors convert.
+ */
+
+const STYLE_TAG = /^(\s*<style>)([\s\S]*?)(<\/style>\s*)$/;
+const SIMPLE_SCOPE_SELECTOR = /^\.hljs-([\w-]+)$/;
+const SUPPORTED_PROPERTIES = new Set(["color", "background-color"]);
+
+/**
+ * @param {string} css
+ * @param {number} start
+ */
+function findStringEnd(css, start) {
+  const quote = css[start];
+  let i = start + 1;
+  while (i < css.length) {
+    const ch = css[i];
+    if (ch === "\\") {
+      i += 2;
+      continue;
+    }
+    if (ch === quote) return i + 1;
+    i += 1;
+  }
+  return css.length;
+}
+
+/**
+ * Index after the `}` that closes the block starting at `start`.
+ * @param {string} css
+ * @param {number} start
+ */
+function findBlockEnd(css, start) {
+  let depth = 1;
+  let i = start;
+  while (i < css.length) {
+    const ch = css[i];
+    if (ch === "/" && css[i + 1] === "*") {
+      const end = css.indexOf("*/", i + 2);
+      i = end === -1 ? css.length : end + 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      i = findStringEnd(css, i);
+      continue;
+    }
+    if (ch === "{") {
+      depth += 1;
+    } else if (ch === "}") {
+      depth -= 1;
+      if (depth === 0) return i;
+    }
+    i += 1;
+  }
+  return css.length;
+}
+
+/**
+ * Split on `delim`, skipping nested strings and comments.
+ * @param {string} str
+ * @param {string} delim
+ */
+function splitTopLevel(str, delim) {
+  const parts = [];
+  let current = "";
+  let i = 0;
+  while (i < str.length) {
+    const ch = str[i];
+    if (ch === "/" && str[i + 1] === "*") {
+      const end = str.indexOf("*/", i + 2);
+      const stop = end === -1 ? str.length : end + 2;
+      current += str.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const stop = findStringEnd(str, i);
+      current += str.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === delim) {
+      parts.push(current);
+      current = "";
+    } else {
+      current += ch;
+    }
+    i += 1;
+  }
+  parts.push(current);
+  return parts;
+}
+
+/** @param {string} body */
+function colorDeclarations(body) {
+  return splitTopLevel(body, ";")
+    .map((declaration) => {
+      const colon = declaration.indexOf(":");
+      if (colon === -1) return null;
+      const prop = declaration.slice(0, colon).trim().toLowerCase();
+      const value = declaration.slice(colon + 1).trim();
+      return value && SUPPORTED_PROPERTIES.has(prop) ? { prop, value } : null;
+    })
+    .filter((declaration) => declaration !== null);
+}
+
+/**
+ * @param {string} prelude Selector list preceding a rule's `{`.
+ * @param {string} body Declarations between the matching `{` and `}`.
+ */
+function highlightRulesFor(prelude, body) {
+  const declarations = colorDeclarations(body);
+  if (declarations.length === 0) return "";
+  const decl = declarations
+    .map(({ prop, value }) => `${prop}:${value}`)
+    .join(";");
+
+  return splitTopLevel(prelude, ",")
+    .map((selector) => SIMPLE_SCOPE_SELECTOR.exec(selector.trim()))
+    .filter((match) => match !== null)
+    .map((match) => `::highlight(hljs-${match[1]}){${decl}}`)
+    .join("");
+}
+
+/**
+ * @param {string} theme Theme CSS (optionally `<style>`-wrapped).
+ * @returns {string} Converted `::highlight()` rules, concatenated.
+ */
+export function highlightRules(theme) {
+  const match = STYLE_TAG.exec(theme);
+  const css = match ? (match[2] ?? "") : theme;
+
+  let out = "";
+  let prelude = "";
+  let i = 0;
+  while (i < css.length) {
+    const ch = css[i];
+    if (ch === "/" && css[i + 1] === "*") {
+      const end = css.indexOf("*/", i + 2);
+      i = end === -1 ? css.length : end + 2;
+      continue;
+    }
+    if (ch === '"' || ch === "'") {
+      const stop = findStringEnd(css, i);
+      prelude += css.slice(i, stop);
+      i = stop;
+      continue;
+    }
+    if (ch === "{") {
+      const bodyEnd = findBlockEnd(css, i + 1);
+      if (!prelude.trim().startsWith("@")) {
+        out += highlightRulesFor(prelude, css.slice(i + 1, bodyEnd));
+      }
+      prelude = "";
+      i = bodyEnd + 1;
+      continue;
+    }
+    if (ch === ";") {
+      // Blockless at-rule (@import, etc.): nothing to convert.
+      prelude = "";
+      i += 1;
+      continue;
+    }
+    prelude += ch;
+    i += 1;
+  }
+  return out;
+}

--- a/src/token-ranges.d.ts
+++ b/src/token-ranges.d.ts
@@ -1,0 +1,18 @@
+export interface TokenRange {
+  /** Character offset into `code` where the token starts. */
+  start: number;
+  /** Character offset into `code` where the token ends. */
+  end: number;
+  /**
+   * hljs scope name (e.g. `"keyword"`, `"title.function"`), as passed to
+   * `startScope`. Dotted/tiered names are kept as-is, not split into
+   * multiple classes.
+   */
+  scope: string;
+}
+
+/**
+ * Tokenize `code` into flat, non-overlapping scope ranges instead of HTML.
+ * `languageName` must already be registered with hljs.
+ */
+export function tokenize(code: string, languageName: string): TokenRange[];

--- a/src/token-ranges.js
+++ b/src/token-ranges.js
@@ -1,0 +1,112 @@
+/**
+ * Tokenize code into flat, absolute-offset scope ranges instead of HTML, via
+ * hljs's `__emitter` hook. Used by the `HighlightEditable` "css-highlights"
+ * engine, which paints tokens as `CSS.highlights` ranges over plain-text
+ * nodes rather than wrapping them in `<span>`s.
+ */
+
+import hljs from "highlight.js/lib/core";
+
+/** @typedef {import("highlight.js").Emitter} Emitter */
+/** @typedef {new (options: unknown) => Emitter} EmitterConstructor */
+
+// Nested `startScope` calls stack up (e.g. a keyword inside a sublanguage
+// block); a run of text takes the innermost (top-of-stack) scope, matching
+// how nested `<span>`s visually resolve to the last-applied color in the
+// class-based renderer.
+/** @implements {Emitter} */
+class RangeEmitter {
+  /** @param {unknown} options */
+  constructor(options) {
+    this.options = options;
+    this.pos = 0;
+    /** @type {string[]} */
+    this.stack = [];
+    /** @type {{ start: number; end: number; scope: string }[]} */
+    this.ranges = [];
+  }
+
+  /** @param {string} text */
+  addText(text) {
+    if (text.length === 0) return;
+    const scope = this.stack[this.stack.length - 1];
+    if (scope !== undefined) {
+      this.ranges.push({ start: this.pos, end: this.pos + text.length, scope });
+    }
+    this.pos += text.length;
+  }
+
+  /** @param {string} scope */
+  startScope(scope) {
+    this.stack.push(scope);
+  }
+
+  endScope() {
+    this.stack.pop();
+  }
+
+  // Grammar modes (as opposed to keyword matches) open/close scopes through
+  // this pair instead of startScope/endScope; same bookkeeping either way.
+  /** @param {string} scope */
+  openNode(scope) {
+    this.startScope(scope);
+  }
+
+  closeNode() {
+    this.endScope();
+  }
+
+  // Sublanguage blocks are parsed by a fresh emitter of this same class,
+  // offsets relative to that block; splice its ranges in at our position.
+  /** @param {RangeEmitter} emitter */
+  __addSublanguage(emitter) {
+    const base = this.pos;
+    for (const range of emitter.ranges) {
+      this.ranges.push({
+        start: base + range.start,
+        end: base + range.end,
+        scope: range.scope,
+      });
+    }
+    this.pos += emitter.pos;
+  }
+
+  // Matches hljs's `Emitter.toHTML` interface; unused since we return ranges.
+  // biome-ignore lint/style/useNamingConvention: interface-mandated name
+  toHTML() {
+    return "";
+  }
+
+  finalize() {}
+}
+
+// hljs only exposes `__emitter` via the shared, module-level `configure()`
+// call (not per-call options), so the default emitter class is captured
+// lazily off a real highlight and restored synchronously after ours runs.
+/** @type {EmitterConstructor} */
+let defaultEmitter;
+
+/**
+ * @param {string} code
+ * @param {string} languageName A language already registered with hljs.
+ * @returns {{ start: number; end: number; scope: string }[]} Ranges sorted
+ *   by `start`, offsets into `code`.
+ */
+export function tokenize(code, languageName) {
+  if (defaultEmitter === undefined) {
+    const probe = hljs.highlight("", { language: languageName });
+    defaultEmitter = /** @type {EmitterConstructor} */ (
+      /** @type {unknown} */ (probe._emitter.constructor)
+    );
+  }
+
+  hljs.configure({ __emitter: RangeEmitter });
+  try {
+    const result = hljs.highlight(code, { language: languageName });
+    return /** @type {RangeEmitter} */ (
+      /** @type {unknown} */ (result._emitter)
+    ).ranges;
+  } finally {
+    hljs.configure({ __emitter: defaultEmitter });
+  }
+}

--- a/tests/e2e/HighlightEditable.cssHighlights.test.svelte
+++ b/tests/e2e/HighlightEditable.cssHighlights.test.svelte
@@ -1,0 +1,22 @@
+<script>
+  import { HighlightEditable } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  export let initialCode = "const a = 1;";
+
+  let editor;
+  let code = initialCode;
+  $: resolvedEngine = editor?.resolvedEngine();
+</script>
+
+<HighlightEditable
+  bind:this={editor}
+  language={typescript}
+  bind:code
+  engine="css-highlights"
+  theme={github}
+/>
+
+<div data-testid="code" data-value={code}></div>
+<div data-testid="resolved-engine" data-value={resolvedEngine}></div>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -15,6 +15,7 @@ import HighlightAction from "./HighlightAction.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
 import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
+import HighlightEditableCssHighlights from "./HighlightEditable.cssHighlights.test.svelte";
 import HighlightEditableLanguageSwap from "./HighlightEditable.languageSwap.test.svelte";
 import HighlightEditable from "./HighlightEditable.test.svelte";
 import HighlightStreamStability from "./HighlightStream.stability.test.svelte";
@@ -910,6 +911,88 @@ test("HighlightEditable - handles bursts of typing on a large document within bu
     "data-value",
     `${lines}${"x".repeat(50)}`,
   );
+});
+
+test("HighlightEditable css-highlights engine - paints tokens with no nested per-token spans", async ({
+  mount,
+  page,
+}) => {
+  const supported = await page.evaluate(
+    () => typeof CSS !== "undefined" && "highlights" in CSS,
+  );
+  test.skip(!supported, "CSS Custom Highlight API not supported");
+
+  await mount(HighlightEditableCssHighlights);
+
+  await expect(page.getByTestId("resolved-engine")).toHaveAttribute(
+    "data-value",
+    "css-highlights",
+  );
+
+  const editor = page.locator("[contenteditable='true']");
+  // One <span> per line (reused from the DOM engine's line structure), but
+  // no nested per-token spans: tokens are painted as CSS.highlights ranges.
+  await expect(editor.locator("> span")).toHaveCount(1);
+  await expect(editor.locator("span span")).toHaveCount(0);
+
+  const keywordPainted = await page.evaluate(() => {
+    const name = [...CSS.highlights.keys()].find((key) =>
+      key.endsWith("-keyword"),
+    );
+    const highlight = name && CSS.highlights.get(name);
+    return highlight ? [...highlight].length > 0 : false;
+  });
+  expect(keywordPainted).toBe(true);
+});
+
+test("HighlightEditable css-highlights engine - unrelated lines stay connected across edits", async ({
+  mount,
+  page,
+}) => {
+  const supported = await page.evaluate(
+    () => typeof CSS !== "undefined" && "highlights" in CSS,
+  );
+  test.skip(!supported, "CSS Custom Highlight API not supported");
+
+  const lines = Array.from({ length: 5 }, (_, i) => `line ${i}`).join("\n");
+  await mount(HighlightEditableCssHighlights, {
+    props: { initialCode: lines },
+  });
+
+  const editor = page.locator("[contenteditable='true']");
+  const firstLine = editor.locator("> span").first();
+  const handle = await firstLine.elementHandle();
+
+  // Click (rather than press End, whose landing offset differs across
+  // browsers for this structure) and type from wherever the click lands --
+  // the assertion below only cares that the edit was recorded and that
+  // unrelated lines were never touched, not the exact caret offset.
+  await editor.locator("> span").last().click();
+  await page.keyboard.type("x".repeat(20));
+
+  const code = await page.getByTestId("code").getAttribute("data-value");
+  expect(code).toHaveLength(lines.length + 20);
+  expect(await handle?.evaluate((el) => el.isConnected)).toBe(true);
+});
+
+test("HighlightEditable css-highlights engine - falls back to the DOM engine without CSS.highlights", async ({
+  mount,
+  page,
+}) => {
+  // No page navigation happens between CT mounts, so deleting the API
+  // directly (rather than via an init script, which only fires on
+  // navigation) is what actually takes effect before the component reads it.
+  await page.evaluate(() => {
+    Reflect.deleteProperty(CSS, "highlights");
+  });
+
+  await mount(HighlightEditableCssHighlights);
+
+  await expect(page.getByTestId("resolved-engine")).toHaveAttribute(
+    "data-value",
+    "dom",
+  );
+  await expect(page.locator(".hljs-keyword").first()).toHaveText("const");
 });
 
 test("HighlightStream - streaming chunks (split mid-keyword and mid-template-literal) settle to Highlight's output", async ({

--- a/tests/highlight-theme.test.ts
+++ b/tests/highlight-theme.test.ts
@@ -1,0 +1,51 @@
+import { highlightRules } from "../src/highlight-theme.js";
+import github from "../src/styles/github.js";
+
+describe("highlightRules", () => {
+  it("converts a simple .hljs-<scope> color rule", () => {
+    const out = highlightRules(".hljs-keyword{color:#c678dd}");
+    expect(out).toBe("::highlight(hljs-keyword){color:#c678dd}");
+  });
+
+  it("keeps color and background-color, drops other declarations", () => {
+    const out = highlightRules(
+      ".hljs-addition{color:green;background-color:#f0fff4;font-weight:bold}",
+    );
+    expect(out).toBe(
+      "::highlight(hljs-addition){color:green;background-color:#f0fff4}",
+    );
+  });
+
+  it("drops font-style-only rules entirely", () => {
+    expect(highlightRules(".hljs-emphasis{font-style:italic}")).toBe("");
+  });
+
+  it("expands a grouped selector list, dropping compound/descendant members", () => {
+    const out = highlightRules(
+      ".hljs-doctag,\n.hljs-keyword,\n.hljs-meta .hljs-keyword,\n.hljs-variable.language_{color:#d73a49}",
+    );
+    expect(out).toBe(
+      "::highlight(hljs-doctag){color:#d73a49}" +
+        "::highlight(hljs-keyword){color:#d73a49}",
+    );
+  });
+
+  it("drops the base .hljs rule (not a scope selector)", () => {
+    expect(highlightRules(".hljs{color:#24292e;background:#ffffff}")).toBe("");
+  });
+
+  it("ignores @media-wrapped rules", () => {
+    const out = highlightRules(
+      "@media (prefers-color-scheme: dark){.hljs-keyword{color:red}}",
+    );
+    expect(out).toBe("");
+  });
+
+  it("converts the github theme with a known rule and drops font-style", () => {
+    const out = highlightRules(github);
+
+    expect(out).toContain("::highlight(hljs-keyword){color:#d73a49}");
+    expect(out).not.toContain("font-style");
+    expect(out).not.toContain("font-weight");
+  });
+});

--- a/tests/token-ranges.test.ts
+++ b/tests/token-ranges.test.ts
@@ -1,0 +1,76 @@
+import hljs from "highlight.js/lib/core";
+import typescript from "highlight.js/lib/languages/typescript";
+import { tokenize } from "../src/token-ranges.js";
+
+hljs.registerLanguage("typescript", typescript);
+
+// Mirrors hljs's own scope-name -> CSS-class conversion (see
+// `scopeToCSSClass` in highlight.js/lib/core.js) so a token's `scope` can be
+// cross-checked against the classes the real HTML renderer produces.
+function scopeToClassAttr(scope: string): string {
+  if (!scope.includes(".")) return `hljs-${scope}`;
+  const pieces = scope.split(".");
+  const first = pieces.shift();
+  return [
+    `hljs-${first}`,
+    ...pieces.map((piece, i) => `${piece}${"_".repeat(i + 1)}`),
+  ].join(" ");
+}
+
+describe("tokenize", () => {
+  it("returns ranges sorted and non-overlapping after flattening", () => {
+    const code =
+      "const value = 42; // done\nfunction greet(name) { return name; }";
+    const ranges = tokenize(code, "typescript");
+
+    expect(ranges.length).toBeGreaterThan(0);
+    let previousEnd = Number.NEGATIVE_INFINITY;
+    for (const range of ranges) {
+      expect(range.start).toBeGreaterThanOrEqual(previousEnd);
+      previousEnd = range.end;
+    }
+  });
+
+  it("keeps token offsets aligned with the source string", () => {
+    const code =
+      "const value = 42; // done\nfunction greet(name) { return name; }";
+    const ranges = tokenize(code, "typescript");
+
+    const keyword = ranges.find(
+      (range) => code.slice(range.start, range.end) === "const",
+    );
+    expect(keyword?.scope).toBe("keyword");
+
+    const comment = ranges.find((range) =>
+      code.slice(range.start, range.end).startsWith("//"),
+    );
+    expect(comment?.scope).toBe("comment");
+  });
+
+  it("matches the classes hljs's HTML renderer produces for the same input", () => {
+    const code =
+      "const value = 42; // done\nfunction greet(name) { return name; }";
+    const ranges = tokenize(code, "typescript");
+    const html = hljs.highlight(code, { language: "typescript" }).value;
+
+    for (const range of ranges) {
+      const text = code.slice(range.start, range.end);
+      const classAttr = scopeToClassAttr(range.scope);
+      expect(html).toContain(`<span class="${classAttr}">${text}</span>`);
+    }
+  });
+
+  it("returns an empty array for plain text with no tokens", () => {
+    expect(tokenize("just some text", "typescript")).toEqual([]);
+  });
+
+  it("does not leak its emitter into subsequent default highlight() calls", () => {
+    tokenize("const a = 1;", "typescript");
+    const html = hljs.highlight("const a = 1;", {
+      language: "typescript",
+    }).value;
+    expect(html).toBe(
+      '<span class="hljs-keyword">const</span> a = <span class="hljs-number">1</span>;',
+    );
+  });
+});

--- a/www/components/EditablePreview.svelte
+++ b/www/components/EditablePreview.svelte
@@ -24,14 +24,24 @@ const greet = (user: User): string => {
   let outlineColor = "#42be65";
   let outlineWidth = 2;
 
+  /** @type {"dom" | "css-highlights"} */
+  let engine = "dom";
+
   /** @type {import("svelte-highlight").HighlightEditable} */
   let editor;
 
   /** @type {{ entries: { size: number }[]; index: number; canUndo: boolean; canRedo: boolean }} */
   let historyState = { entries: [], index: 0, canUndo: false, canRedo: false };
 
+  $: resolvedEngine = editor?.resolvedEngine();
+
   const sideThemes = [
     { name: "atom-one-dark", theme: atomOneDark },
+    { name: "nord", theme: nord },
+  ];
+
+  const cssHighlightThemes = [
+    { name: "github-dark", theme: githubDark },
     { name: "nord", theme: nord },
   ];
 
@@ -105,13 +115,37 @@ const greet = (user: User): string => {
           bind:value={outlineWidth}
         />
       </div>
+      <div class="control">
+        <span class="label-01">Engine</span>
+        <div class="engine-toggle">
+          <Button
+            size="small"
+            kind={engine === "dom" ? "primary" : "tertiary"}
+            on:click={() => (engine = "dom")}
+            >dom</Button
+          >
+          <Button
+            size="small"
+            kind={engine === "css-highlights" ? "primary" : "tertiary"}
+            on:click={() => (engine = "css-highlights")}
+            >css-highlights</Button
+          >
+        </div>
+      </div>
     </div>
 
+    <!-- HighlightStyle stays mounted across engine toggles: it supplies the
+    base `.hljs`/`pre code.hljs` layout rules (display, padding, overflow)
+    for both engines. `theme` on HighlightEditable additionally generates
+    the `::highlight()` token-color rules, only consumed in css-highlights
+    mode. -->
     <HighlightStyle theme={githubDark}>
       <HighlightEditable
         bind:this={editor}
         language={typescript}
         bind:code
+        {engine}
+        theme={engine === "css-highlights" ? githubDark : undefined}
         --outline-color={outlineColor}
         --outline-width={`${outlineWidth}px`}
         on:change={(e) => (lastEvent = `change: ${e.detail.code.length} chars`)}
@@ -119,6 +153,10 @@ const greet = (user: User): string => {
         on:history={(e) => (historyState = e.detail)}
       />
     </HighlightStyle>
+
+    <p class="label-01" style="margin-top: 0.5rem">
+      resolvedEngine(): <code class="code">{resolvedEngine}</code>
+    </p>
   </Column>
 
   <Column xlg={10} lg={10} md={12} class="mb-5">
@@ -170,6 +208,33 @@ const greet = (user: User): string => {
   {/each}
 </Row>
 
+<h3 class="mb-3">
+  css-highlights engine: same <code>bind:code</code>, different themes side by
+  side
+</h3>
+<p class="label-01 mb-3">
+  Each instance registers its own <code>CSS.highlights</code> entries, so two
+  editors on the same page can run different themes without one clobbering the
+  other's colors.
+</p>
+<Row class="mb-9">
+  {#each cssHighlightThemes as { name, theme }}
+    <Column xlg={10} lg={10} md={12} class="mb-5">
+      <div class="label-01 mb-3">{name}</div>
+      <HighlightStyle {theme}>
+        <HighlightEditable
+          language={typescript}
+          bind:code
+          engine="css-highlights"
+          {theme}
+          --outline-color={outlineColor}
+          --outline-width={`${outlineWidth}px`}
+        />
+      </HighlightStyle>
+    </Column>
+  {/each}
+</Row>
+
 <h3 class="mb-3">Rendered with LineNumbers</h3>
 <Row class="mb-9">
   <Column xlg={12} class="mb-5">
@@ -209,6 +274,11 @@ const greet = (user: User): string => {
     border: none;
     background: none;
     cursor: pointer;
+  }
+
+  .engine-toggle {
+    display: flex;
+    gap: 0.25rem;
   }
 
   .history {

--- a/www/components/HighlightEditable/CssHighlights.svelte
+++ b/www/components/HighlightEditable/CssHighlights.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { HighlightEditable } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+
+  let editor;
+  let code = "const add = (a: number, b: number) => a + b;";
+  $: resolvedEngine = editor?.resolvedEngine();
+</script>
+
+<!-- class provides the base `.hljs`/`pre code.hljs` layout rules (from the
+site-wide theme stylesheet); theme additionally generates the
+`::highlight()` token-color rules this engine actually paints with. -->
+<HighlightEditable
+  bind:this={editor}
+  language={typescript}
+  bind:code
+  engine="css-highlights"
+  theme={horizonDark}
+  class={THEME_MODULE_NAME}
+/>
+
+<p class="label-01" style="margin-top: 0.75rem">
+  resolvedEngine(): <code class="code">{resolvedEngine}</code>
+</p>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -11,6 +11,7 @@
   import FileTabs from "@components/FileTabs.svelte";
   import EditableBasic from "@components/HighlightEditable/Basic.svelte";
   import EditableCommands from "@components/HighlightEditable/Commands.svelte";
+  import EditableCssHighlights from "@components/HighlightEditable/CssHighlights.svelte";
   import HighlightStreamBasic from "@components/HighlightStream/Basic.svelte";
   import HighlightStreamControls from "@components/HighlightStream/Controls.svelte";
   import Basic from "@components/LineNumbers/Basic.svelte";
@@ -642,6 +643,35 @@
       <code class="code">--outline-offset</code>.
     </p>
   </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <strong>Experimental:</strong>
+      set
+      <code class="code">engine="css-highlights"</code>
+      to paint tokens with the{" "}
+      <Link
+        inline
+        style="font-size: inherit"
+        href="https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API"
+        >CSS Custom Highlight API</Link
+      >
+      instead of wrapping them in <code class="code">{"<span>"}</code>s. The
+      editable block never replaces DOM the caret is sitting in on repaint.
+      Requires Chrome 105+, Safari 17.2+, or Firefox 140+; falls back to
+      <code class="code">"dom"</code>
+      silently otherwise—check what ran with
+      <code class="code">resolvedEngine()</code>.
+    </p>
+    <p class="mb-5">
+      Pass <code class="code">theme</code> (the same string you'd give
+      <code class="code">HighlightStyle</code>) to generate
+      <code class="code">::highlight()</code>
+      rules from it. Only <code class="code">color</code>/
+      <code class="code">background-color</code>
+      convert; bold and italic scopes render plain in this mode.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <EditableCssHighlights /> </Column>
 </Row>
 
 <Row class="mb-9">


### PR DESCRIPTION
Adds an opt-in engine="css-highlights" mode to HighlightEditable that paints tokens with the CSS Custom Highlight API instead of wrapping them in span elements. A custom hljs emitter (src/token-ranges.js) tokenizes code into flat scope ranges with no DOM involved, and a small converter (src/highlight-theme.js) rewrites a theme's .hljs-* color rules into ::highlight() rules (color/background-color only, since that's the API's cross-browser support envelope). The editable line structure is reused as-is, so repaints on unaffected lines never touch DOM the caret could be sitting in. Falls back to the default dom engine silently when CSS.highlights isn't available, and the resolved engine is queryable via a new resolvedEngine() method. Default behavior (engine="dom") is unchanged, verified by the full existing test suite passing untouched.

Also fixes a real bug in HighlightStyle found while building the docs demo: its dedup logic picked the first-mounted instance sharing a theme to own the shared style tag and froze that choice, so if that instance unmounted while sibling instances with the same theme were still mounted, the tag disappeared and every survivor lost its styling. Replaced the plain ref count with a store holding an ordered queue of owner tokens per key, so ownership hands off to the next instance in line instead of being dropped.

Docs site gets a new "Experimental" subsection under Editable with a live demo, and the unlisted preview-editable page gets a dom/css-highlights toggle plus a side-by-side demo running two differently-themed css-highlights instances against the same bound code, to exercise the per-instance CSS.highlights scoping.

Main risk area is the new HighlightStyle ownership-handoff logic, since it touches a widely-used component; it's covered by the existing HighlightStyle e2e suite plus manual verification of mount/unmount ordering. The css-highlights engine itself is scoped to opt-in usage and marked experimental, with browser support gated behind a feature check (Chrome 105+, Safari 17.2+, Firefox 140+).