### PR TITLE
feat(theme): add defineTheme, extendTheme, and a TextMate importer

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,6 +159,85 @@ Variable names are derived mechanically from the selectors found in `highlight.j
 
 `base.css` assumes the default `hljs-` class prefix; projects using a custom `classPrefix` should stay on the legacy string path below.
 
+### Creating themes
+
+`svelte-highlight/theme` exports a typed, programmatic way to build or derive `ThemePalette` objects, instead of hand-writing `--shl-*` vars against the full scope vocabulary.
+
+**`defineTheme()`** builds a complete palette from a small typed definition: a ~14-key **semantic role** layer (pick a dozen colors, get a full theme) plus optional per-scope precision overrides.
+
+```js
+import { defineTheme } from "svelte-highlight/theme";
+
+const midnight = defineTheme({
+  name: "midnight",
+  roles: {
+    background: "#0b1021",
+    foreground: "#d6deeb",
+    comment: { color: "#637777", fontStyle: "italic" },
+    keyword: "#c792ea",
+    string: "#ecc48d",
+    literal: "#f78c6c",
+    function: "#82aaff",
+    type: "#ffcb8b",
+    variable: "#addb67",
+    tag: "#7fdbca",
+  },
+  scopes: {
+    "title.class_": "#ffd700", // per-scope precision on top of roles
+    "meta keyword": "#5f7e97",
+  },
+});
+```
+
+```svelte
+<HighlightStyle theme={midnight}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>
+```
+
+`roles` are `foreground`, `background`, `comment`, `keyword`, `string`, `literal`, `function`, `type`, `variable`, `property`, `tag`, `punctuation`, `meta`, `addition`, `deletion` — each expands to a documented set of `--shl-*` scope vars. A bare string is shorthand for `{ color: string }`; both roles and `scopes` also accept a `{ color, background, fontStyle, fontWeight, textDecoration }` object. Precedence is `extends` palette vars → `roles` → `scopes` (later layers win per-var, not per-role). `foreground`/`background` are required unless `extends` is given.
+
+**`extendTheme()`** derives a new palette from any shipped or user palette with role- or scope-level overrides:
+
+```js
+import atomOneDark from "svelte-highlight/themes/atom-one-dark";
+import { extendTheme } from "svelte-highlight/theme";
+
+const branded = extendTheme(atomOneDark, {
+  name: "atom-one-dark-branded",
+  roles: { keyword: "#ff79c6" },
+});
+```
+
+**`paletteToCss()`** emits any palette as a CSS string — for build-time/global CSS instead of the `HighlightStyle` component:
+
+```js
+import { paletteToCss } from "svelte-highlight/theme";
+
+writeFileSync("public/midnight.css", paletteToCss(midnight));
+```
+
+`defineTheme` output is a plain `ThemePalette` — spreadable, serializable, diffable, and valid everywhere shipped palettes work, per [Themes are data](#theming) above.
+
+### Importing VS Code themes
+
+`svelte-highlight/theme/textmate` imports VS Code / TextMate theme JSON (thousands of existing editor themes) into a `ThemePalette`:
+
+```js
+import { fromTextMate } from "svelte-highlight/theme/textmate";
+import nightOwl from "./night-owl-color-theme.json" with { type: "json" };
+
+const palette = fromTextMate(nightOwl);
+```
+
+`fromTextMate` accepts a **parsed object** only — VS Code themes are often JSONC, so parsing is the caller's job. The scope mapping is best-effort: TextMate scope selectors are matched against a starter table by segment-prefix (`"entity.name.function"` matches `"entity.name.function.method.ts"`), with the most specific (longest) match winning ties broken by the later `tokenColors` entry — the same specificity semantics VS Code itself uses. Entries that don't map to anything are never silently dropped; pass `onWarn` to observe them:
+
+```js
+const palette = fromTextMate(nightOwl, {
+  onWarn: (message) => console.warn(message),
+});
+```
+
 ## Styling
 
 Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility.

--- a/scripts/build-themes.ts
+++ b/scripts/build-themes.ts
@@ -1,6 +1,7 @@
 import type { Declaration } from "postcss";
 import postcss from "postcss";
 import { scopeSelectors } from "../src/scoped.js";
+import { serializeVars } from "../src/theme-vars.js";
 import type { ThemeInput } from "./build-styles.ts";
 import { createMarkdown } from "./utils/create-markdown.ts";
 import {
@@ -59,13 +60,6 @@ type ThemeReportEntry = {
 
 function declText(decls: Declaration[]): string {
   return decls.map((d) => `${d.prop}:${d.value}`).join(";");
-}
-
-function serializeVars(vars: Map<string, string>): string {
-  return [...vars.entries()]
-    .sort(([a], [b]) => a.localeCompare(b))
-    .map(([key, value]) => `${key}:${value}`)
-    .join(";");
 }
 
 function processTheme(

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -67,6 +67,11 @@ pkgJson.exports = {
   },
   "./theme": {
     types: "./theme.d.ts",
+    default: "./theme.js",
+  },
+  "./theme/textmate": {
+    types: "./textmate-theme.d.ts",
+    default: "./textmate-theme.js",
   },
   "./languages": {
     types: "./languages/index.d.ts",

--- a/scripts/utils/theme-ir.ts
+++ b/scripts/utils/theme-ir.ts
@@ -9,22 +9,21 @@
  * - `.hljs-<a>.<b>[.<c>...]` — compound (no combinator between parts; the
  *   first part must be `hljs-`-prefixed, later parts may or may not be).
  * - `.hljs-<a> .hljs-<b>` — descendant (exactly two levels).
+ *
+ * The `--shl-*` var-name derivation itself (`varName`, `colorSchemeFor`,
+ * ...) lives in `src/theme-vars.js`, shared with the runtime
+ * theme-authoring API (`src/theme.js`) — re-exported here so existing
+ * importers of this module are unaffected.
  */
 
-const SHL_PREFIX = "--shl-";
+import {
+  SUPPORTED_PROPERTIES,
+  colorSchemeFor,
+  parseColorToRgb,
+  varName,
+} from "../../src/theme-vars.js";
 
-/** CSS property -> `--shl-*` name suffix. `""` means no suffix (color is
- * the dominant, unsuffixed case). Only these properties fit the var
- * contract; anything else is routed to extras. */
-const PROP_SUFFIX: Record<string, string> = {
-  color: "",
-  "background-color": "bg",
-  "font-style": "font-style",
-  "font-weight": "font-weight",
-  "text-decoration": "text-decoration",
-};
-
-export const SUPPORTED_PROPERTIES = new Set(Object.keys(PROP_SUFFIX));
+export { colorSchemeFor, parseColorToRgb, varName, SUPPORTED_PROPERTIES };
 
 /** `background` is normalized to `background-color` — one property per
  * rule in the IR, regardless of which shorthand/longhand a theme used. */
@@ -91,18 +90,6 @@ export function subjectScope(shape: SelectorShape): string[] | null {
   return null;
 }
 
-/** `null` when `property` isn't part of the var contract. */
-export function varName(scopes: string[], property: string): string | null {
-  const suffix = PROP_SUFFIX[property];
-  if (suffix === undefined) return null;
-  if (scopes.length === 0) {
-    const base = suffix === "" ? "fg" : suffix === "bg" ? "bg" : suffix;
-    return `${SHL_PREFIX}${base}`;
-  }
-  const joined = scopes.join("-");
-  return `${SHL_PREFIX}${suffix === "" ? joined : `${joined}-${suffix}`}`;
-}
-
 const SIMPLE_COLOR_VALUE =
   /^(#[0-9a-fA-F]{3,8}|rgba?\([^()]*\)|hsla?\([^()]*\)|[a-zA-Z]+)$/;
 
@@ -114,59 +101,4 @@ const SIMPLE_COLOR_VALUE =
  */
 export function isSimpleColorValue(value: string): boolean {
   return SIMPLE_COLOR_VALUE.test(value.trim());
-}
-
-const NAMED_COLORS: Record<string, [number, number, number]> = {
-  black: [0, 0, 0],
-  white: [255, 255, 255],
-  gold: [255, 215, 0],
-  navy: [0, 0, 128],
-};
-
-/** Best-effort color parse for `colorScheme` inference; not a general CSS
- * color parser (hex + rgb()/rgba() + the handful of named colors themes
- * actually use are all that's needed here). */
-export function parseColorToRgb(
-  value: string,
-): [number, number, number] | null {
-  const v = value.trim().toLowerCase();
-  const named = NAMED_COLORS[v];
-  if (named) return named;
-
-  const hex3 = /^#([0-9a-f]{3})$/.exec(v);
-  if (hex3?.[1]) {
-    const digits = hex3[1];
-    return [0, 1, 2].map((i) => {
-      const ch = digits[i] as string;
-      return Number.parseInt(ch + ch, 16);
-    }) as [number, number, number];
-  }
-
-  const hex6 = /^#([0-9a-f]{6})[0-9a-f]{0,2}$/.exec(v);
-  if (hex6?.[1]) {
-    const hex = hex6[1];
-    return [0, 2, 4].map((i) => Number.parseInt(hex.slice(i, i + 2), 16)) as [
-      number,
-      number,
-      number,
-    ];
-  }
-
-  const rgb = /^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/.exec(v);
-  if (rgb?.[1] && rgb[2] && rgb[3]) {
-    return [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])];
-  }
-
-  return null;
-}
-
-/** Falls back to `"light"` when `bgValue` is missing or unparseable — a
- * theme whose background never resolved to a var (e.g. a gradient) still
- * needs *some* metadata value. */
-export function colorSchemeFor(bgValue: string | undefined): "light" | "dark" {
-  const rgb = bgValue ? parseColorToRgb(bgValue) : null;
-  if (!rgb) return "light";
-  const [r, g, b] = rgb;
-  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
-  return luminance > 0.5 ? "light" : "dark";
 }

--- a/scripts/utils/theme-ir.ts
+++ b/scripts/utils/theme-ir.ts
@@ -17,13 +17,13 @@
  */
 
 import {
-  SUPPORTED_PROPERTIES,
   colorSchemeFor,
   parseColorToRgb,
+  SUPPORTED_PROPERTIES,
   varName,
 } from "../../src/theme-vars.js";
 
-export { colorSchemeFor, parseColorToRgb, varName, SUPPORTED_PROPERTIES };
+export { colorSchemeFor, parseColorToRgb, SUPPORTED_PROPERTIES, varName };
 
 /** `background` is normalized to `background-color` — one property per
  * rule in the IR, regardless of which shorthand/longhand a theme used. */

--- a/src/textmate-theme.d.ts
+++ b/src/textmate-theme.d.ts
@@ -1,0 +1,41 @@
+import type { ThemePalette } from "./theme.d.ts";
+
+export interface TextMateTokenColor {
+  scope?: string | string[];
+  settings: {
+    foreground?: string;
+    background?: string;
+    fontStyle?: string;
+  };
+}
+
+/** A parsed VS Code / TextMate theme JSON object. JSONC parsing (comments,
+ * trailing commas) is the caller's job — `fromTextMate` accepts plain
+ * objects only. */
+export interface TextMateTheme {
+  name?: string;
+  type?: "light" | "dark" | string;
+  /** VS Code workbench colors, e.g. `"editor.foreground"`. */
+  colors?: Record<string, string>;
+  tokenColors?: TextMateTokenColor[];
+}
+
+export interface FromTextMateOptions {
+  /** Called once per unmappable or unsupported `tokenColors` entry —
+   * scopes with no starter-table match, and descendant (space-separated)
+   * selectors, which aren't supported. Unmappable entries are never
+   * silently dropped. */
+  onWarn?: (message: string) => void;
+}
+
+/**
+ * Import a VS Code / TextMate theme into a `ThemePalette`. Scope selectors
+ * match by segment-prefix (`"entity.name.function"` matches
+ * `"entity.name.function.method.ts"`); when multiple `tokenColors`
+ * entries match the same hljs target, the most specific (longest
+ * matching) selector wins, ties going to the later entry.
+ */
+export function fromTextMate(
+  theme: TextMateTheme,
+  options?: FromTextMateOptions,
+): ThemePalette;

--- a/src/textmate-theme.js
+++ b/src/textmate-theme.js
@@ -1,0 +1,211 @@
+/**
+ * Import VS Code / TextMate theme JSON (a parsed object — JSONC parsing is
+ * the caller's job) into a `ThemePalette`.
+ *
+ * @typedef {import("./textmate-theme.d.ts").TextMateTheme} TextMateTheme
+ * @typedef {import("./textmate-theme.d.ts").TextMateTokenColor} TextMateTokenColor
+ * @typedef {import("./textmate-theme.d.ts").FromTextMateOptions} FromTextMateOptions
+ * @typedef {import("./theme.d.ts").ThemePalette} ThemePalette
+ * @typedef {import("./theme.d.ts").TokenStyle} TokenStyle
+ */
+
+import {
+  applyTokenStyle,
+  colorSchemeFor,
+  parseScopeKey,
+  varName,
+} from "./theme-vars.js";
+
+const DEFAULT_NAME = "custom-theme";
+const WHITESPACE_RUN = /\s+/;
+const HAS_WHITESPACE = /\s/;
+
+/**
+ * TextMate scope prefix -> hljs target scope key (in the same
+ * dot/space-separated grammar `defineTheme`'s `scopes` option uses).
+ * Starter table — extend if a well-known scope is obviously missing.
+ * @type {Array<[string, string]>}
+ */
+const STARTER_TABLE = [
+  ["comment", "comment"],
+  ["string", "string"],
+  ["string.regexp", "regexp"],
+  ["constant.numeric", "number"],
+  ["constant.language", "literal"],
+  ["constant.character.escape", "string"],
+  ["constant.other", "symbol"],
+  ["keyword", "keyword"],
+  ["keyword.operator", "operator"],
+  ["storage.type", "keyword"],
+  ["storage.modifier", "keyword"],
+  ["entity.name.function", "title.function_"],
+  ["support.function", "title.function_"],
+  ["entity.name.type", "title.class_"],
+  ["entity.name.class", "title.class_"],
+  ["support.type", "title.class_"],
+  ["support.class", "title.class_"],
+  ["entity.name.tag", "tag"],
+  ["entity.other.attribute-name", "attr"],
+  ["variable", "variable"],
+  ["variable.other", "variable"],
+  ["variable.parameter", "params"],
+  ["variable.language", "variable.language_"],
+  ["support.constant", "literal"],
+  ["punctuation", "punctuation"],
+  ["meta.preprocessor", "meta"],
+  ["markup.heading", "section"],
+  ["markup.quote", "quote"],
+  ["markup.bold", "strong"],
+  ["markup.italic", "emphasis"],
+  ["markup.underline.link", "link"],
+  ["markup.inserted", "addition"],
+  ["markup.deleted", "deletion"],
+];
+
+const STARTER_ROWS = STARTER_TABLE.map(([prefix, target]) => ({
+  segments: prefix.split("."),
+  target,
+}));
+
+/**
+ * The most specific (longest segment-prefix) starter-table row matching
+ * `scope`, or `null` if none does.
+ * @param {string} scope
+ */
+function bestMatch(scope) {
+  const segments = scope.split(".");
+  let best = /** @type {typeof STARTER_ROWS[number] | null} */ (null);
+
+  for (const row of STARTER_ROWS) {
+    if (row.segments.length > segments.length) continue;
+    let matches = true;
+    for (let i = 0; i < row.segments.length; i++) {
+      if (row.segments[i] !== segments[i]) {
+        matches = false;
+        break;
+      }
+    }
+    if (matches && (!best || row.segments.length > best.segments.length)) {
+      best = row;
+    }
+  }
+
+  return best;
+}
+
+/**
+ * @param {TextMateTokenColor["settings"] | undefined} settings
+ * @returns {TokenStyle}
+ */
+function styleFromSettings(settings) {
+  /** @type {TokenStyle} */
+  const style = {};
+  if (!settings) return style;
+  if (settings.foreground !== undefined) style.color = settings.foreground;
+  if (settings.background !== undefined) style.background = settings.background;
+  if (settings.fontStyle) {
+    const tokens = settings.fontStyle.split(WHITESPACE_RUN).filter(Boolean);
+    if (tokens.includes("italic")) style.fontStyle = "italic";
+    if (tokens.includes("bold")) style.fontWeight = "bold";
+    if (tokens.includes("underline")) style.textDecoration = "underline";
+  }
+  return style;
+}
+
+/**
+ * @param {TextMateTokenColor | undefined} entry
+ */
+function isGlobalSettingsEntry(entry) {
+  if (!entry) return false;
+  const scope = entry.scope;
+  if (scope === undefined || scope === null || scope === "") return true;
+  return Array.isArray(scope) && scope.length === 0;
+}
+
+/**
+ * @param {TextMateTheme} theme
+ * @param {FromTextMateOptions} [options]
+ * @returns {ThemePalette}
+ */
+export function fromTextMate(theme, options = {}) {
+  const onWarn = options.onWarn ?? (() => {});
+  const tokenColors = theme.tokenColors ?? [];
+  const globalEntry = tokenColors.find(isGlobalSettingsEntry);
+
+  const fg =
+    theme.colors?.["editor.foreground"] ?? globalEntry?.settings?.foreground;
+  const bg =
+    theme.colors?.["editor.background"] ?? globalEntry?.settings?.background;
+
+  if (fg === undefined) {
+    throw new Error(
+      'fromTextMate(): could not resolve a foreground color — provide colors["editor.foreground"] or a tokenColors entry with no "scope".',
+    );
+  }
+  if (bg === undefined) {
+    throw new Error(
+      'fromTextMate(): could not resolve a background color — provide colors["editor.background"] or a tokenColors entry with no "scope".',
+    );
+  }
+
+  /** @type {Record<string, string>} */
+  const vars = {};
+  vars[/** @type {string} */ (varName([], "color"))] = fg;
+  vars[/** @type {string} */ (varName([], "background-color"))] = bg;
+
+  /** @type {Map<string, number>} */
+  const winnerSpecificity = new Map();
+  /** @type {Map<string, TokenStyle>} */
+  const winnerStyle = new Map();
+
+  for (const entry of tokenColors) {
+    if (isGlobalSettingsEntry(entry)) continue;
+
+    const rawScopes = Array.isArray(entry.scope)
+      ? entry.scope
+      : (entry.scope ?? "").split(",");
+
+    for (const rawScope of rawScopes) {
+      const scope = rawScope.trim();
+      if (!scope) continue;
+
+      if (HAS_WHITESPACE.test(scope)) {
+        onWarn(
+          `fromTextMate(): skipping descendant selector "${scope}" (TextMate parent scoping isn't supported).`,
+        );
+        continue;
+      }
+
+      const match = bestMatch(scope);
+      if (!match) {
+        onWarn(`fromTextMate(): no hljs mapping for scope "${scope}".`);
+        continue;
+      }
+
+      const specificity = match.segments.length;
+      const current = winnerSpecificity.get(match.target);
+      // Later entries win ties (VS Code order semantics); iterating
+      // tokenColors in array order means an equal-specificity match seen
+      // later always overwrites the current winner.
+      if (current !== undefined && specificity < current) continue;
+
+      winnerSpecificity.set(match.target, specificity);
+      winnerStyle.set(match.target, styleFromSettings(entry.settings));
+    }
+  }
+
+  for (const [target, style] of winnerStyle) {
+    applyTokenStyle(vars, parseScopeKey(target), style);
+  }
+
+  const colorScheme =
+    theme.type === "light" || theme.type === "dark"
+      ? theme.type
+      : colorSchemeFor(bg);
+
+  return {
+    name: theme.name ?? DEFAULT_NAME,
+    colorScheme,
+    vars,
+  };
+}

--- a/src/theme-vars.js
+++ b/src/theme-vars.js
@@ -1,0 +1,205 @@
+/**
+ * Shared `--shl-*` var-name derivation. Used by both the theme build
+ * pipeline (`scripts/build-themes.ts`, via `scripts/utils/theme-ir.ts`) and
+ * the runtime theme-authoring API (`src/theme.js`, `src/textmate-theme.js`)
+ * so the two can never derive different var names for the same scope.
+ */
+
+const SHL_PREFIX = "--shl-";
+
+/** CSS property -> `--shl-*` name suffix. `""` means no suffix (color is
+ * the dominant, unsuffixed case). Only these properties fit the var
+ * contract.
+ * @type {Record<string, string>} */
+export const PROP_SUFFIX = {
+  color: "",
+  "background-color": "bg",
+  "font-style": "font-style",
+  "font-weight": "font-weight",
+  "text-decoration": "text-decoration",
+};
+
+export const SUPPORTED_PROPERTIES = new Set(Object.keys(PROP_SUFFIX));
+
+/**
+ * `null` when `property` isn't part of the var contract.
+ * @param {string[]} scopes
+ * @param {string} property
+ * @returns {string | null}
+ */
+export function varName(scopes, property) {
+  const suffix = PROP_SUFFIX[property];
+  if (suffix === undefined) return null;
+  if (scopes.length === 0) {
+    const base = suffix === "" ? "fg" : suffix === "bg" ? "bg" : suffix;
+    return `${SHL_PREFIX}${base}`;
+  }
+  const joined = scopes.join("-");
+  return `${SHL_PREFIX}${suffix === "" ? joined : `${joined}-${suffix}`}`;
+}
+
+const HAS_WHITESPACE = /\s/;
+const WHITESPACE_RUN = /\s+/;
+
+/**
+ * Parse a raw `ThemeDefinition["scopes"]` key ("keyword", "title.class_",
+ * "meta keyword") into the ordered scope segments `varName` expects — the
+ * same grouping a `.hljs-*` selector would classify into, just spelled
+ * without the `.hljs-` prefix and CSS combinators.
+ * @param {string} key
+ * @returns {string[]}
+ */
+export function parseScopeKey(key) {
+  const trimmed = key.trim();
+  if (HAS_WHITESPACE.test(trimmed)) return trimmed.split(WHITESPACE_RUN);
+  return trimmed.split(".");
+}
+
+/** @type {Record<string, [number, number, number]>} */
+const NAMED_COLORS = {
+  black: [0, 0, 0],
+  white: [255, 255, 255],
+  gold: [255, 215, 0],
+  navy: [0, 0, 128],
+};
+
+const HEX3 = /^#([0-9a-f]{3})$/;
+const HEX6 = /^#([0-9a-f]{6})[0-9a-f]{0,2}$/;
+const RGB_FUNCTION = /^rgba?\(\s*([\d.]+)[,\s]+([\d.]+)[,\s]+([\d.]+)/;
+
+/** Best-effort color parse for `colorScheme` inference; not a general CSS
+ * color parser (hex + rgb()/rgba() + the handful of named colors themes
+ * actually use are all that's needed here).
+ * @param {string} value
+ * @returns {[number, number, number] | null}
+ */
+export function parseColorToRgb(value) {
+  const v = value.trim().toLowerCase();
+  const named = NAMED_COLORS[v];
+  if (named) return named;
+
+  const hex3 = HEX3.exec(v);
+  if (hex3?.[1]) {
+    const digits = hex3[1];
+    return /** @type {[number, number, number]} */ (
+      [0, 1, 2].map((i) => {
+        const ch = /** @type {string} */ (digits[i]);
+        return Number.parseInt(ch + ch, 16);
+      })
+    );
+  }
+
+  const hex6 = HEX6.exec(v);
+  if (hex6?.[1]) {
+    const hex = hex6[1];
+    return /** @type {[number, number, number]} */ (
+      [0, 2, 4].map((i) => Number.parseInt(hex.slice(i, i + 2), 16))
+    );
+  }
+
+  const rgb = RGB_FUNCTION.exec(v);
+  if (rgb?.[1] && rgb[2] && rgb[3]) {
+    return [Number(rgb[1]), Number(rgb[2]), Number(rgb[3])];
+  }
+
+  return null;
+}
+
+/** Falls back to `"light"` when `bgValue` is missing or unparseable — a
+ * theme whose background never resolved to a var (e.g. a gradient) still
+ * needs *some* metadata value.
+ * @param {string | undefined} bgValue
+ * @returns {"light" | "dark"}
+ */
+export function colorSchemeFor(bgValue) {
+  const rgb = bgValue ? parseColorToRgb(bgValue) : null;
+  if (!rgb) return "light";
+  const [r, g, b] = rgb;
+  const luminance = (0.299 * r + 0.587 * g + 0.114 * b) / 255;
+  return luminance > 0.5 ? "light" : "dark";
+}
+
+/**
+ * `ThemeRole` -> raw hljs scope keys it writes (the taste decision from
+ * the theme-authoring design — see the role table in the theme-authoring
+ * spec). `foreground` and `background` target the base `.hljs` scope
+ * directly and are handled separately by callers. Exported so
+ * `defineTheme`'s role expansion and the role-map validation report (see
+ * `tests/theme-role-map-fidelity.test.ts`) can never drift apart.
+ * @type {Record<string, string[]>}
+ */
+export const ROLE_SCOPES = {
+  comment: ["comment", "quote"],
+  keyword: ["keyword", "doctag", "formula", "template-tag", "meta keyword"],
+  string: ["string", "regexp", "meta string"],
+  literal: ["literal", "number", "symbol", "bullet"],
+  function: ["title", "title.function_"],
+  type: ["type", "title.class_", "built_in", "class title"],
+  variable: [
+    "variable",
+    "template-variable",
+    "variable.language_",
+    "variable.constant_",
+    "params",
+  ],
+  property: [
+    "attr",
+    "attribute",
+    "property",
+    "selector-attr",
+    "selector-class",
+    "selector-id",
+    "selector-pseudo",
+  ],
+  tag: ["tag", "name", "selector-tag", "section"],
+  punctuation: ["punctuation", "operator", "subst"],
+  meta: ["meta", "meta.prompt_"],
+  addition: ["addition"],
+  deletion: ["deletion"],
+};
+
+/** `TokenStyle` field -> CSS property in the `--shl-*` var contract. Shared
+ * between `defineTheme`'s role/scope expansion and the TextMate importer so
+ * both write vars the same way. */
+export const TOKEN_STYLE_FIELD_TO_PROPERTY = {
+  color: "color",
+  background: "background-color",
+  fontStyle: "font-style",
+  fontWeight: "font-weight",
+  textDecoration: "text-decoration",
+};
+
+/**
+ * Write every set field of one `TokenStyle` into `vars`, for the given
+ * scope segments.
+ * @param {Record<string, string>} vars
+ * @param {string[]} scopes
+ * @param {import("./theme.d.ts").TokenStyle} style
+ */
+export function applyTokenStyle(vars, scopes, style) {
+  for (const [field, property] of Object.entries(
+    TOKEN_STYLE_FIELD_TO_PROPERTY,
+  )) {
+    const value =
+      style[/** @type {keyof import("./theme.d.ts").TokenStyle} */ (field)];
+    if (value === undefined) continue;
+    const vn = varName(scopes, property);
+    if (vn) vars[vn] = value;
+  }
+}
+
+/**
+ * `key:value;key2:value2` — vars sorted alphabetically. The same
+ * serialization the build uses for the generated `themes/<name>.css`
+ * artifacts, shared so `paletteToCss` output matches byte-for-byte.
+ * @param {Record<string, string> | Map<string, string>} vars
+ * @returns {string}
+ */
+export function serializeVars(vars) {
+  const entries =
+    vars instanceof Map ? [...vars.entries()] : Object.entries(vars);
+  return entries
+    .sort(([a], [b]) => a.localeCompare(b))
+    .map(([key, value]) => `${key}:${value}`)
+    .join(";");
+}

--- a/src/theme.d.ts
+++ b/src/theme.d.ts
@@ -16,3 +16,89 @@ export interface ThemePalette {
    * palette-object) path. */
   extras?: string;
 }
+
+/** One scope's styling. A bare `string` (in `ThemeDefinition`) is shorthand
+ * for `{ color: string }`. */
+export interface TokenStyle {
+  color?: string;
+  background?: string;
+  fontStyle?: "italic" | "normal";
+  fontWeight?: string;
+  textDecoration?: string;
+}
+
+/** The ~14-key semantic layer `defineTheme()`'s `roles` expand into a full
+ * set of `--shl-*` scope variables. See the role -> scope table in
+ * `src/theme.js`. */
+export type ThemeRole =
+  | "foreground"
+  | "background"
+  | "comment"
+  | "keyword"
+  | "string"
+  | "literal"
+  | "function"
+  | "type"
+  | "variable"
+  | "property"
+  | "tag"
+  | "punctuation"
+  | "meta"
+  | "addition"
+  | "deletion";
+
+export interface ThemeDefinition {
+  /** Theme name, matching `svelte-highlight/styles/<name>`. Default
+   * `"custom-theme"`. */
+  name?: string;
+  /** Default: inferred from the resolved background's luminance. */
+  colorScheme?: "light" | "dark";
+  /** Start from an existing palette's vars (any shipped or user
+   * `ThemePalette`). */
+  extends?: ThemePalette;
+  /** Semantic roles, expanded to `--shl-*` scope variables via a
+   * documented mapping table. */
+  roles?: Partial<Record<ThemeRole, string | TokenStyle>>;
+  /** Raw hljs scope keys for per-scope precision on top of `roles` — e.g.
+   * `"title.function_"` (compound, dot-separated) or `"meta keyword"`
+   * (descendant, space-separated). */
+  scopes?: Record<string, string | TokenStyle>;
+}
+
+/**
+ * Build a complete `ThemePalette` from a small typed definition: a
+ * semantic `roles` layer (pick a dozen colors, get a full theme) plus
+ * optional per-scope `scopes` overrides.
+ *
+ * Precedence (low -> high): `extends` palette vars -> `roles` expansion ->
+ * `scopes` overrides. `foreground`/`background` roles are required when
+ * `extends` is omitted.
+ */
+export function defineTheme(definition: ThemeDefinition): ThemePalette;
+
+/**
+ * Derive a new palette from any shipped or user palette with role- or
+ * scope-level overrides. Equivalent to
+ * `defineTheme({ ...overrides, extends: base })`.
+ */
+export function extendTheme(
+  base: ThemePalette,
+  overrides: Omit<ThemeDefinition, "extends">,
+): ThemePalette;
+
+export interface PaletteToCssOptions {
+  /** CSS selector for the scoped block. Default `[data-shl-theme="<name>"]`. */
+  selector?: string;
+  /** Whether to also emit a `:root { … }` block. Default `true`. */
+  root?: boolean;
+}
+
+/**
+ * Emit a palette as a CSS string (`:root` and/or `[data-shl-theme=…]`
+ * blocks), matching the format of the generated `themes/<name>.css`
+ * artifacts. Includes `extras` verbatim when present.
+ */
+export function paletteToCss(
+  palette: ThemePalette,
+  options?: PaletteToCssOptions,
+): string;

--- a/src/theme.js
+++ b/src/theme.js
@@ -1,0 +1,130 @@
+/**
+ * Programmatic theme authoring on top of the `ThemePalette` format:
+ * `defineTheme()` builds a complete palette from a small typed
+ * `roles`/`scopes` definition, `extendTheme()` derives a palette from an
+ * existing one, and `paletteToCss()` emits any palette as static CSS.
+ *
+ * @typedef {import("./theme.d.ts").ThemePalette} ThemePalette
+ * @typedef {import("./theme.d.ts").ThemeDefinition} ThemeDefinition
+ * @typedef {import("./theme.d.ts").TokenStyle} TokenStyle
+ * @typedef {import("./theme.d.ts").PaletteToCssOptions} PaletteToCssOptions
+ */
+
+import {
+  ROLE_SCOPES,
+  applyTokenStyle,
+  colorSchemeFor,
+  parseScopeKey,
+  serializeVars,
+  varName,
+} from "./theme-vars.js";
+
+const DEFAULT_NAME = "custom-theme";
+
+/**
+ * @param {string | TokenStyle} value
+ * @returns {TokenStyle}
+ */
+function normalizeStyle(value) {
+  return typeof value === "string" ? { color: value } : value;
+}
+
+/**
+ * Build a complete `ThemePalette` from a `ThemeDefinition`. Precedence
+ * (low -> high): `extends` palette vars -> `roles` expansion -> `scopes`
+ * overrides.
+ * @param {ThemeDefinition} definition
+ * @returns {ThemePalette}
+ */
+export function defineTheme(definition) {
+  const roles = definition.roles ?? {};
+
+  if (!definition.extends) {
+    if (roles.foreground === undefined) {
+      throw new Error(
+        'defineTheme(): "roles.foreground" is required when no "extends" palette is given.',
+      );
+    }
+    if (roles.background === undefined) {
+      throw new Error(
+        'defineTheme(): "roles.background" is required when no "extends" palette is given.',
+      );
+    }
+  }
+
+  /** @type {Record<string, string>} */
+  const vars = definition.extends ? { ...definition.extends.vars } : {};
+
+  for (const [role, rawValue] of Object.entries(roles)) {
+    if (rawValue === undefined) continue;
+    const style = normalizeStyle(rawValue);
+
+    if (role === "foreground") {
+      if (style.color !== undefined) {
+        vars[/** @type {string} */ (varName([], "color"))] = style.color;
+      }
+      continue;
+    }
+    if (role === "background") {
+      if (style.color !== undefined) {
+        vars[/** @type {string} */ (varName([], "background-color"))] =
+          style.color;
+      }
+      continue;
+    }
+
+    const scopeKeys = ROLE_SCOPES[role];
+    if (!scopeKeys) continue;
+    for (const scopeKey of scopeKeys) {
+      applyTokenStyle(vars, parseScopeKey(scopeKey), style);
+    }
+  }
+
+  for (const [scopeKey, rawValue] of Object.entries(definition.scopes ?? {})) {
+    applyTokenStyle(vars, parseScopeKey(scopeKey), normalizeStyle(rawValue));
+  }
+
+  const colorScheme =
+    definition.colorScheme ?? colorSchemeFor(vars["--shl-bg"]);
+
+  /** @type {ThemePalette} */
+  const palette = {
+    name: definition.name ?? DEFAULT_NAME,
+    colorScheme,
+    vars,
+  };
+  if (definition.extends?.extras !== undefined) {
+    palette.extras = definition.extends.extras;
+  }
+  return palette;
+}
+
+/**
+ * Derive a new palette from any shipped or user palette with role- or
+ * scope-level overrides.
+ * @param {ThemePalette} base
+ * @param {Omit<ThemeDefinition, "extends">} overrides
+ * @returns {ThemePalette}
+ */
+export function extendTheme(base, overrides) {
+  return defineTheme({ ...overrides, extends: base });
+}
+
+/**
+ * Emit a palette as a CSS string, matching the format of the generated
+ * `themes/<name>.css` artifacts.
+ * @param {ThemePalette} palette
+ * @param {PaletteToCssOptions} [options]
+ * @returns {string}
+ */
+export function paletteToCss(palette, options = {}) {
+  const root = options.root ?? true;
+  const selector = options.selector ?? `[data-shl-theme="${palette.name}"]`;
+  const varsCss = serializeVars(palette.vars);
+
+  let css = "";
+  if (root) css += `:root{${varsCss}}`;
+  css += `${selector}{${varsCss}}`;
+  if (palette.extras) css += palette.extras;
+  return css;
+}

--- a/src/theme.js
+++ b/src/theme.js
@@ -11,10 +11,10 @@
  */
 
 import {
-  ROLE_SCOPES,
   applyTokenStyle,
   colorSchemeFor,
   parseScopeKey,
+  ROLE_SCOPES,
   serializeVars,
   varName,
 } from "./theme-vars.js";

--- a/tests/differential-allowlist.ts
+++ b/tests/differential-allowlist.ts
@@ -40,10 +40,4 @@ export interface RealFileAllowlistEntry {
   reason: string;
 }
 
-export const REAL_FILE_ALLOWLIST: RealFileAllowlistEntry[] = [
-  {
-    path: "README.md",
-    reason:
-      "Nested xml-embedding depth mismatch for inline HTML that appears inside a markdown heading whose emphasis span never closes (e.g. a heading with a `` `--shl-*` `` code span, per tests/markdown-embedded-sublanguage-leak.test.ts's header comment): hljs and this engine agree on the outer section/emphasis nesting but disagree on how many times the inline-HTML-embeds-as-xml rule re-applies within it. This is a markdown grammar-conversion fidelity gap (src/languages/markdown.js's rule set for that nested context), not the Tokenizer.subContinuations cross-occurrence leak fixed alongside this entry - that leak is what previously caused *this same* README divergence for a different reason; the heading/emphasis gap is a separate, still-open issue newly exposed by (not caused by) added README content. Root-cause fix belongs in the markdown grammar conversion, out of scope here.",
-  },
-];
+export const REAL_FILE_ALLOWLIST: RealFileAllowlistEntry[] = [];

--- a/tests/textmate-theme.test.ts
+++ b/tests/textmate-theme.test.ts
@@ -1,0 +1,230 @@
+import { fromTextMate } from "../src/textmate-theme.js";
+
+describe("fromTextMate", () => {
+  it("resolves fg/bg from colors[editor.foreground/background]", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [],
+    });
+    expect(palette.vars["--shl-fg"]).toBe("#eee");
+    expect(palette.vars["--shl-bg"]).toBe("#111");
+  });
+
+  it("falls back to the global (no-scope) tokenColors settings entry for fg/bg", () => {
+    const palette = fromTextMate({
+      tokenColors: [
+        { settings: { foreground: "#aaa", background: "#222" } },
+        { scope: "keyword", settings: { foreground: "#f0f" } },
+      ],
+    });
+    expect(palette.vars["--shl-fg"]).toBe("#aaa");
+    expect(palette.vars["--shl-bg"]).toBe("#222");
+  });
+
+  it("prefers colors[] over the global tokenColors entry when both are present", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [{ settings: { foreground: "#aaa", background: "#222" } }],
+    });
+    expect(palette.vars["--shl-fg"]).toBe("#eee");
+    expect(palette.vars["--shl-bg"]).toBe("#111");
+  });
+
+  it("throws a descriptive error when foreground can't be resolved", () => {
+    expect(() =>
+      fromTextMate({
+        colors: { "editor.background": "#111" },
+        tokenColors: [],
+      }),
+    ).toThrow(/foreground/);
+  });
+
+  it("throws a descriptive error when background can't be resolved", () => {
+    expect(() =>
+      fromTextMate({
+        colors: { "editor.foreground": "#eee" },
+        tokenColors: [],
+      }),
+    ).toThrow(/background/);
+  });
+
+  it("matches scope selectors by segment-prefix", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        {
+          scope: "entity.name.function.method.ts",
+          settings: { foreground: "#0af" },
+        },
+      ],
+    });
+    expect(palette.vars["--shl-title-function_"]).toBe("#0af");
+  });
+
+  it("resolves a specificity conflict in favor of the longest matching selector", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        { scope: "entity.name", settings: { foreground: "#111111" } },
+        { scope: "entity.name.function", settings: { foreground: "#222222" } },
+      ],
+    });
+    // "entity.name" alone isn't in the starter table, so only the more
+    // specific "entity.name.function" row should resolve.
+    expect(palette.vars["--shl-title-function_"]).toBe("#222222");
+  });
+
+  it("breaks a specificity tie in favor of the later entry (VS Code order semantics)", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        { scope: "entity.name.type", settings: { foreground: "#111111" } },
+        { scope: "entity.name.class", settings: { foreground: "#222222" } },
+      ],
+    });
+    // Both starter rows ("entity.name.type", "entity.name.class") map to
+    // "title.class_" at equal specificity (3 segments each) — the later
+    // entry wins.
+    expect(palette.vars["--shl-title-class_"]).toBe("#222222");
+  });
+
+  it("treats comma-separated scopes as individual selectors", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        { scope: "keyword, storage.type", settings: { foreground: "#c0f" } },
+      ],
+    });
+    expect(palette.vars["--shl-keyword"]).toBe("#c0f");
+  });
+
+  it("treats array scopes as individual selectors", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        {
+          scope: ["entity.name.function", "support.function"],
+          settings: { foreground: "#0af" },
+        },
+      ],
+    });
+    expect(palette.vars["--shl-title-function_"]).toBe("#0af");
+  });
+
+  it("maps fontStyle combinations to font-style/font-weight/text-decoration vars", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        {
+          scope: "comment",
+          settings: { foreground: "#666", fontStyle: "italic bold underline" },
+        },
+      ],
+    });
+    expect(palette.vars["--shl-comment-font-style"]).toBe("italic");
+    expect(palette.vars["--shl-comment-font-weight"]).toBe("bold");
+    expect(palette.vars["--shl-comment-text-decoration"]).toBe("underline");
+  });
+
+  it("surfaces warnings for tokenColors entries whose scope has no starter-table mapping", () => {
+    const warnings: string[] = [];
+    fromTextMate(
+      {
+        colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+        tokenColors: [
+          { scope: "totally.unknown.scope", settings: { foreground: "#bad" } },
+        ],
+      },
+      { onWarn: (message) => warnings.push(message) },
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/totally\.unknown\.scope/);
+  });
+
+  it("skips descendant (space-separated) selectors and surfaces a warning instead of mis-matching", () => {
+    const warnings: string[] = [];
+    const palette = fromTextMate(
+      {
+        colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+        tokenColors: [
+          {
+            scope: "source.js entity.name.function",
+            settings: { foreground: "#bad" },
+          },
+        ],
+      },
+      { onWarn: (message) => warnings.push(message) },
+    );
+    expect(palette.vars["--shl-title-function_"]).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/descendant selector/);
+  });
+
+  it("never silently drops an unmappable entry (onWarn is required to observe it, but the palette still omits it)", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        { scope: "totally.unknown.scope", settings: { foreground: "#bad" } },
+      ],
+    });
+    expect(Object.values(palette.vars)).not.toContain("#bad");
+  });
+
+  it("infers colorScheme from background luminance when type is absent", () => {
+    const dark = fromTextMate({
+      colors: { "editor.foreground": "#fff", "editor.background": "#000000" },
+      tokenColors: [],
+    });
+    const light = fromTextMate({
+      colors: { "editor.foreground": "#000", "editor.background": "#ffffff" },
+      tokenColors: [],
+    });
+    expect(dark.colorScheme).toBe("dark");
+    expect(light.colorScheme).toBe("light");
+  });
+
+  it("uses type when it's exactly 'light' or 'dark'", () => {
+    const palette = fromTextMate({
+      type: "light",
+      colors: { "editor.foreground": "#000", "editor.background": "#000000" },
+      tokenColors: [],
+    });
+    expect(palette.colorScheme).toBe("light");
+  });
+
+  it("falls back to luminance for a non-light/dark type (e.g. high-contrast)", () => {
+    const palette = fromTextMate({
+      type: "hc-black",
+      colors: { "editor.foreground": "#fff", "editor.background": "#000000" },
+      tokenColors: [],
+    });
+    expect(palette.colorScheme).toBe("dark");
+  });
+
+  it("defaults name to 'custom-theme' when the theme has none", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [],
+    });
+    expect(palette.name).toBe("custom-theme");
+  });
+
+  it("uses theme.name when present", () => {
+    const palette = fromTextMate({
+      name: "night-owl",
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [],
+    });
+    expect(palette.name).toBe("night-owl");
+  });
+
+  it("returns a plain, serializable ThemePalette", () => {
+    const palette = fromTextMate({
+      name: "night-owl",
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [{ scope: "keyword", settings: { foreground: "#f0f" } }],
+    });
+    expect(() => JSON.stringify(palette)).not.toThrow();
+    expect(JSON.parse(JSON.stringify(palette))).toEqual(palette);
+  });
+});

--- a/tests/theme-integration-ssr.test.ts
+++ b/tests/theme-integration-ssr.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Integration coverage proving `defineTheme()` output is a plain
+ * `ThemePalette` valid everywhere shipped palettes work: SSR-render
+ * `HighlightStyle` with it and assert the inline vars appear (follows the
+ * `tests/highlight-style-ssr.test.ts` compile pattern).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+import { defineTheme } from "../src/theme.js";
+
+const componentPath = path.join(
+  import.meta.dir,
+  "../src/HighlightStyle.svelte",
+);
+
+async function compileForServer() {
+  const source = fs.readFileSync(componentPath, "utf-8");
+  const { js } = compile(source, {
+    generate: "server",
+    filename: "HighlightStyle.svelte",
+  });
+
+  // Written alongside the component (not in tests/) so its relative
+  // imports (e.g. "./theme-style.js") resolve.
+  const outPath = path.join(
+    import.meta.dir,
+    "../src/.tmp-theme-integration.server.js",
+  );
+  fs.writeFileSync(outPath, js.code);
+  try {
+    return await import(pathToFileURL(outPath).href);
+  } finally {
+    fs.unlinkSync(outPath);
+  }
+}
+
+describe("defineTheme output through HighlightStyle SSR", () => {
+  it("inlines the defineTheme palette's vars with no <style>/<svelte:head> content", async () => {
+    const { default: HighlightStyle } = await compileForServer();
+
+    const midnight = defineTheme({
+      name: "midnight",
+      roles: {
+        background: "#0b1021",
+        foreground: "#d6deeb",
+        comment: { color: "#637777", fontStyle: "italic" },
+        keyword: "#c792ea",
+      },
+      scopes: { "title.class_": "#ffd700" },
+    });
+
+    const { head, body } = render(HighlightStyle, {
+      props: { theme: midnight },
+    });
+
+    expect(head).not.toContain("<style>");
+    expect(body).not.toContain("<style>");
+    expect(body).toContain("--shl-bg:#0b1021");
+    expect(body).toContain("--shl-fg:#d6deeb");
+    expect(body).toContain("--shl-comment:#637777");
+    expect(body).toContain("--shl-comment-font-style:italic");
+    expect(body).toContain("--shl-keyword:#c792ea");
+    expect(body).toContain("--shl-title-class_:#ffd700");
+  });
+});

--- a/tests/theme-role-map-fidelity.test.ts
+++ b/tests/theme-role-map-fidelity.test.ts
@@ -1,0 +1,142 @@
+/**
+ * Validation report for `defineTheme`'s role -> scope table (the taste
+ * decision documented in `src/theme-vars.js`'s `ROLE_SCOPES`): for every
+ * shipped palette, compute the best-fit role assignment (per role, the
+ * dominant color among its mapped scope vars actually present in that
+ * palette) and measure the fraction of the palette's color-scope vars that
+ * assignment exactly reconstructs.
+ *
+ * There is no hard threshold — this exists so the numbers are seen. A low
+ * median suggests the role grouping doesn't fit the shipped-theme corpus
+ * well and should prompt a follow-up look at the table, not a unilateral
+ * redesign here.
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { ROLE_SCOPES, parseScopeKey, varName } from "../src/theme-vars.js";
+import type { ThemePalette } from "../src/theme.d.ts";
+
+const THEMES_DIR = path.join(import.meta.dir, "../src/themes");
+
+const themeNames = fs
+  .readdirSync(THEMES_DIR)
+  .filter((f) => f.endsWith(".js") && f !== "index.js" && !f.startsWith("_"))
+  .map((f) => f.replace(/\.js$/, ""))
+  .sort();
+
+const NON_COLOR_SUFFIXES = [
+  "-bg",
+  "-font-style",
+  "-font-weight",
+  "-text-decoration",
+];
+
+function isColorVar(key: string): boolean {
+  return !NON_COLOR_SUFFIXES.some((suffix) => key.endsWith(suffix));
+}
+
+/** var name -> role that claims it, per `ROLE_SCOPES` plus the two
+ * base-scope roles `defineTheme` special-cases. */
+const VAR_TO_ROLE = new Map<string, string>();
+VAR_TO_ROLE.set(varName([], "color") as string, "foreground");
+VAR_TO_ROLE.set(varName([], "background-color") as string, "background");
+for (const [role, scopeKeys] of Object.entries(ROLE_SCOPES)) {
+  for (const scopeKey of scopeKeys) {
+    const vn = varName(parseScopeKey(scopeKey), "color");
+    if (vn) VAR_TO_ROLE.set(vn, role);
+  }
+}
+
+/** For each role, the most frequent value among its mapped vars that are
+ * actually present in `vars` (ties keep the first-seen value). */
+function bestFitRoleValues(vars: Record<string, string>): Map<string, string> {
+  const roleValues = new Map<string, Map<string, number>>();
+
+  for (const [vn, role] of VAR_TO_ROLE) {
+    const value = vars[vn];
+    if (value === undefined) continue;
+    let counts = roleValues.get(role);
+    if (!counts) {
+      counts = new Map();
+      roleValues.set(role, counts);
+    }
+    counts.set(value, (counts.get(value) ?? 0) + 1);
+  }
+
+  const dominant = new Map<string, string>();
+  for (const [role, counts] of roleValues) {
+    let bestValue: string | undefined;
+    let bestCount = -1;
+    for (const [value, count] of counts) {
+      if (count > bestCount) {
+        bestValue = value;
+        bestCount = count;
+      }
+    }
+    if (bestValue !== undefined) dominant.set(role, bestValue);
+  }
+  return dominant;
+}
+
+type ReportEntry = {
+  name: string;
+  reconstructed: number;
+  total: number;
+  percent: number;
+};
+
+function reconstructionReport(palette: ThemePalette): ReportEntry {
+  const dominant = bestFitRoleValues(palette.vars);
+
+  let total = 0;
+  let reconstructed = 0;
+  for (const [key, value] of Object.entries(palette.vars)) {
+    if (!isColorVar(key)) continue;
+    total++;
+    const role = VAR_TO_ROLE.get(key);
+    if (role && dominant.get(role) === value) reconstructed++;
+  }
+
+  const percent = total === 0 ? 100 : (reconstructed / total) * 100;
+  return { name: palette.name, reconstructed, total, percent };
+}
+
+describe("defineTheme role-map validation report", () => {
+  it("computes and reports role-reconstruction fidelity for every shipped theme", async () => {
+    const modules = (await Promise.all(
+      themeNames.map((name) => import(path.join(THEMES_DIR, `${name}.js`))),
+    )) as Array<{ default: ThemePalette }>;
+    const entries = modules.map((mod) => reconstructionReport(mod.default));
+
+    expect(entries).toHaveLength(themeNames.length);
+    for (const entry of entries) {
+      expect(entry.percent).toBeGreaterThanOrEqual(0);
+      expect(entry.percent).toBeLessThanOrEqual(100);
+    }
+
+    const sorted = [...entries].sort((a, b) => a.percent - b.percent);
+    const mid = Math.floor(sorted.length / 2);
+    const median =
+      sorted.length % 2 === 0
+        ? ((sorted[mid - 1]?.percent ?? 0) + (sorted[mid]?.percent ?? 0)) / 2
+        : (sorted[mid]?.percent ?? 0);
+
+    const worst = sorted.slice(0, 10);
+
+    console.log(
+      `\ndefineTheme role-map reconstruction: median ${median.toFixed(1)}% across ${entries.length} themes`,
+    );
+    console.log("Worst offenders:");
+    for (const entry of worst) {
+      console.log(
+        `  ${entry.name}: ${entry.percent.toFixed(1)}% (${entry.reconstructed}/${entry.total})`,
+      );
+    }
+
+    if (median < 60) {
+      console.log(
+        "NOTE: median reconstruction is below ~60% — this may indicate a role-mapping error and is worth a follow-up look (not auto-fixed here).",
+      );
+    }
+  });
+});

--- a/tests/theme-role-map-fidelity.test.ts
+++ b/tests/theme-role-map-fidelity.test.ts
@@ -13,8 +13,8 @@
  */
 import fs from "node:fs";
 import path from "node:path";
-import { ROLE_SCOPES, parseScopeKey, varName } from "../src/theme-vars.js";
 import type { ThemePalette } from "../src/theme.d.ts";
+import { parseScopeKey, ROLE_SCOPES, varName } from "../src/theme-vars.js";
 
 const THEMES_DIR = path.join(import.meta.dir, "../src/themes");
 

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,0 +1,307 @@
+import fs from "node:fs";
+import path from "node:path";
+import postcss from "postcss";
+import { defineTheme, extendTheme, paletteToCss } from "../src/theme.js";
+import type { ThemeDefinition, ThemePalette } from "../src/theme.d.ts";
+
+const THEME_VAR_GRAMMAR = /^--shl-[\w-]+$/;
+
+describe("defineTheme", () => {
+  it("requires roles.foreground and roles.background when there's no extends", () => {
+    expect(() => defineTheme({ roles: { background: "#000" } })).toThrow(
+      /roles\.foreground/,
+    );
+    expect(() => defineTheme({ roles: { foreground: "#fff" } })).toThrow(
+      /roles\.background/,
+    );
+    expect(() => defineTheme({})).toThrow(/roles\.foreground/);
+  });
+
+  it("does not require foreground/background when extending a palette", () => {
+    const palette = defineTheme({
+      extends: {
+        name: "base",
+        colorScheme: "dark",
+        vars: { "--shl-fg": "#fff", "--shl-bg": "#000" },
+      },
+      roles: { keyword: "#f0f" },
+    });
+    expect(palette.vars["--shl-fg"]).toBe("#fff");
+    expect(palette.vars["--shl-bg"]).toBe("#000");
+    expect(palette.vars["--shl-keyword"]).toBe("#f0f");
+  });
+
+  it("maps foreground/background roles to --shl-fg/--shl-bg", () => {
+    const palette = defineTheme({
+      roles: { foreground: "#d6deeb", background: "#0b1021" },
+    });
+    expect(palette.vars).toEqual({
+      "--shl-fg": "#d6deeb",
+      "--shl-bg": "#0b1021",
+    });
+  });
+
+  it("expands the comment role to comment + quote, including TokenStyle fields as suffixed vars", () => {
+    const palette = defineTheme({
+      roles: {
+        foreground: "#fff",
+        background: "#000",
+        comment: { color: "#637777", fontStyle: "italic" },
+      },
+    });
+    expect(palette.vars["--shl-comment"]).toBe("#637777");
+    expect(palette.vars["--shl-comment-font-style"]).toBe("italic");
+    expect(palette.vars["--shl-quote"]).toBe("#637777");
+    expect(palette.vars["--shl-quote-font-style"]).toBe("italic");
+  });
+
+  it("expands the keyword role across all its mapped scopes, including the descendant 'meta keyword'", () => {
+    const palette = defineTheme({
+      roles: { foreground: "#fff", background: "#000", keyword: "#c792ea" },
+    });
+    for (const key of [
+      "--shl-keyword",
+      "--shl-doctag",
+      "--shl-formula",
+      "--shl-template-tag",
+      "--shl-meta-keyword",
+    ] as const) {
+      expect(palette.vars[key]).toBe("#c792ea");
+    }
+  });
+
+  it("expands the function role to the compound 'title.function_' var", () => {
+    const palette = defineTheme({
+      roles: { foreground: "#fff", background: "#000", function: "#82aaff" },
+    });
+    expect(palette.vars["--shl-title"]).toBe("#82aaff");
+    expect(palette.vars["--shl-title-function_"]).toBe("#82aaff");
+  });
+
+  it("expands every TokenStyle field to its suffixed var (color/background/fontStyle/fontWeight/textDecoration)", () => {
+    const palette = defineTheme({
+      roles: {
+        foreground: "#fff",
+        background: "#000",
+        addition: {
+          color: "#0f0",
+          background: "#001100",
+          fontStyle: "italic",
+          fontWeight: "bold",
+          textDecoration: "underline",
+        },
+      },
+    });
+    expect(palette.vars["--shl-addition"]).toBe("#0f0");
+    expect(palette.vars["--shl-addition-bg"]).toBe("#001100");
+    expect(palette.vars["--shl-addition-font-style"]).toBe("italic");
+    expect(palette.vars["--shl-addition-font-weight"]).toBe("bold");
+    expect(palette.vars["--shl-addition-text-decoration"]).toBe("underline");
+  });
+
+  it("treats a bare string the same as { color: string }", () => {
+    const a = defineTheme({
+      roles: { foreground: "#fff", background: "#000", keyword: "#f0f" },
+    });
+    const b = defineTheme({
+      roles: {
+        foreground: "#fff",
+        background: "#000",
+        keyword: { color: "#f0f" },
+      },
+    });
+    expect(a.vars).toEqual(b.vars);
+  });
+
+  it("applies precedence extends < roles < scopes, overwriting per-var not per-role", () => {
+    const base: ThemePalette = {
+      name: "base",
+      colorScheme: "dark",
+      vars: {
+        "--shl-fg": "#000",
+        "--shl-bg": "#fff",
+        "--shl-keyword": "#111",
+        "--shl-doctag": "#222",
+      },
+    };
+    const palette = defineTheme({
+      extends: base,
+      roles: { keyword: "#c792ea" }, // writes --shl-keyword and --shl-doctag (and others)
+      scopes: { keyword: "#ff0000" }, // overrides only --shl-keyword
+    });
+    expect(palette.vars["--shl-keyword"]).toBe("#ff0000");
+    expect(palette.vars["--shl-doctag"]).toBe("#c792ea");
+  });
+
+  it("scopes overrides parse compound (dot) and descendant (space) keys the same way the build does", () => {
+    const palette = defineTheme({
+      roles: { foreground: "#fff", background: "#000" },
+      scopes: { "title.class_": "#ffd700", "meta keyword": "#5f7e97" },
+    });
+    expect(palette.vars["--shl-title-class_"]).toBe("#ffd700");
+    expect(palette.vars["--shl-meta-keyword"]).toBe("#5f7e97");
+  });
+
+  it("infers colorScheme from background luminance when not given", () => {
+    const dark = defineTheme({
+      roles: { foreground: "#fff", background: "#000000" },
+    });
+    const light = defineTheme({
+      roles: { foreground: "#000", background: "#ffffff" },
+    });
+    expect(dark.colorScheme).toBe("dark");
+    expect(light.colorScheme).toBe("light");
+  });
+
+  it("uses an explicit colorScheme over the inferred one", () => {
+    const palette = defineTheme({
+      colorScheme: "light",
+      roles: { foreground: "#000", background: "#000000" },
+    });
+    expect(palette.colorScheme).toBe("light");
+  });
+
+  it("defaults name to 'custom-theme'", () => {
+    const palette = defineTheme({
+      roles: { foreground: "#fff", background: "#000" },
+    });
+    expect(palette.name).toBe("custom-theme");
+  });
+
+  it("produces a well-formed ThemePalette: every var key matches the --shl-* grammar", () => {
+    const palette = defineTheme({
+      roles: {
+        foreground: "#fff",
+        background: "#000",
+        comment: { color: "#888", fontStyle: "italic" },
+        type: "#eee",
+      },
+      scopes: { "title.class_": "#f00" },
+    });
+    for (const key of Object.keys(palette.vars)) {
+      expect(key).toMatch(THEME_VAR_GRAMMAR);
+    }
+  });
+});
+
+describe("extendTheme", () => {
+  it("is equivalent to defineTheme({ ...overrides, extends: base })", async () => {
+    const { default: atomOneDark } = (await import(
+      "../src/themes/atom-one-dark.js"
+    )) as {
+      default: ThemePalette;
+    };
+    const a = extendTheme(atomOneDark, { roles: { keyword: "#ff79c6" } });
+    const b = defineTheme({
+      extends: atomOneDark,
+      roles: { keyword: "#ff79c6" },
+    });
+    expect(a).toEqual(b);
+  });
+
+  it("round-trips a shipped palette's vars deep-equal when given no overrides", async () => {
+    const { default: atomOneDark } = (await import(
+      "../src/themes/atom-one-dark.js"
+    )) as {
+      default: ThemePalette;
+    };
+    const roundTripped = extendTheme(atomOneDark, {});
+    expect(roundTripped.vars).toEqual(atomOneDark.vars);
+  });
+});
+
+describe("paletteToCss", () => {
+  it("matches the generated themes/<name>.css artifact for a shipped palette", async () => {
+    const { default: atomOneDark } = (await import(
+      "../src/themes/atom-one-dark.js"
+    )) as {
+      default: ThemePalette;
+    };
+    const generatedCss = fs.readFileSync(
+      path.join(import.meta.dir, "../src/themes/atom-one-dark.css"),
+      "utf8",
+    );
+    expect(paletteToCss(atomOneDark)).toBe(generatedCss);
+  });
+
+  it("output parses via PostCSS into declarations equal to the generated CSS", async () => {
+    const { default: atomOneDark } = (await import(
+      "../src/themes/atom-one-dark.js"
+    )) as {
+      default: ThemePalette;
+    };
+    const generatedCss = fs.readFileSync(
+      path.join(import.meta.dir, "../src/themes/atom-one-dark.css"),
+      "utf8",
+    );
+
+    function declMap(css: string) {
+      const root = postcss.parse(css);
+      const map = new Map<string, Map<string, string>>();
+      root.walkRules((rule) => {
+        for (const selector of rule.selectors) {
+          const decls = map.get(selector) ?? new Map<string, string>();
+          rule.walkDecls((decl) => {
+            decls.set(decl.prop, decl.value);
+          });
+          map.set(selector, decls);
+        }
+      });
+      return map;
+    }
+
+    expect(declMap(paletteToCss(atomOneDark))).toEqual(declMap(generatedCss));
+  });
+
+  it("root defaults to true and selector defaults to [data-shl-theme=name]", () => {
+    const palette = defineTheme({
+      name: "midnight",
+      roles: { foreground: "#fff", background: "#000" },
+    });
+    const css = paletteToCss(palette);
+    expect(css).toContain(":root{");
+    expect(css).toContain('[data-shl-theme="midnight"]{');
+  });
+
+  it("omits the :root block when root: false", () => {
+    const palette = defineTheme({
+      name: "midnight",
+      roles: { foreground: "#fff", background: "#000" },
+    });
+    const css = paletteToCss(palette, { root: false });
+    expect(css).not.toContain(":root{");
+    expect(css).toContain('[data-shl-theme="midnight"]{');
+  });
+
+  it("honors a custom selector", () => {
+    const palette = defineTheme({
+      name: "midnight",
+      roles: { foreground: "#fff", background: "#000" },
+    });
+    const css = paletteToCss(palette, { selector: ".my-theme" });
+    expect(css).toContain(".my-theme{");
+    expect(css).not.toContain("[data-shl-theme");
+  });
+
+  it("includes extras verbatim when present", () => {
+    const palette: ThemePalette = {
+      name: "gradients",
+      colorScheme: "dark",
+      vars: { "--shl-fg": "#fff", "--shl-bg": "#000" },
+      extras: ".hljs{background-image:linear-gradient(red,blue)}",
+    };
+    const css = paletteToCss(palette);
+    expect(css).toContain(".hljs{background-image:linear-gradient(red,blue)}");
+  });
+});
+
+describe("ThemeDefinition types", () => {
+  it("rejects an unknown role key at the type level", () => {
+    const valid: ThemeDefinition = { roles: { keyword: "#fff" } };
+    expect(valid.roles?.keyword).toBe("#fff");
+
+    // @ts-expect-error - "bogusRole" is not a ThemeRole
+    const invalid: ThemeDefinition = { roles: { bogusRole: "#fff" } };
+    expect(invalid).toBeDefined();
+  });
+});

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -1,8 +1,8 @@
 import fs from "node:fs";
 import path from "node:path";
 import postcss from "postcss";
-import { defineTheme, extendTheme, paletteToCss } from "../src/theme.js";
 import type { ThemeDefinition, ThemePalette } from "../src/theme.d.ts";
+import { defineTheme, extendTheme, paletteToCss } from "../src/theme.js";
 
 const THEME_VAR_GRAMMAR = /^--shl-[\w-]+$/;
 

--- a/www/components/DefineThemePreview.svelte
+++ b/www/components/DefineThemePreview.svelte
@@ -1,0 +1,220 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import Highlight, { HighlightStyle, HighlightSvelte } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/themes/atom-one-dark";
+  import "svelte-highlight/themes/base.css";
+  import { defineTheme, extendTheme } from "svelte-highlight/theme";
+
+  const code = `interface User {
+  id: number;
+  name: string;
+}
+
+const greet = (user: User): string => {
+  // Say hello
+  return \`Hello, \${user.name}!\`;
+};`;
+
+  const modes = ["defineTheme", "extendTheme"];
+
+  /** @type {"defineTheme" | "extendTheme"} */
+  let mode = "defineTheme";
+
+  let background = "#0b1021";
+  let foreground = "#d6deeb";
+  let comment = "#637777";
+  let keyword = "#c792ea";
+  let string = "#ecc48d";
+  let fn = "#82aaff";
+  let type = "#ffcb8b";
+  let tag = "#7fdbca";
+
+  $: customTheme = defineTheme({
+    name: "midnight",
+    roles: {
+      background,
+      foreground,
+      comment: { color: comment, fontStyle: "italic" },
+      keyword,
+      string,
+      function: fn,
+      type,
+      tag,
+    },
+  });
+
+  $: brandedTheme = extendTheme(atomOneDark, {
+    name: "atom-one-dark-branded",
+    roles: { keyword },
+  });
+
+  $: theme = mode === "defineTheme" ? customTheme : brandedTheme;
+
+  const snippet = `<script>
+  import { defineTheme, extendTheme } from "svelte-highlight/theme";
+  import atomOneDark from "svelte-highlight/themes/atom-one-dark";
+
+  const midnight = defineTheme({
+    name: "midnight",
+    roles: {
+      background: "#0b1021",
+      foreground: "#d6deeb",
+      comment: { color: "#637777", fontStyle: "italic" },
+      keyword: "#c792ea",
+      // ...
+    },
+  });
+
+  const branded = extendTheme(atomOneDark, {
+    name: "atom-one-dark-branded",
+    roles: { keyword: "#c792ea" },
+  });
+<\/script>
+
+<HighlightStyle theme={mode === "defineTheme" ? midnight : branded}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>`;
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+<div class="controls">
+  <fieldset>
+    <legend>API</legend>
+    {#each modes as value}
+      <button
+        type="button"
+        class="mode-button"
+        class:selected={mode === value}
+        on:click={() => (mode = value)}
+      >
+        {value}()
+      </button>
+    {/each}
+  </fieldset>
+
+  {#if mode === "defineTheme"}
+    <div class="swatches">
+      <label class="swatch"
+        ><input type="color" bind:value={background}>background</label
+      >
+      <label class="swatch"
+        ><input type="color" bind:value={foreground}>foreground</label
+      >
+      <label class="swatch"
+        ><input type="color" bind:value={comment}>comment</label
+      >
+      <label class="swatch"
+        ><input type="color" bind:value={keyword}>keyword</label
+      >
+      <label class="swatch"
+        ><input type="color" bind:value={string}>string</label
+      >
+      <label class="swatch"><input type="color" bind:value={fn}>function</label>
+      <label class="swatch"><input type="color" bind:value={type}>type</label>
+      <label class="swatch"><input type="color" bind:value={tag}>tag</label>
+    </div>
+  {:else}
+    <div class="swatches">
+      <label class="swatch"
+        ><input type="color" bind:value={keyword}>keyword</label
+      >
+    </div>
+  {/if}
+</div>
+
+<p class="hint">
+  {#if mode === "defineTheme"}
+    <code>defineTheme()</code>
+    building a full palette from the ~14 semantic roles above — pick any swatch
+    to see it update live.
+  {:else}
+    <code>{"extendTheme(atomOneDark, { roles: { keyword } })"}</code>
+    deriving a branded variant of a shipped palette — only <code>keyword</code>
+    (tied to the swatch above) diverges from atom-one-dark.
+  {/if}
+</p>
+
+<HighlightStyle {theme}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>
+
+<style>
+  .controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  fieldset {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    border: 1px solid var(--cds-ui-04, #8d8d8d);
+    border-radius: 4px;
+    padding: 0.25rem 0.75rem;
+  }
+
+  legend {
+    padding: 0 0.25rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .mode-button {
+    cursor: pointer;
+    border: 1px solid var(--cds-ui-04, #8d8d8d);
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    padding: 0.25rem 0.625rem;
+    font: inherit;
+    font-size: 0.875rem;
+  }
+
+  .mode-button.selected {
+    background: var(--cds-interactive-01, #0f62fe);
+    border-color: var(--cds-interactive-01, #0f62fe);
+    color: var(--cds-text-04, #ffffff);
+  }
+
+  .swatches {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 0.75rem;
+  }
+
+  .swatch {
+    display: inline-flex;
+    gap: 0.375rem;
+    align-items: center;
+    cursor: pointer;
+    font-size: 0.8125rem;
+  }
+
+  .swatch input[type="color"] {
+    width: 1.75rem;
+    height: 1.75rem;
+    padding: 0;
+    border: 1px solid var(--cds-ui-04, #8d8d8d);
+    border-radius: 4px;
+    background: none;
+    cursor: pointer;
+  }
+
+  .hint {
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+    opacity: 0.8;
+  }
+
+  code {
+    font-family: var(--cds-code-02-font-family, monospace);
+  }
+</style>

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -82,6 +82,7 @@
     "/preview-templ": "templ language preview",
     "/preview-hlsl": "HLSL language preview",
     "/preview-just": "just language preview",
+    "/preview-define-theme": "defineTheme preview",
   };
 
   $: path = pathname === "/" ? pathname : pathname.replace(/\/$/, "");

--- a/www/pages/preview-define-theme.astro
+++ b/www/pages/preview-define-theme.astro
@@ -1,0 +1,8 @@
+---
+import DefineThemePreview from "@components/DefineThemePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="defineTheme preview">
+  <DefineThemePreview client:idle />
+</Layout>


### PR DESCRIPTION
Theming a ThemePalette meant hand-writing CSS against the full
hljs-* selector vocabulary, or copying and editing a shipped
theme's vars by hand. There was no typed, programmatic way to
build or derive a palette, and no path for importing the large
existing ecosystem of VS Code / TextMate themes.

Adds `svelte-highlight/theme`: `defineTheme()` builds a full
palette from a small typed definition, a semantic role layer
(foreground, keyword, string, ...) plus optional per-scope
overrides, expanded to `--shl-*` vars via a documented mapping
table. `extendTheme()` derives a palette from any shipped or
user palette with role- or scope-level overrides. `paletteToCss()`
emits a palette as static CSS matching the generated theme
artifacts. A new `svelte-highlight/theme/textmate` subpath adds
`fromTextMate()`, importing VS Code / TextMate theme JSON via
segment-prefix scope matching with longest-selector specificity,
surfacing unmappable entries instead of dropping them silently.

The `--shl-*` var-name derivation used by the build pipeline is
now factored into `src/theme-vars.js` and shared with this new
runtime code, so the two can't drift apart; regenerating the
shipped themes produces a byte-identical `src/themes/` output.
A role-map validation report measures how much of each shipped
theme's palette the role layer alone reconstructs, to keep the
mapping honest without gating on an arbitrary threshold.

Also adds an unlisted `/preview-define-theme` docs page: role
swatches drive a live `defineTheme()` palette, with a toggle to
an `extendTheme(atomOneDark, ...)` variant, both rendered through
`HighlightStyle`. It follows the same unlisted convention as
every other `/preview-*` route already in this site.

## Risk

Additive only. No changes to `HighlightStyle`, `HighlightEditable`,
the generated palettes, or `base.css`. The higher-risk piece is the
`theme-ir.ts` / `build-themes.ts` refactor to share var-name
derivation with the runtime; a fidelity test suite and a zero-diff
check against the regenerated `src/themes/` output guard against
silent drift there.