### PR TITLE
feat(engine): expose the scope-event stream as public API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1433,6 +1433,13 @@ Arrow keys move between tabs; `Home` and `End` jump to the first and last. The m
      * @example "<span>...</span>"
      */
     console.log(e.detail.highlighted);
+
+    /**
+     * The scope-event stream behind `highlighted`. See "Headless usage"
+     * below for consuming it directly (tokenLines, toRanges, custom
+     * renderers) instead of re-parsing the HTML.
+     */
+    console.log(e.detail.events);
   }}
 />
 ```
@@ -1527,6 +1534,9 @@ Arrow keys move between tabs; `Home` and `End` jump to the first and last. The m
      * @example "<span>...</span>"
      */
     console.log(e.detail.highlighted);
+
+    /** The scope-event stream behind `highlighted`. See "Headless usage" below. */
+    console.log(e.detail.events);
   }}
 />
 ```
@@ -1568,6 +1578,9 @@ import type { LanguageName } from "svelte-highlight";
      * @example "css"
      */
     console.log(e.detail.language);
+
+    /** The scope-event stream behind `highlighted`. See "Headless usage" below. */
+    console.log(e.detail.events);
   }}
 />
 ```
@@ -1676,6 +1689,92 @@ Use `bind:this`, then call `undo()`, `redo()`, `focus()`, `selectAll()`, `insert
 <Highlight language={typescript} {code} let:highlighted>
   <Typewriter {highlighted} on:done={() => console.log("revealed")} />
 </Highlight>
+```
+
+## Headless usage
+
+The highlighting engine's output is a flat scope-event stream (`ScopeEvent[]`): a sequence of `TEXT`/`OPEN`/`CLOSE` events that `renderHtml`, `toRanges`, and `tokenLines` each render differently. Every `<Highlight>`-family component exposes this stream (as `events`, in the default slot and the `highlight` event detail — see [Component API](#component-api) above), and `svelte-highlight/engine` + `svelte-highlight/registry` expose it directly, so highlighting can be consumed headlessly: server routes, build pipelines, tests, or any non-component context. `svelte-highlight/engine` has zero Svelte dependency and works in any JS runtime.
+
+### Stability tiers
+
+- **Stable, semver-governed:** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`, `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`, `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`, `Registry` and its methods, `createRegistry`, `registerAll`, `StreamSession`. `Snapshot` is a serializable format that round-trips within one library version, but is **not** guaranteed stable across versions — a snapshot from an older release may be rejected on resume.
+- **Generated data, versioned with the library:** `GrammarIR`/`GrammarState`. These come from the build pipeline and are consumed by `registerAll`; treat them as opaque payloads whose field-level structure may change in any minor release. Always load grammars from the same package version as the engine.
+
+### Headless highlighting, isolated registry
+
+Use `createRegistry()` when you want an instance isolated from the components' shared registry (SSR request isolation, tests):
+
+```js
+import { createRegistry, registerAll, renderHtml, tokenLines } from "svelte-highlight/engine";
+import typescript from "svelte-highlight/languages/typescript";
+
+const registry = createRegistry();
+registerAll(registry, typescript);
+
+const { events, value } = registry.highlight(code, { language: "typescript" });
+// value: same HTML the <Highlight> component renders
+// events: the scope-event stream — one tokenization, any number of consumers
+const lines = tokenLines(events); // [[{ text: "const", scopes: ["keyword"] }, …], …]
+```
+
+### Joining the components' shared registry
+
+Use `svelte-highlight/registry` when a language registered here should also be visible to `<Highlight>` (and vice versa):
+
+```js
+import { registry, ensureRegistered } from "svelte-highlight/registry";
+import typescript from "svelte-highlight/languages/typescript";
+
+ensureRegistered(typescript);
+const ranges = registry.tokenizeRanges(code, { language: "typescript" });
+```
+
+### Streaming, headless
+
+The same primitives `HighlightStream` uses:
+
+```js
+import { registry } from "svelte-highlight/registry";
+
+const session = registry.createSession("typescript");
+session.append(chunk); // repeat as chunks arrive
+const snapshot = session.snapshot(); // JSON-serializable checkpoint
+const { value } = session.finish();
+```
+
+### Reaching the stream from a component — no HTML re-parsing
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted let:events>
+  <pre><code>{@html highlighted}</code></pre>
+  <TokenMinimap {events} />
+</Highlight>
+
+<Highlight language={typescript} {code} on:highlight={(e) => analyze(e.detail.events)} />
+```
+
+### A third-party render target
+
+`Renderer<Out>` names the contract that `renderHtml`, `toRanges`, and `tokenLines` (via `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`) all conform to — implement it to plug a custom render target into the same pipeline:
+
+```js
+import { TEXT, OPEN, CLOSE } from "svelte-highlight/engine";
+
+/** @type {import("svelte-highlight/engine").Renderer<MyOutput>} */
+const myRenderer = {
+  render(events) {
+    for (const ev of events) {
+      if (ev.t === TEXT) {
+        /* ev.v */
+      } else if (ev.t === OPEN) {
+        /* ev.s */
+      } else {
+        /* CLOSE */
+      }
+    }
+    return out;
+  },
+};
 ```
 
 ## [Supported Languages](SUPPORTED_LANGUAGES.md)

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -80,6 +80,22 @@ pkgJson.exports = {
     types: "./languages/*.d.ts",
     import: "./languages/*.js",
   },
+  "./engine": {
+    types: "./engine.d.ts",
+    default: "./engine.js",
+  },
+  "./engine.js": {
+    types: "./engine.d.ts",
+    default: "./engine.js",
+  },
+  "./registry": {
+    types: "./registry.d.ts",
+    default: "./registry.js",
+  },
+  "./registry.js": {
+    types: "./registry.d.ts",
+    default: "./registry.js",
+  },
   "./ansi": {
     types: "./ansi.d.ts",
     default: "./ansi.js",

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -12,23 +12,32 @@
   import LangTag from "./LangTag.svelte";
   import { ensureRegistered, registry } from "./registry.js";
 
+  /**
+   * @typedef {{ highlighted: string; events: import("./engine.d.ts").ScopeEvent[] }} HighlightEventDetail
+   * @type {import("svelte").EventDispatcher<{ highlight: HighlightEventDetail }>}
+   */
   const dispatch = createEventDispatcher();
 
   /** @type {string} */
   let highlighted = "";
 
+  /** @type {import("./engine.d.ts").ScopeEvent[]} */
+  let events = [];
+
   afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted });
+    if (highlighted) dispatch("highlight", { highlighted, events });
   });
 
   $: {
     ensureRegistered(language);
     const source = typeof code === "string" ? code : String(code ?? "");
-    highlighted = registry.highlight(source, { language: language.name }).value;
+    const result = registry.highlight(source, { language: language.name });
+    highlighted = result.value;
+    events = result.events;
   }
 </script>
 
-<slot {highlighted} {langtag} languageName={language.name}>
+<slot {highlighted} {langtag} languageName={language.name} {events}>
   <LangTag
     {...$$restProps}
     languageName={language.name}

--- a/src/Highlight.svelte.d.ts
+++ b/src/Highlight.svelte.d.ts
@@ -1,5 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
+import type { ScopeEvent } from "./engine.d.ts";
 import type { LanguageType } from "./languages";
 
 export type LangtagProps = {
@@ -78,6 +79,13 @@ export type HighlightEvents = {
      * @example "<span>...</span>"
      */
     highlighted: string;
+
+    /**
+     * The scope-event stream behind `highlighted` - the same array
+     * `registry.highlight(...).events` returns. See `svelte-highlight/engine`
+     * for headless consumption (`tokenLines`, `toRanges`, custom renderers).
+     */
+    events: ScopeEvent[];
   }>;
 };
 
@@ -88,6 +96,13 @@ export type HighlightSlots = {
      * @example "<span>...</span>"
      */
     highlighted: string;
+
+    /**
+     * The scope-event stream behind `highlighted` - the same array
+     * `registry.highlight(...).events` returns. See `svelte-highlight/engine`
+     * for headless consumption (`tokenLines`, `toRanges`, custom renderers).
+     */
+    events: ScopeEvent[];
   };
 };
 

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -18,7 +18,7 @@
   import { registry } from "./registry.js";
 
   /**
-   * @typedef {{ highlighted: string; language: string; }} HighlightEventDetail
+   * @typedef {{ highlighted: string; language: string; events: import("./engine.d.ts").ScopeEvent[] }} HighlightEventDetail
    * @type {import("svelte").EventDispatcher<{ highlight: HighlightEventDetail}>}
    */
   const dispatch = createEventDispatcher();
@@ -38,21 +38,25 @@
   /** @type {string} */
   let language = "";
 
+  /** @type {import("./engine.d.ts").ScopeEvent[]} */
+  let events = [];
+
   afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted, language });
+    if (highlighted) dispatch("highlight", { highlighted, language, events });
   });
 
   $: {
     ensureAllRegistered();
     const source = typeof code === "string" ? code : String(code ?? "");
-    ({ value: highlighted, language = "" } = registry.highlightAuto(
-      source,
-      languageNames,
-    ));
+    ({
+      value: highlighted,
+      language = "",
+      events,
+    } = registry.highlightAuto(source, languageNames));
   }
 </script>
 
-<slot {highlighted} {langtag} languageName={language}>
+<slot {highlighted} {langtag} languageName={language} {events}>
   <LangTag
     {...$$restProps}
     languageName={language}

--- a/src/HighlightAuto.svelte.d.ts
+++ b/src/HighlightAuto.svelte.d.ts
@@ -1,5 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
+import type { ScopeEvent } from "./engine.d.ts";
 import type { LangtagProps } from "./Highlight.svelte";
 import type { LanguageName } from "./languages";
 
@@ -31,6 +32,14 @@ export type HighlightAutoEvents = {
      * @example "css"
      */
     language: string;
+
+    /**
+     * The scope-event stream behind `highlighted` - the same array
+     * `registry.highlightAuto(...).events` returns. See
+     * `svelte-highlight/engine` for headless consumption (`tokenLines`,
+     * `toRanges`, custom renderers).
+     */
+    events: ScopeEvent[];
   }>;
 };
 
@@ -41,6 +50,14 @@ export type HighlightAutoSlots = {
      * @example "<span>...</span>"
      */
     highlighted: string;
+
+    /**
+     * The scope-event stream behind `highlighted` - the same array
+     * `registry.highlightAuto(...).events` returns. See
+     * `svelte-highlight/engine` for headless consumption (`tokenLines`,
+     * `toRanges`, custom renderers).
+     */
+    events: ScopeEvent[];
   };
 };
 

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -11,23 +11,32 @@
   import svelte from "./languages/svelte";
   import { ensureRegistered, registry } from "./registry.js";
 
+  /**
+   * @typedef {{ highlighted: string; events: import("./engine.d.ts").ScopeEvent[] }} HighlightEventDetail
+   * @type {import("svelte").EventDispatcher<{ highlight: HighlightEventDetail }>}
+   */
   const dispatch = createEventDispatcher();
 
   /** @type {string} */
   let highlighted = "";
 
+  /** @type {import("./engine.d.ts").ScopeEvent[]} */
+  let events = [];
+
   afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted });
+    if (highlighted) dispatch("highlight", { highlighted, events });
   });
 
   $: {
     ensureRegistered(svelte);
     const source = typeof code === "string" ? code : String(code ?? "");
-    highlighted = registry.highlight(source, { language: svelte.name }).value;
+    const result = registry.highlight(source, { language: svelte.name });
+    highlighted = result.value;
+    events = result.events;
   }
 </script>
 
-<slot {highlighted} {langtag} languageName="svelte">
+<slot {highlighted} {langtag} languageName="svelte" {events}>
   <LangTag
     {...$$restProps}
     languageName="svelte"

--- a/src/HighlightSvelte.svelte.d.ts
+++ b/src/HighlightSvelte.svelte.d.ts
@@ -1,5 +1,6 @@
 import type { SvelteComponentTyped } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
+import type { ScopeEvent } from "./engine.d.ts";
 import type { LangtagProps } from "./Highlight.svelte";
 
 export type HighlightSvelteProps = HTMLAttributes<HTMLPreElement> &
@@ -17,6 +18,13 @@ export type HighlightSvelteEvents = {
      * @example "<span>...</span>"
      */
     highlighted: string;
+
+    /**
+     * The scope-event stream behind `highlighted` - the same array
+     * `registry.highlight(...).events` returns. See `svelte-highlight/engine`
+     * for headless consumption (`tokenLines`, `toRanges`, custom renderers).
+     */
+    events: ScopeEvent[];
   }>;
 };
 
@@ -27,6 +35,13 @@ export type HighlightSvelteSlots = {
      * @example "<span>...</span>"
      */
     highlighted: string;
+
+    /**
+     * The scope-event stream behind `highlighted` - the same array
+     * `registry.highlight(...).events` returns. See `svelte-highlight/engine`
+     * for headless consumption (`tokenLines`, `toRanges`, custom renderers).
+     */
+    events: ScopeEvent[];
   };
 };
 

--- a/src/engine.d.ts
+++ b/src/engine.d.ts
@@ -1,6 +1,29 @@
 /**
+ * Stability tiers for this module's exports:
+ *
+ * - **Stable (semver-governed):** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`,
+ *   `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`,
+ *   `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`,
+ *   `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`,
+ *   `Registry` and all its methods, `createRegistry`, `registerAll`,
+ *   `StreamSession`, `Snapshot` (see its own doc comment for a narrower
+ *   guarantee).
+ * - **Generated data (structure versioned with the library):** `GrammarIR`,
+ *   `GrammarState` (see their doc comment).
+ *
+ * Event grammar: a well-formed `ScopeEvent[]` stream is balanced (every
+ * `OPEN` has a matching later `CLOSE`, properly nested) and its `TEXT`
+ * values, concatenated in order, equal the tokenized source.
+ */
+
+/**
  * Grammar IR produced by `scripts/utils/convert-language.ts` at build time.
  * Plain JSON: no functions, no highlight.js code.
+ *
+ * Generated data, not a hand-authored API: produced by the build pipeline
+ * (`scripts/convert-grammars.ts`) and consumed by `registerAll`. Treat as an
+ * opaque payload - field-level structure may change in any minor release.
+ * Grammars should always come from the same package version as the engine.
  */
 export interface GrammarState {
   /** Omitted when it's the default (1) - see convert-language.ts's compaction. */
@@ -31,6 +54,7 @@ export interface GrammarState {
   starts?: number;
 }
 
+/** Generated data - see `GrammarState`'s doc comment for the stability caveat. */
 // biome-ignore lint/style/useNamingConvention: "IR" (intermediate representation) is an established term throughout this codebase's docs
 export interface GrammarIR {
   name: string;
@@ -70,6 +94,35 @@ export function extendLines(
 
 export function toRanges(events: ScopeEvent[]): TokenRange[];
 
+export interface LineToken {
+  /** Token text; never contains a line break. */
+  text: string;
+  /** Open scope stack, outermost first, e.g. ["keyword"] or ["meta", "string"]. */
+  scopes: string[];
+}
+
+/**
+ * Line-indexed `{ text, scopes }` tokens - the structured alternative to
+ * re-splitting `renderHtml`'s output (see `src/split-lines.js`). Splits
+ * solely on LF; see `tokenLines`'s JSDoc in `engine.js` for the exact
+ * newline and edge-case semantics (CRLF, trailing newline, empty input),
+ * which are chosen to match `splitLines` line-for-line.
+ */
+export function tokenLines(events: ScopeEvent[]): LineToken[][];
+
+/** A conforming render target over a `ScopeEvent[]` stream. */
+export interface Renderer<Out> {
+  render(events: ScopeEvent[]): Out;
+}
+
+export function createHtmlRenderer(options?: {
+  classPrefix?: string;
+}): Renderer<string>;
+
+export function createRangeRenderer(): Renderer<TokenRange[]>;
+
+export function createLineRenderer(): Renderer<LineToken[][]>;
+
 export interface HighlightResult {
   language: string | undefined;
   relevance: number;
@@ -78,7 +131,14 @@ export interface HighlightResult {
   secondBest?: { language: string | undefined; relevance: number };
 }
 
-/** Serializable parse checkpoint; JSON round-trips (see `Registry#resume`). */
+/**
+ * Serializable parse checkpoint; JSON round-trips (see `Registry#resume`)
+ * within one installed library version. Not guaranteed stable across
+ * versions: a snapshot produced by an older or newer version of this
+ * package may be rejected on resume. Callers that persist snapshots across
+ * deploys (windowing, long-lived streaming sessions) should pin the engine
+ * version or be prepared to discard stale snapshots.
+ */
 export interface Snapshot {
   pos: number;
   buffer: string;

--- a/src/engine.js
+++ b/src/engine.js
@@ -2,14 +2,23 @@
  * Highlighting engine (MIT, no highlight.js code). Runs a serializable
  * grammar IR built from hljs grammars by scripts/convert-grammars.ts.
  *
- * Output is a flat scope-event stream. HTML and CSS Custom Highlight ranges
- * are two renderers over the same events. Tokenizer state is serializable so
- * parses can checkpoint, resume, and stream. Callback behavior from hljs
- * grammars becomes declarative IR flags (endSameAsBegin, onlyAtInputStart,
+ * Output is a flat scope-event stream. HTML, CSS Custom Highlight ranges, and
+ * line-indexed tokens (`renderHtml`, `toRanges`, `tokenLines`) are three
+ * renderers over the same events - see the `Renderer` interface exported
+ * from engine.d.ts. Tokenizer state is serializable so parses can
+ * checkpoint, resume, and stream. Callback behavior from hljs grammars
+ * becomes declarative IR flags (endSameAsBegin, onlyAtInputStart,
  * notAfterDot).
  *
+ * A well-formed event stream is balanced: every OPEN has a matching later
+ * CLOSE, properly nested, and the TEXT values, concatenated in order, equal
+ * the tokenized source. All renderers in this module assume this invariant.
+ *
  * Scope names stay on hljs's vocabulary (`hljs-*` classes) so existing themes
- * and the CSS-Highlight theme converter keep working.
+ * and the CSS-Highlight theme converter keep working. Scope names as they
+ * appear in events/tokenLines are the raw, unprefixed strings (e.g.
+ * "keyword", "title.class_"); the `hljs-` prefix and multi-class expansion
+ * are `renderHtml`'s concern (see `scopeToCssClass`).
  */
 
 /**
@@ -17,6 +26,7 @@
  * @typedef {import("./engine.d.ts").GrammarState} GrammarState
  * @typedef {import("./engine.d.ts").ScopeEvent} ScopeEvent
  * @typedef {import("./engine.d.ts").TokenRange} TokenRange
+ * @typedef {import("./engine.d.ts").LineToken} LineToken
  * @typedef {import("./engine.d.ts").HighlightResult} HighlightResult
  * @typedef {import("./engine.d.ts").StreamSession} StreamSession
  * @typedef {import("./engine.d.ts").Registry} Registry
@@ -883,6 +893,92 @@ export function toRanges(events) {
     }
   }
   return ranges;
+}
+
+/**
+ * Line-indexed `{ text, scopes }` tokens - the structured alternative to
+ * re-splitting `renderHtml`'s output. A single pass over `events`, maintaining
+ * the open-scope stack (like `toRanges`) and splitting `TEXT` values on line
+ * breaks (like `extendLines`'s HTML splitting).
+ *
+ * Splits solely on LF (`\n`, code point 10), matching `splitLines`'s behavior
+ * on `renderHtml` output (escaping never touches `\n`). CR (`\r`) is not
+ * treated specially - for CRLF input, the `\r` lands as the last character of
+ * the preceding line's trailing token, exactly where `splitLines` leaves it
+ * in the HTML string. A trailing newline in the source yields a trailing
+ * empty line, and an empty `events` array yields one empty line - both to
+ * match `splitLines("")` / `splitLines`'s unconditional final push.
+ * @param {ScopeEvent[]} events
+ * @returns {LineToken[][]}
+ */
+export function tokenLines(events) {
+  /** @type {LineToken[][]} */
+  const lines = [];
+  /** @type {LineToken[]} */
+  let line = [];
+  /** @type {string[]} */
+  const stack = [];
+  // Recomputed only on OPEN/CLOSE, so adjacent text on the same nesting
+  // level (even across separate TEXT events) shares one array reference and
+  // can be merged by identity below.
+  /** @type {string[]} */
+  let scopes = [];
+  /** @type {LineToken | null} */
+  let lastToken = null;
+
+  /** @param {string} text */
+  const pushText = (text) => {
+    if (text === "") return;
+    if (lastToken && lastToken.scopes === scopes) {
+      lastToken.text += text;
+    } else {
+      lastToken = { text, scopes };
+      line.push(lastToken);
+    }
+  };
+
+  for (const event of events) {
+    if (event.t === OPEN) {
+      stack.push(event.s);
+      scopes = stack.slice();
+    } else if (event.t === CLOSE) {
+      stack.pop();
+      scopes = stack.slice();
+    } else {
+      const text = event.v;
+      let start = 0;
+      for (let i = 0; i < text.length; i++) {
+        if (text.charCodeAt(i) === 10) {
+          pushText(text.slice(start, i));
+          lines.push(line);
+          line = [];
+          lastToken = null;
+          start = i + 1;
+        }
+      }
+      pushText(text.slice(start));
+    }
+  }
+  lines.push(line);
+  return lines;
+}
+
+/**
+ * @param {{ classPrefix?: string }} [options]
+ * @returns {import("./engine.d.ts").Renderer<string>}
+ */
+export function createHtmlRenderer(options) {
+  return { render: (events) => renderHtml(events, options) };
+}
+
+/** @returns {import("./engine.d.ts").Renderer<TokenRange[]>} */
+export function createRangeRenderer() {
+  return { render: toRanges };
+}
+
+/** @returns {import("./engine.d.ts").Renderer<LineToken[][]>} */
+export function createLineRenderer() {
+  return { render: tokenLines };
 }
 
 /**

--- a/src/registry.d.ts
+++ b/src/registry.d.ts
@@ -1,0 +1,17 @@
+import type { Registry as EngineRegistry } from "./engine.d.ts";
+import type { LanguageType } from "./languages";
+
+/**
+ * Shared engine registry: components register languages onto this one
+ * instance on demand, same pattern as the shared `hljs.registerLanguage`
+ * singleton it replaces. A language registered here is visible to
+ * `<Highlight>` and vice versa. For an isolated instance (SSR request
+ * isolation, tests), use `createRegistry()` from `svelte-highlight/engine`.
+ */
+export const registry: EngineRegistry;
+
+/**
+ * Registers `language` (and any grammars it embeds via `subLanguage`, e.g.
+ * astro's html/typescript/css/javascript) on the shared registry.
+ */
+export function ensureRegistered(language: LanguageType<string>): void;

--- a/tests/e2e/Highlight.events.test.svelte
+++ b/tests/e2e/Highlight.events.test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import Highlight from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import { ensureRegistered, registry } from "svelte-highlight/registry";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+
+  ensureRegistered(typescript);
+  const expectedEventsJson = JSON.stringify(
+    registry.highlight(code, { language: "typescript" }).events,
+  );
+
+  let slotEventsJson = "";
+  let dispatchEventsJson = "";
+
+  function captureSlotEvents(events: unknown) {
+    slotEventsJson = JSON.stringify(events);
+    return "";
+  }
+</script>
+
+<Highlight
+  language={typescript}
+  {code}
+  let:events
+  on:highlight={(e) => (dispatchEventsJson = JSON.stringify(e.detail.events))}
+>
+  {captureSlotEvents(events)}
+</Highlight>
+
+<p data-testid="expected-events">{expectedEventsJson}</p>
+<p data-testid="slot-events">{slotEventsJson}</p>
+<p data-testid="dispatch-events">{dispatchEventsJson}</p>

--- a/tests/e2e/HighlightAuto.events.test.svelte
+++ b/tests/e2e/HighlightAuto.events.test.svelte
@@ -1,0 +1,37 @@
+<script lang="ts">
+  import { HighlightAuto } from "svelte-highlight";
+  import { registry } from "svelte-highlight/registry";
+
+  const code = "const add = (a, b) => a + b;";
+
+  let slotEventsJson = "";
+  let dispatchEventsJson = "";
+  let dispatchLanguage = "";
+
+  function captureSlotEvents(events: unknown) {
+    slotEventsJson = JSON.stringify(events);
+    return "";
+  }
+</script>
+
+<HighlightAuto
+  {code}
+  languageNames={["javascript", "typescript"]}
+  let:events
+  on:highlight={(e) => {
+    dispatchEventsJson = JSON.stringify(e.detail.events);
+    dispatchLanguage = e.detail.language;
+  }}
+>
+  {captureSlotEvents(events)}
+</HighlightAuto>
+
+<p data-testid="expected-events">
+  {dispatchLanguage
+    ? JSON.stringify(
+        registry.highlight(code, { language: dispatchLanguage }).events,
+      )
+    : ""}
+</p>
+<p data-testid="slot-events">{slotEventsJson}</p>
+<p data-testid="dispatch-events">{dispatchEventsJson}</p>

--- a/tests/e2e/HighlightSvelte.events.test.svelte
+++ b/tests/e2e/HighlightSvelte.events.test.svelte
@@ -1,0 +1,33 @@
+<script lang="ts">
+  import { HighlightSvelte } from "svelte-highlight";
+  import svelte from "svelte-highlight/languages/svelte";
+  import { ensureRegistered, registry } from "svelte-highlight/registry";
+
+  const code =
+    "<script>\n  let count = 0;\n<\\/script>\n<button>{count}</button>\n";
+
+  ensureRegistered(svelte);
+  const expectedEventsJson = JSON.stringify(
+    registry.highlight(code, { language: "svelte" }).events,
+  );
+
+  let slotEventsJson = "";
+  let dispatchEventsJson = "";
+
+  function captureSlotEvents(events: unknown) {
+    slotEventsJson = JSON.stringify(events);
+    return "";
+  }
+</script>
+
+<HighlightSvelte
+  {code}
+  let:events
+  on:highlight={(e) => (dispatchEventsJson = JSON.stringify(e.detail.events))}
+>
+  {captureSlotEvents(events)}
+</HighlightSvelte>
+
+<p data-testid="expected-events">{expectedEventsJson}</p>
+<p data-testid="slot-events">{slotEventsJson}</p>
+<p data-testid="dispatch-events">{dispatchEventsJson}</p>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -8,10 +8,12 @@ import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
 import CopyButton from "./CopyButton.test.svelte";
 import CopyButtonTransform from "./CopyButton.transform.test.svelte";
 import FileTabs from "./FileTabs.test.svelte";
+import HighlightEvents from "./Highlight.events.test.svelte";
 import Highlight from "./Highlight.test.svelte";
 import HighlightActionOmittedCode from "./HighlightAction.omittedCode.test.svelte";
 import HighlightActionRegisterThrows from "./HighlightAction.registerThrows.test.svelte";
 import HighlightAction from "./HighlightAction.test.svelte";
+import HighlightAutoEvents from "./HighlightAuto.events.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
 import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
@@ -24,6 +26,7 @@ import HighlightStream from "./HighlightStream.test.svelte";
 import HighlightStyleDedupe from "./HighlightStyle.dedupe.test.svelte";
 import HighlightStyleNoTheme from "./HighlightStyle.noTheme.test.svelte";
 import HighlightStyleThemeSwitch from "./HighlightStyle.themeSwitch.test.svelte";
+import HighlightSvelteEvents from "./HighlightSvelte.events.test.svelte";
 import LangTag from "./LangTag.test.svelte";
 import LineNumbersCssVariables from "./LineNumbers.cssVariables.test.svelte";
 import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test.svelte";
@@ -320,6 +323,42 @@ test("HighlightAuto", async ({ mount, page }) => {
 
   // Language tag
   await expect(page.locator("pre")).toHaveAttribute("data-language", "css");
+});
+
+test("Highlight - exposes the scope-event stream via slot prop and on:highlight detail", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEvents);
+
+  const expected = await page.getByTestId("expected-events").textContent();
+  expect(expected).not.toBe("");
+  await expect(page.getByTestId("slot-events")).toHaveText(expected ?? "");
+  await expect(page.getByTestId("dispatch-events")).toHaveText(expected ?? "");
+});
+
+test("HighlightAuto - exposes the scope-event stream via slot prop and on:highlight detail", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightAutoEvents);
+
+  const expected = await page.getByTestId("expected-events").textContent();
+  expect(expected).not.toBe("");
+  await expect(page.getByTestId("slot-events")).toHaveText(expected ?? "");
+  await expect(page.getByTestId("dispatch-events")).toHaveText(expected ?? "");
+});
+
+test("HighlightSvelte - exposes the scope-event stream via slot prop and on:highlight detail", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightSvelteEvents);
+
+  const expected = await page.getByTestId("expected-events").textContent();
+  expect(expected).not.toBe("");
+  await expect(page.getByTestId("slot-events")).toHaveText(expected ?? "");
+  await expect(page.getByTestId("dispatch-events")).toHaveText(expected ?? "");
 });
 
 test("SvelteHighlight", async ({ mount, page }) => {

--- a/tests/highlight-events-ssr.test.ts
+++ b/tests/highlight-events-ssr.test.ts
@@ -1,0 +1,122 @@
+/**
+ * `Highlight`, `HighlightAuto`, and `HighlightSvelte` all expose the
+ * scope-event stream as a default-slot prop (`events`) alongside the
+ * existing `highlighted`/`langtag`/`languageName`. Slot content renders
+ * synchronously during SSR, so this asserts the slot prop's contents match
+ * the registry's own `events` for the same input - independent of the
+ * `on:highlight` event detail, which is dispatched from `afterUpdate` and so
+ * only fires client-side (covered instead by tests/e2e/*.events.test.svelte).
+ *
+ * Follows the `tests/highlight-non-string-code.test.ts` compile pattern: a
+ * Bun plugin server-compiles every `.svelte` file on load (not just the
+ * entrypoint), because Highlight/HighlightAuto/HighlightSvelte all
+ * transitively import LangTag.svelte.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { plugin } from "bun";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+import { createRegistry, registerAll } from "../src/engine.js";
+import allLanguages from "../src/languages/all.js";
+import svelteLanguage from "../src/languages/svelte.js";
+import typescript from "../src/languages/typescript.js";
+
+plugin({
+  name: "svelte-server-compile",
+  setup(build) {
+    build.onLoad({ filter: /\.svelte$/ }, ({ path: filePath }) => {
+      const source = fs.readFileSync(filePath, "utf-8");
+      const { js } = compile(source, {
+        generate: "server",
+        filename: path.basename(filePath),
+      });
+      return { contents: js.code, loader: "js" };
+    });
+  },
+});
+
+const srcDir = path.join(import.meta.dir, "../src");
+
+/** Independent registry mirroring what the shared components register onto. */
+const registry = createRegistry();
+registerAll(registry, typescript);
+registerAll(registry, svelteLanguage);
+for (const language of allLanguages) registerAll(registry, language);
+
+/**
+ * Writes a temp `.svelte` wrapper alongside the real components (so its
+ * relative import resolves), imports it, and deletes it afterward.
+ */
+async function importWrapper(name: string, source: string) {
+  const wrapperPath = path.join(srcDir, `.tmp-${name}.svelte`);
+  fs.writeFileSync(wrapperPath, source);
+  try {
+    return await import(wrapperPath);
+  } finally {
+    fs.unlinkSync(wrapperPath);
+  }
+}
+
+describe("slot `events` matches the registry's events", () => {
+  it("Highlight", async () => {
+    const { default: Wrapper } = await importWrapper(
+      "highlight-events",
+      `<script>
+  import Highlight from "./Highlight.svelte";
+  export let language;
+  export let code;
+</script>
+<Highlight {language} {code} let:events>{@html JSON.stringify(events)}</Highlight>
+`,
+    );
+
+    const code = "const add = (a, b) => a + b;";
+    const { body } = render(Wrapper, { props: { language: typescript, code } });
+    const expected = registry.highlight(code, {
+      language: "typescript",
+    }).events;
+
+    expect(body).toContain(JSON.stringify(expected));
+  });
+
+  it("HighlightAuto", async () => {
+    const { default: Wrapper } = await importWrapper(
+      "highlight-auto-events",
+      `<script>
+  import HighlightAuto from "./HighlightAuto.svelte";
+  export let code;
+</script>
+<HighlightAuto {code} let:events>{@html JSON.stringify(events)}</HighlightAuto>
+`,
+    );
+
+    const code = "const add = (a, b) => a + b;";
+    const { body } = render(Wrapper, { props: { code } });
+    const detected = registry.highlightAuto(code);
+    const expected = registry.highlight(code, {
+      language: detected.language as string,
+    }).events;
+
+    expect(body).toContain(JSON.stringify(expected));
+  });
+
+  it("HighlightSvelte", async () => {
+    const { default: Wrapper } = await importWrapper(
+      "highlight-svelte-events",
+      `<script>
+  import HighlightSvelte from "./HighlightSvelte.svelte";
+  export let code;
+</script>
+<HighlightSvelte {code} let:events>{@html JSON.stringify(events)}</HighlightSvelte>
+`,
+    );
+
+    const code =
+      "<script>\n  let count = 0;\n<\\/script>\n<button>{count}</button>\n";
+    const { body } = render(Wrapper, { props: { code } });
+    const expected = registry.highlight(code, { language: "svelte" }).events;
+
+    expect(body).toContain(JSON.stringify(expected));
+  });
+});

--- a/tests/token-lines.test.ts
+++ b/tests/token-lines.test.ts
@@ -1,0 +1,222 @@
+/**
+ * Invariants for `tokenLines`, the line-indexed structured alternative to
+ * `splitLines(renderHtml(events))`, plus the `Renderer` factories that wrap
+ * it (and `renderHtml`/`toRanges`) as named conforming peers.
+ */
+import type {
+  LineToken,
+  Renderer,
+  ScopeEvent,
+  TokenRange,
+} from "../src/engine.d.ts";
+import {
+  CLOSE,
+  createHtmlRenderer,
+  createLineRenderer,
+  createRangeRenderer,
+  createRegistry,
+  OPEN,
+  registerAll,
+  renderHtml,
+  TEXT,
+  tokenLines,
+  toRanges,
+} from "../src/engine.js";
+import * as languages from "../src/languages/index.js";
+import { splitLines } from "../src/split-lines.js";
+import { CUSTOM_SNIPPETS } from "./differential-corpus.ts";
+
+const registry = createRegistry();
+for (const language of Object.values(languages)) {
+  registerAll(registry, language);
+}
+
+// biome-ignore lint/suspicious/noTemplateCurlyInString: literal JS source text being tokenized, not a template placeholder
+const JS_TEMPLATE_LITERAL = "const x = `foo ${bar} baz`;\nconsole.log(x);\n";
+
+const HTML_EMBEDDED_JS = "<script>\nconst x = 1;\n<\\/script>\n";
+
+// Custom-grammar snippets from the differential corpus give broad,
+// feature-dense coverage across ~40 languages for free.
+const CORPUS: Record<string, string> = {
+  javascript: JS_TEMPLATE_LITERAL,
+  html: HTML_EMBEDDED_JS,
+  ...CUSTOM_SNIPPETS,
+};
+
+function eventsFor(language: string, code: string): ScopeEvent[] {
+  return registry.tokenize(code, language).events;
+}
+
+function joinLines(lines: LineToken[][]): string {
+  return lines
+    .map((line) => line.map((token) => token.text).join(""))
+    .join("\n");
+}
+
+describe("tokenLines: losslessness (joined token text reproduces the source)", () => {
+  for (const [language, code] of Object.entries(CORPUS)) {
+    it(language, () => {
+      const events = eventsFor(language, code);
+      expect(joinLines(tokenLines(events))).toBe(code);
+    });
+  }
+});
+
+describe("tokenLines: line-count parity with splitLines(renderHtml(events))", () => {
+  for (const [language, code] of Object.entries(CORPUS)) {
+    it(language, () => {
+      const events = eventsFor(language, code);
+      expect(tokenLines(events).length).toBe(
+        splitLines(renderHtml(events)).length,
+      );
+    });
+  }
+});
+
+describe("tokenLines: scope correctness", () => {
+  it("a template literal with interpolation nests the `subst` scope inside `string`", () => {
+    const events = eventsFor("javascript", JS_TEMPLATE_LITERAL);
+    const lines = tokenLines(events);
+
+    expect(lines[0]).toEqual([
+      { text: "const", scopes: ["keyword"] },
+      { text: " x = ", scopes: [] },
+      { text: "`foo ", scopes: ["string"] },
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: the literal token text, not a template placeholder
+      { text: "${bar}", scopes: ["string", "subst"] },
+      { text: " baz`", scopes: ["string"] },
+      { text: ";", scopes: [] },
+    ]);
+  });
+
+  it("an embedded sub-language nests its scopes under `language:<name>`", () => {
+    const events = eventsFor("html", HTML_EMBEDDED_JS);
+    const lines = tokenLines(events);
+
+    expect(lines[0]).toEqual([
+      { text: "<", scopes: ["tag"] },
+      { text: "script", scopes: ["tag", "name"] },
+      { text: ">", scopes: ["tag"] },
+    ]);
+    expect(lines[1]).toEqual([
+      { text: "const", scopes: ["language:javascript", "keyword"] },
+      { text: " x = ", scopes: ["language:javascript"] },
+      { text: "1", scopes: ["language:javascript", "number"] },
+      { text: ";", scopes: ["language:javascript"] },
+    ]);
+  });
+
+  it("scope names are raw, unprefixed strings (no hljs- prefix)", () => {
+    const events = eventsFor("javascript", JS_TEMPLATE_LITERAL);
+    for (const line of tokenLines(events)) {
+      for (const token of line) {
+        for (const scope of token.scopes) {
+          expect(scope.startsWith("hljs-")).toBe(false);
+        }
+      }
+    }
+  });
+});
+
+describe("tokenLines: edge cases", () => {
+  it('empty events array is a single empty line, matching splitLines("")', () => {
+    expect(tokenLines([])).toEqual([[]]);
+    expect(tokenLines([]).length).toBe(splitLines(renderHtml([])).length);
+  });
+
+  it("a single newline produces two empty lines", () => {
+    const events: ScopeEvent[] = [{ t: TEXT, v: "\n" }];
+    expect(tokenLines(events)).toEqual([[], []]);
+    expect(tokenLines(events).length).toBe(
+      splitLines(renderHtml(events)).length,
+    );
+  });
+
+  it("a trailing newline produces a trailing empty line", () => {
+    const events: ScopeEvent[] = [{ t: TEXT, v: "a\n" }];
+    expect(tokenLines(events)).toEqual([[{ text: "a", scopes: [] }], []]);
+    expect(tokenLines(events).length).toBe(
+      splitLines(renderHtml(events)).length,
+    );
+  });
+
+  it("CRLF: the CR lands on the preceding line's trailing token, matching splitLines", () => {
+    const events: ScopeEvent[] = [{ t: TEXT, v: "a\r\nb" }];
+    expect(tokenLines(events)).toEqual([
+      [{ text: "a\r", scopes: [] }],
+      [{ text: "b", scopes: [] }],
+    ]);
+    expect(tokenLines(events).length).toBe(
+      splitLines(renderHtml(events)).length,
+    );
+    expect(joinLines(tokenLines(events))).toBe("a\r\nb");
+  });
+
+  it("a line with no tokens between two full lines is an empty array", () => {
+    const events: ScopeEvent[] = [
+      { t: TEXT, v: "a\n" },
+      { t: OPEN, s: "keyword" },
+      { t: TEXT, v: "b" },
+      { t: CLOSE },
+      { t: TEXT, v: "\nc" },
+    ];
+    const lines = tokenLines(events);
+    expect(lines).toEqual([
+      [{ text: "a", scopes: [] }],
+      [{ text: "b", scopes: ["keyword"] }],
+      [{ text: "c", scopes: [] }],
+    ]);
+  });
+
+  it("adjacent text under an identical scope stack may be merged into one token", () => {
+    const events: ScopeEvent[] = [
+      { t: OPEN, s: "keyword" },
+      { t: TEXT, v: "foo" },
+      { t: TEXT, v: "bar" },
+      { t: CLOSE },
+    ];
+    expect(tokenLines(events)).toEqual([
+      [{ text: "foobar", scopes: ["keyword"] }],
+    ]);
+  });
+
+  it("zero-length tokens are never emitted", () => {
+    const events: ScopeEvent[] = [
+      { t: TEXT, v: "" },
+      { t: OPEN, s: "keyword" },
+      { t: TEXT, v: "" },
+      { t: CLOSE },
+      { t: TEXT, v: "a" },
+    ];
+    expect(tokenLines(events)).toEqual([[{ text: "a", scopes: [] }]]);
+  });
+});
+
+describe("Renderer factories", () => {
+  const events = eventsFor("javascript", JS_TEMPLATE_LITERAL);
+
+  it("createHtmlRenderer matches renderHtml", () => {
+    const renderer: Renderer<string> = createHtmlRenderer();
+    expect(renderer.render(events)).toBe(renderHtml(events));
+  });
+
+  it("createHtmlRenderer forwards options to renderHtml", () => {
+    const renderer: Renderer<string> = createHtmlRenderer({
+      classPrefix: "x-",
+    });
+    expect(renderer.render(events)).toBe(
+      renderHtml(events, { classPrefix: "x-" }),
+    );
+  });
+
+  it("createRangeRenderer matches toRanges", () => {
+    const renderer: Renderer<TokenRange[]> = createRangeRenderer();
+    expect(renderer.render(events)).toEqual(toRanges(events));
+  });
+
+  it("createLineRenderer matches tokenLines", () => {
+    const renderer: Renderer<LineToken[][]> = createLineRenderer();
+    expect(renderer.render(events)).toEqual(tokenLines(events));
+  });
+});


### PR DESCRIPTION
The engine rewrite produces a flat scope-event stream internally,
where HTML and CSS Custom Highlight ranges are just two renderers
over the same events. That stream was entirely private, though.
Components only ever exposed the final HTML string, so anything
needing structured tokens (line-indexed views, custom render
targets, headless or server-side highlighting) had to re-parse
that HTML string by hand.

This promotes the event stream to a documented, semver-stable
public API: a new `svelte-highlight/engine` subpath, a new
`svelte-highlight/registry` subpath for joining the components'
shared language registry, a `tokenLines` primitive for
line-indexed `{ text, scopes }` tokens, and a `Renderer<Out>`
interface naming the existing render targets as conforming peers.
`Highlight`, `HighlightAuto`, and `HighlightSvelte` also expose
the event stream via slot prop and event detail, so component
users can reach it without re-parsing HTML. The change is
additive only; no existing export or component behavior changes.

## Risk

Low blast radius: no existing code paths change, only new exports
and an additive slot prop/event field are added. The main
ongoing cost is the stability contract itself, the documented
`Snapshot` and `GrammarIR` tiers constrain how those internals can
change in future engine work.