### PR TITLE
feat(components): windowed rendering via a checkpointed document index

### DIFF
--- a/README.md
+++ b/README.md
@@ -1300,7 +1300,42 @@ Set `autoScroll` to keep the container pinned to the bottom as output grows -- i
 <HighlightStream language={typescript} {code} {done} autoScroll style="max-height: 20em; overflow-y: auto;" />
 ```
 
-This is O(buffer) per highlighted frame and DOM updates proportional to the changed lines -- fine for chat-sized output up to a few thousand lines, not a virtualized log viewer.
+Per-chunk work is O(tail), not O(stream length so far): finished output is sealed into immutable chunks the DOM never re-diffs, so a response that's ten times longer doesn't cost ten times more per repaint. DOM updates stay proportional to the changed lines -- fine for chat-sized output up to very long responses, not a substitute for `HighlightVirtual` below if you also need to *scroll* through a huge, already-complete document.
+
+## Large documents
+
+`HighlightVirtual` renders only the visible lines of a huge document (plus a small overscan margin) inside its own scroll container -- a 100k-line file costs a couple dozen DOM line nodes, not one per line. It exploits the same engine checkpoint/resume primitive `HighlightStream` uses for streaming, but for *random-access* windows into a static document instead of a growing tail.
+
+```svelte
+<script>
+  import { HighlightVirtual } from "svelte-highlight";
+  import json from "svelte-highlight/languages/json";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+</script>
+
+<svelte:head>
+  {@html atomOneDark}
+</svelte:head>
+
+<HighlightVirtual language={json} code={hugeLogDump} style="height: 480px" />
+```
+
+The rendered `<pre>` is the scroll container itself -- size it with `style`/`class`/`$$restProps`, same as `Highlight`. Content doesn't wrap (uniform line height is a v1 constraint, measured once from a rendered probe line). `overscan` (default `12`) controls how many extra lines render above/below the viewport; `checkpointInterval` (default `100`) controls how often the engine snapshots its parse state, trading a little memory for cheaper random access. Server-rendered output is the full document as plain escaped text (predictable cost for huge documents); the windowed, highlighted view takes over after hydration.
+
+For custom virtualization, servers, or tests, `svelte-highlight/tokenized-document` exposes the same windowing primitive headlessly:
+
+```js
+import { createTokenizedDocument } from "svelte-highlight/tokenized-document";
+import typescript from "svelte-highlight/languages/typescript";
+
+const doc = createTokenizedDocument({ language: typescript });
+doc.setCode(bigFile);
+doc.lineCount(); // cheap -- never triggers tokenization
+doc.lineRange(50_000, 50_040); // 40 highlighted lines in O(window + interval)
+doc.append(moreCode); // streaming growth, no re-tokenization
+```
+
+`lineRange` tokenizes lazily and caches the most recently resolved window, so scrolling through even a huge document only ever pays for the lines actually requested. Its output matches `HighlightStream`'s live (non-canonicalized) parse: constructs needing multi-line lookahead across a window's edge can render slightly differently than `registry.highlight()`'s canonical output, the same tradeoff streaming already makes. `TokenizedDocument` doesn't support mid-document edits -- `append` and full `setCode` resets only.
 
 ## Terminal Output
 
@@ -1647,6 +1682,25 @@ Use `bind:this`, then call `undo()`, `redo()`, `focus()`, `selectAll()`, `insert
   on:done={() => console.log("stream finished")}
 />
 ```
+
+### `HighlightVirtual`
+
+#### Props
+
+| Name              | Type                                           | Default value  |
+| :---------------- | :--------------------------------------------- | :------------- |
+| code               | `any`                                          | N/A (required) |
+| language           | { name: `string`; register: `object` } | N/A (required) |
+| overscan           | `number`                                       | `12`           |
+| checkpointInterval | `number`                                       | `100`          |
+
+`$$restProps` are forwarded to the top-level `pre` element (the scroll container -- size it with `style`/`class`).
+
+```svelte
+<HighlightVirtual language={json} code={hugeLogDump} style="height: 480px" />
+```
+
+See [Large documents](#large-documents) above.
 
 ### `FileTabs`
 

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -88,6 +88,14 @@ pkgJson.exports = {
     types: "./engine.d.ts",
     default: "./engine.js",
   },
+  "./tokenized-document": {
+    types: "./tokenized-document.d.ts",
+    default: "./tokenized-document.js",
+  },
+  "./tokenized-document.js": {
+    types: "./tokenized-document.d.ts",
+    default: "./tokenized-document.js",
+  },
   "./registry": {
     types: "./registry.d.ts",
     default: "./registry.js",

--- a/src/HighlightStream.svelte
+++ b/src/HighlightStream.svelte
@@ -31,7 +31,12 @@
   import { createEventDispatcher, onMount, tick } from "svelte";
   import { extendLines } from "./engine.js";
   import { ensureRegistered, registry } from "./registry.js";
-  import { splitLines } from "./split-lines.js";
+
+  // Lines between sealed chunks. Once a chunk fills, its line spans are
+  // joined into one immutable HTML string and never touched again - keyed
+  // reconciliation for `{#each sealedChunks}` below only ever diffs the
+  // (constant-size) unsealed tail, not the whole stream.
+  const SEAL_CHUNK_LINES = 256;
 
   const dispatch = createEventDispatcher();
 
@@ -40,9 +45,6 @@
 
   /** @type {string} */
   let highlighted = "";
-
-  /** @type {string[]} */
-  let lines = [];
 
   /** @type {ReturnType<typeof requestAnimationFrame> | undefined} */
   let frame;
@@ -64,14 +66,29 @@
   // this, treat it as a restart (new stream or language change).
   let fedCode = "";
 
-  // Incremental line rendering via extendLines. finalizedLines is append-only;
-  // the keyed each-block below does not touch completed lines on repaint.
-  /** @type {string[]} */
-  let finalizedLines = [];
+  // Incremental line rendering via extendLines.
   let finalizedPendingHtml = "";
   /** @type {string[]} */
   let finalizedOpenScopes = [];
   let renderedCommittedCount = 0;
+
+  // Sealed (finished, immutable) chunks of `SEAL_CHUNK_LINES` line spans
+  // each, pre-joined into one HTML string apiece - `sealedChunks` is never
+  // mutated in place, only appended to, and past entries are never rebuilt.
+  // `sealedHtml` mirrors the same sealed prefix as plain (wrapper-free) HTML,
+  // appended once per sealed chunk, so `highlighted` below is O(tail) per
+  // repaint instead of rejoining every line streamed so far.
+  /** @type {string[]} */
+  let sealedChunks = [];
+  let sealedHtml = "";
+  let sealedLineCount = 0;
+  // Completed lines not yet folded into a sealed chunk - bounded by
+  // `SEAL_CHUNK_LINES`, so touching it every repaint stays O(1).
+  /** @type {string[]} */
+  let unsealedLines = [];
+  // unsealedLines + the live preview line(s); rendered by the tail each-block.
+  /** @type {string[]} */
+  let tailLines = [];
 
   function ensureSession() {
     if (
@@ -85,10 +102,34 @@
     session = registry.createSession(language.name);
     sessionLanguageName = language.name;
     fedCode = "";
-    finalizedLines = [];
     finalizedPendingHtml = "";
     finalizedOpenScopes = [];
     renderedCommittedCount = 0;
+    sealedChunks = [];
+    sealedHtml = "";
+    sealedLineCount = 0;
+    unsealedLines = [];
+    tailLines = [];
+  }
+
+  // Folds the first SEAL_CHUNK_LINES entries of `unsealedLines` into one new
+  // sealed chunk. Called in a loop, so a single repaint that completes many
+  // lines at once (a burst of chunks coalesced into one frame) still seals
+  // as many full chunks as are ready.
+  function sealChunk() {
+    const chunkLines = unsealedLines.slice(0, SEAL_CHUNK_LINES);
+    let domHtml = "";
+    let plainHtml = "";
+    for (let li = 0; li < chunkLines.length; li++) {
+      const i = sealedLineCount + li;
+      const sep = i > 0 ? "\n" : "";
+      domHtml += `${sep}<span class="highlight-stream-line" data-line="${i}">${chunkLines[li]}</span>`;
+      plainHtml += sep + chunkLines[li];
+    }
+    sealedChunks = [...sealedChunks, domHtml];
+    sealedHtml += plainHtml;
+    sealedLineCount += chunkLines.length;
+    unsealedLines = unsealedLines.slice(SEAL_CHUNK_LINES);
   }
 
   function repaint() {
@@ -101,7 +142,6 @@
     if (done) {
       // Full re-parse for multi-line lookahead (heredocs, etc.).
       highlighted = session.finish({ canonicalize: true }).value;
-      lines = splitLines(highlighted);
     } else {
       // Newly committed events (append only tokenizes complete lines).
       const committed = session.events();
@@ -111,7 +151,10 @@
           finalizedOpenScopes,
           finalizedPendingHtml,
         );
-        finalizedLines = [...finalizedLines, ...result.completedLines];
+        if (result.completedLines.length > 0) {
+          unsealedLines = unsealedLines.concat(result.completedLines);
+          while (unsealedLines.length >= SEAL_CHUNK_LINES) sealChunk();
+        }
         finalizedPendingHtml = result.pendingHtml;
         finalizedOpenScopes = result.openScopes;
         renderedCommittedCount = committed.length;
@@ -130,8 +173,9 @@
         previewLines = [...result.completedLines, result.pendingHtml];
       }
 
-      lines = [...finalizedLines, ...previewLines];
-      highlighted = lines.join("\n");
+      tailLines = [...unsealedLines, ...previewLines];
+      highlighted =
+        sealedHtml + (sealedLineCount > 0 ? "\n" : "") + tailLines.join("\n");
     }
 
     dispatch("highlight", { highlighted });
@@ -198,7 +242,7 @@
 
 <pre bind:this={container} on:scroll={onScroll} {...$$restProps}><code
   class:hljs={true}
->{#if useSplitRendering}{#each lines as line, i (i)}{#if i > 0}{"\n"}{/if}<span class="highlight-stream-line" data-line={i}>{@html line}</span>{/each}{#if showCaret}<span class="highlight-stream-caret" aria-hidden="true"></span>{/if}{:else}{@html highlighted}{/if}</code></pre>
+>{#if useSplitRendering}{#each sealedChunks as chunk, c (c)}{@html chunk}{/each}{#each tailLines as line, li (sealedLineCount + li)}{#if sealedLineCount + li > 0}{"\n"}{/if}<span class="highlight-stream-line" data-line={sealedLineCount + li}>{@html line}</span>{/each}{#if showCaret}<span class="highlight-stream-caret" aria-hidden="true"></span>{/if}{:else}{@html highlighted}{/if}</code></pre>
 
 <style>
   .highlight-stream-caret {

--- a/src/HighlightVirtual.svelte
+++ b/src/HighlightVirtual.svelte
@@ -185,7 +185,7 @@
 
 <pre
   bind:this={container}
-  class="shl-virtual"
+  class:shl-virtual={true}
   class:hljs={true}
   on:scroll={onScroll}
   {...$$restProps}
@@ -198,6 +198,7 @@
 <style>
   .shl-virtual {
     display: block;
+    position: relative;
     overflow: auto;
     white-space: pre;
     margin: 0;

--- a/src/HighlightVirtual.svelte
+++ b/src/HighlightVirtual.svelte
@@ -1,0 +1,228 @@
+<script>
+  /**
+   * Code to render. A 100k-line document costs ~`overscan`*2 + viewport
+   * line nodes, not one per line.
+   * @type {any}
+   */
+  export let code = "";
+
+  /** @type {import("./languages").LanguageType<string>} */
+  export let language;
+
+  /**
+   * Extra lines rendered above and below the viewport.
+   * @type {number}
+   */
+  export let overscan = 12;
+
+  /**
+   * Lines between engine checkpoints (forwarded to `createTokenizedDocument`).
+   * @type {number}
+   */
+  export let checkpointInterval = 100;
+
+  import { onMount, tick } from "svelte";
+  import { createTokenizedDocument } from "./tokenized-document.js";
+
+  /** @type {HTMLElement} */
+  let container;
+
+  /** @type {HTMLElement} */
+  let probe;
+
+  // Uniform line height (v1 constraint), measured once from a rendered
+  // probe line and re-measured when webfonts finish loading.
+  let lineHeight = 16;
+
+  // Gates the SSR/pre-mount plain-text branch vs. the windowed view: the
+  // client's first render must match the server's markup byte-for-byte, so
+  // this only flips true inside onMount, after hydration has attached.
+  let hydrated = false;
+
+  let scrollTop = 0;
+  let clientHeight = 0;
+
+  /** @type {ReturnType<typeof requestAnimationFrame> | undefined} */
+  let frame;
+
+  /** @type {ResizeObserver | undefined} */
+  let resizeObserver;
+
+  /** @type {ReturnType<typeof createTokenizedDocument> | undefined} */
+  let doc;
+  let docLanguageName = "";
+  let docCheckpointInterval;
+
+  let lineCount = 0;
+  let start = 0;
+  let end = 0;
+  /** @type {string[]} */
+  let visibleLines = [];
+
+  $: source = typeof code === "string" ? code : String(code ?? "");
+
+  function ensureDoc() {
+    if (
+      doc &&
+      docLanguageName === language.name &&
+      docCheckpointInterval === checkpointInterval
+    ) {
+      return;
+    }
+    doc = createTokenizedDocument({ language, checkpointInterval });
+    docLanguageName = language.name;
+    docCheckpointInterval = checkpointInterval;
+  }
+
+  function computeWindow() {
+    if (!doc) return;
+    const total = doc.lineCount();
+    lineCount = total;
+    const first = Math.max(0, Math.floor(scrollTop / lineHeight) - overscan);
+    const last = Math.min(
+      total,
+      Math.ceil((scrollTop + clientHeight) / lineHeight) + overscan,
+    );
+    start = Math.min(first, total);
+    end = Math.max(start, last);
+    visibleLines = doc.lineRange(start, end);
+  }
+
+  // After the document changes shape, the sizer's height changes too; sync
+  // our tracked scrollTop/clientHeight from the (now-updated) DOM so an
+  // out-of-range scroll position - the document shrank while scrolled near
+  // its old end - is clamped rather than left pointing past the new content.
+  async function syncFromContainer() {
+    await tick();
+    if (!container) return;
+    const maxScrollTop = Math.max(
+      0,
+      container.scrollHeight - container.clientHeight,
+    );
+    if (container.scrollTop > maxScrollTop) container.scrollTop = maxScrollTop;
+    scrollTop = container.scrollTop;
+    clientHeight = container.clientHeight;
+  }
+
+  function cancelFrame() {
+    if (frame != null) {
+      cancelAnimationFrame(frame);
+      frame = undefined;
+    }
+  }
+
+  // Coalesce scroll bursts into one window recompute per frame.
+  function scheduleRepaint() {
+    if (frame != null) return;
+    frame = requestAnimationFrame(() => {
+      frame = undefined;
+      if (container) scrollTop = container.scrollTop;
+    });
+  }
+
+  function onScroll() {
+    scheduleRepaint();
+  }
+
+  async function measureLineHeight() {
+    await tick();
+    if (probe) {
+      const height = probe.getBoundingClientRect().height;
+      if (height > 0) lineHeight = height;
+    }
+    if (typeof document !== "undefined" && document.fonts?.ready) {
+      document.fonts.ready.then(async () => {
+        await tick();
+        if (!probe) return;
+        const height = probe.getBoundingClientRect().height;
+        if (height > 0 && height !== lineHeight) lineHeight = height;
+      });
+    }
+  }
+
+  // Rebuilds/updates the document whenever its content or shape changes.
+  // Deliberately separate from the scroll-driven block below so scrolling
+  // never touches doc.setCode() (O(len) prefix check) on every frame.
+  $: if (hydrated) {
+    void source;
+    void language;
+    void checkpointInterval;
+    ensureDoc();
+    doc.setCode(source);
+    lineCount = doc.lineCount();
+    computeWindow();
+    syncFromContainer();
+  }
+
+  // Scroll/resize/overscan/lineHeight-driven window recompute.
+  $: if (hydrated) {
+    void overscan;
+    void lineHeight;
+    void scrollTop;
+    void clientHeight;
+    void lineCount;
+    computeWindow();
+  }
+
+  onMount(() => {
+    measureLineHeight();
+    hydrated = true;
+    syncFromContainer();
+
+    if (typeof ResizeObserver !== "undefined" && container) {
+      resizeObserver = new ResizeObserver(() => {
+        if (container) clientHeight = container.clientHeight;
+      });
+      resizeObserver.observe(container);
+    }
+
+    return () => {
+      cancelFrame();
+      resizeObserver?.disconnect();
+    };
+  });
+</script>
+
+<pre
+  bind:this={container}
+  class="shl-virtual"
+  class:hljs={true}
+  on:scroll={onScroll}
+  {...$$restProps}
+><code>{#if !hydrated}{source}{:else}<span class="shl-virtual-sizer" style="height: {lineCount * lineHeight}px;"><span class="shl-virtual-window" style="transform: translateY({start * lineHeight}px);">{#each visibleLines as line, i (start + i)}<span class="shl-virtual-line" data-line={start + i}>{@html line}</span>{"\n"}{/each}</span></span>{/if}</code><span
+  bind:this={probe}
+  class="shl-virtual-probe shl-virtual-line"
+  aria-hidden="true"
+>&nbsp;</span></pre>
+
+<style>
+  .shl-virtual {
+    display: block;
+    overflow: auto;
+    white-space: pre;
+    margin: 0;
+  }
+
+  .shl-virtual-sizer {
+    display: block;
+    position: relative;
+  }
+
+  .shl-virtual-window {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+  }
+
+  .shl-virtual-line {
+    display: inline;
+  }
+
+  .shl-virtual-probe {
+    position: absolute;
+    visibility: hidden;
+    pointer-events: none;
+  }
+</style>

--- a/src/HighlightVirtual.svelte.d.ts
+++ b/src/HighlightVirtual.svelte.d.ts
@@ -1,0 +1,36 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+import type { LanguageType } from "./languages";
+
+export type HighlightVirtualProps = HTMLAttributes<HTMLPreElement> & {
+  /**
+   * Code to render.
+   */
+  code: any;
+
+  /**
+   * highlight.js language module.
+   * Import languages from `svelte-highlight/languages/*`.
+   * @example
+   * import typescript from "svelte-highlight/languages/typescript";
+   */
+  language: LanguageType<string>;
+
+  /**
+   * Extra lines rendered above and below the viewport.
+   * @default 12
+   */
+  overscan?: number;
+
+  /**
+   * Lines between engine checkpoints.
+   * @default 100
+   */
+  checkpointInterval?: number;
+};
+
+export default class HighlightVirtual extends SvelteComponentTyped<
+  HighlightVirtualProps,
+  Record<string, never>,
+  Record<string, never>
+> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -13,6 +13,7 @@ export { default as HighlightEditable } from "./HighlightEditable.svelte";
 export { default as HighlightStream } from "./HighlightStream.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
+export { default as HighlightVirtual } from "./HighlightVirtual.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export type { LanguageName, LanguageType } from "./languages";
 export { loadLanguage } from "./load-language";

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,7 @@ export { default as HighlightEditable } from "./HighlightEditable.svelte";
 export { default as HighlightStream } from "./HighlightStream.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
+export { default as HighlightVirtual } from "./HighlightVirtual.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export { loadLanguage } from "./load-language.js";
 export {

--- a/src/tokenized-document.d.ts
+++ b/src/tokenized-document.d.ts
@@ -1,0 +1,29 @@
+import type { LanguageType } from "./languages";
+
+/**
+ * A shared substrate for windowed rendering: text plus an engine checkpoint
+ * every `checkpointInterval` lines, producing highlighted HTML for any line
+ * range in O(range + interval) instead of O(document). See
+ * `createTokenizedDocument`'s doc comment for the fidelity caveat and the
+ * no-mid-document-edit scope.
+ */
+export interface TokenizedDocument {
+  /** Replace the document. Cheap; tokenization is lazy. */
+  setCode(code: string): void;
+  /** Append to the document (streaming). Must be equivalent to setCode(old + chunk) but incremental. */
+  append(chunk: string): void;
+  /** Total line count (string scan; never triggers tokenization). */
+  lineCount(): number;
+  /** Highlighted HTML per line for [start, end) — same line HTML extendLines produces. Tokenizes lazily. */
+  lineRange(start: number, end: number): string[];
+  /** Lines tokenized so far (monotonically grows; for tests/introspection). */
+  tokenizedThrough(): number;
+}
+
+export function createTokenizedDocument(options: {
+  language: LanguageType<string>;
+  /** Lines between engine checkpoints. @default 100 */
+  checkpointInterval?: number;
+  /** Forwarded to extendLines/renderHtml. @default "hljs-" */
+  classPrefix?: string;
+}): TokenizedDocument;

--- a/src/tokenized-document.js
+++ b/src/tokenized-document.js
@@ -1,0 +1,263 @@
+/**
+ * A shared substrate for windowed rendering: text plus an engine checkpoint
+ * every `checkpointInterval` lines, so highlighted HTML for any line range
+ * costs O(range + interval) instead of O(document). Built on the same
+ * `StreamSession` / `Registry#resume` / `extendLines` primitives
+ * `HighlightStream` uses for incremental streaming - this module applies
+ * the same checkpoint/resume trick to random-access windows instead of a
+ * growing tail.
+ *
+ * Fidelity caveat: window output matches the *streaming* (non-canonicalized)
+ * parse. Constructs needing multi-line lookahead beyond a window's edge may
+ * differ from `registry.highlight()`'s canonical output - the same tradeoff
+ * `HighlightStream`'s live view already makes.
+ *
+ * No mid-document edit support: `append` and full `setCode` resets only. A
+ * patch/invalidation API for editable large documents is out of scope here.
+ */
+
+/**
+ * @typedef {import("./engine.d.ts").Snapshot} Snapshot
+ * @typedef {import("./engine.d.ts").StreamSession} StreamSession
+ */
+
+/**
+ * @typedef {{
+ *   line: number,
+ *   snapshot: Snapshot,
+ *   openScopes: string[],
+ *   pendingHtml: string,
+ * }} Checkpoint
+ */
+
+import { extendLines } from "./engine.js";
+import { ensureRegistered, registry } from "./registry.js";
+
+/**
+ * Finds the last checkpoint whose `line` is `<= target`. `checkpoints` is
+ * non-empty (index 0 always covers line 0) and sorted ascending by `line`.
+ * @param {Checkpoint[]} checkpoints
+ * @param {number} target
+ * @returns {Checkpoint}
+ */
+function findCheckpoint(checkpoints, target) {
+  let lo = 0;
+  let hi = checkpoints.length - 1;
+  // checkpoints[0] is always present (index 0 covers line 0).
+  let result = /** @type {Checkpoint} */ (checkpoints[0]);
+  while (lo <= hi) {
+    const mid = (lo + hi) >> 1;
+    // mid is in [lo, hi], always a valid checkpoints index.
+    const candidate = /** @type {Checkpoint} */ (checkpoints[mid]);
+    if (candidate.line <= target) {
+      result = candidate;
+      lo = mid + 1;
+    } else {
+      hi = mid - 1;
+    }
+  }
+  return result;
+}
+
+/**
+ * @param {{
+ *   language: import("./languages").LanguageType<string>,
+ *   checkpointInterval?: number,
+ *   classPrefix?: string,
+ * }} options
+ */
+export function createTokenizedDocument({
+  language,
+  checkpointInterval = 100,
+  classPrefix = "hljs-",
+}) {
+  ensureRegistered(language);
+
+  /** @type {string} */
+  let code = "";
+  /** Character offset each line starts at; one entry per line (line 0 is always 0). */
+  /** @type {number[]} */
+  let lineStartOffsets = [0];
+
+  /** @type {StreamSession} */
+  let session;
+  /** Character offset of `code` already fed to `session`. */
+  let fedOffset = 0;
+  /** Line count already fed to `session` (index into `lineStartOffsets`). */
+  let fedLineCount = 0;
+
+  // Incremental extendLines state, advanced lazily as far as any lineRange()
+  // call has required (never further) - the same bookkeeping HighlightStream
+  // uses, except only checkpoints are retained, not the full line history.
+  let committedLineCount = 0;
+  /** @type {string[]} */
+  let openScopesStack = [];
+  let pendingHtmlStr = "";
+  let renderedEventCount = 0;
+
+  /** @type {Checkpoint[]} */
+  let checkpoints = [];
+
+  /** @type {{ checkpoint: Checkpoint, combined: string[], throughLine: number } | null} */
+  let cache = null;
+
+  /** @param {number} scanFrom Character offset to resume scanning from. */
+  function extendLineOffsets(scanFrom) {
+    for (let i = scanFrom; i < code.length; i++) {
+      if (code.charCodeAt(i) === 10) lineStartOffsets.push(i + 1);
+    }
+  }
+
+  /**
+   * The character offset line `i` starts at. `i` may equal `lineCount()`
+   * (one past the last line), which resolves to `code.length`.
+   * @param {number} i
+   */
+  function lineStartOffset(i) {
+    return i < lineStartOffsets.length
+      ? /** @type {number} */ (lineStartOffsets[i])
+      : code.length;
+  }
+
+  /** @param {string} newCode */
+  function reset(newCode) {
+    code = newCode;
+    lineStartOffsets = [0];
+    extendLineOffsets(0);
+    session = registry.createSession(language.name);
+    fedOffset = 0;
+    fedLineCount = 0;
+    committedLineCount = 0;
+    openScopesStack = [];
+    pendingHtmlStr = "";
+    renderedEventCount = 0;
+    checkpoints = [
+      {
+        line: 0,
+        snapshot: session.snapshot(),
+        openScopes: [],
+        pendingHtml: "",
+      },
+    ];
+    cache = null;
+  }
+
+  reset("");
+
+  /**
+   * Feeds the session in `checkpointInterval`-line batches until either
+   * `targetLine` lines are committed or the whole document has been fed.
+   * Recording a checkpoint after every batch, regardless of how many lines
+   * it actually completed, keeps checkpoints valid even when a batch lands
+   * mid-construct (an unresolved multi-line lookahead): the checkpoint's
+   * `pendingHtml`/`openScopes` simply carry the in-progress line forward,
+   * mirroring HighlightStream's own finalizedPendingHtml/openScopes.
+   * @param {number} targetLine
+   */
+  function ensureTokenizedThrough(targetLine) {
+    const total = lineStartOffsets.length;
+    const clampedTarget = Math.min(targetLine, total);
+    while (committedLineCount < clampedTarget && fedLineCount < total) {
+      const batchEndLine = Math.min(fedLineCount + checkpointInterval, total);
+      const batchEndOffset = lineStartOffset(batchEndLine);
+      const chunk = code.slice(fedOffset, batchEndOffset);
+      if (chunk.length > 0) session.append(chunk);
+      fedOffset = batchEndOffset;
+      fedLineCount = batchEndLine;
+
+      const committedEvents = session.events();
+      if (committedEvents.length > renderedEventCount) {
+        const result = extendLines(
+          committedEvents.slice(renderedEventCount),
+          openScopesStack,
+          pendingHtmlStr,
+          { classPrefix },
+        );
+        committedLineCount += result.completedLines.length;
+        openScopesStack = result.openScopes;
+        pendingHtmlStr = result.pendingHtml;
+        renderedEventCount = committedEvents.length;
+      }
+
+      checkpoints.push({
+        line: committedLineCount,
+        snapshot: session.snapshot(),
+        openScopes: openScopesStack.slice(),
+        pendingHtml: pendingHtmlStr,
+      });
+    }
+  }
+
+  return {
+    /** @param {string} newCode */
+    setCode(newCode) {
+      if (newCode.startsWith(code)) {
+        this.append(newCode.slice(code.length));
+      } else {
+        reset(newCode);
+      }
+    },
+
+    /** @param {string} chunk */
+    append(chunk) {
+      if (chunk === "") return;
+      const scanFrom = code.length;
+      code += chunk;
+      extendLineOffsets(scanFrom);
+    },
+
+    lineCount() {
+      return lineStartOffsets.length;
+    },
+
+    /**
+     * @param {number} start
+     * @param {number} end
+     * @returns {string[]}
+     */
+    lineRange(start, end) {
+      const total = lineStartOffsets.length;
+      const s = Math.max(0, Math.min(start, total));
+      const e = Math.max(s, Math.min(end, total));
+      if (s === e) return [];
+
+      ensureTokenizedThrough(e);
+
+      const checkpoint = findCheckpoint(checkpoints, s);
+
+      // `combined`'s last entry (pendingHtml) is only valid as the answer for
+      // the exact `end` it was computed against: resume()'s finish() force-
+      // closes whatever is still open at that cut point, which is correct
+      // for *that* boundary but not a real line's content otherwise. Cache
+      // coverage is therefore bounded by `throughLine` - the count of
+      // genuinely-completed lines - never by `combined.length`, so a later,
+      // larger `end` can't accidentally reuse that force-closed entry as if
+      // it were real, already-tokenized content.
+      if (cache && cache.checkpoint === checkpoint && e <= cache.throughLine) {
+        return cache.combined.slice(s - checkpoint.line, e - checkpoint.line);
+      }
+
+      const prefix = code.slice(0, lineStartOffset(e));
+      const resumed = registry.resume(
+        prefix,
+        language.name,
+        checkpoint.snapshot,
+      );
+      const result = extendLines(
+        resumed.events,
+        checkpoint.openScopes,
+        checkpoint.pendingHtml,
+        { classPrefix },
+      );
+      const combined = [...result.completedLines, result.pendingHtml];
+      const throughLine = checkpoint.line + result.completedLines.length;
+      cache = { checkpoint, combined, throughLine };
+
+      return combined.slice(s - checkpoint.line, e - checkpoint.line);
+    },
+
+    tokenizedThrough() {
+      return committedLineCount;
+    },
+  };
+}

--- a/tests/e2e/HighlightStream.sealing.test.svelte
+++ b/tests/e2e/HighlightStream.sealing.test.svelte
@@ -1,0 +1,80 @@
+<script>
+  import Highlight, { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  // SEAL_CHUNK_LINES is 256 (module constant in HighlightStream.svelte) -
+  // these batches are sized to land squarely inside, exactly at, and past
+  // that boundary so sealing is actually exercised more than once.
+  export let firstBatch = 300;
+  export let secondBatch = 300;
+
+  let code = "";
+  let linesSent = 0;
+  let done = false;
+  let highlighted = "";
+  let highlightCount = 0;
+  let referenceHighlighted = "";
+
+  function appendLines(n) {
+    let extra = "";
+    for (let i = 0; i < n; i++) {
+      extra += `const x${linesSent} = ${linesSent}; // line ${linesSent}\n`;
+      linesSent++;
+    }
+    code += extra;
+  }
+
+  // Seed one line immediately so data-line="0" exists on first mount.
+  appendLines(1);
+
+  function appendFirstBatch() {
+    appendLines(firstBatch - linesSent);
+  }
+
+  function appendSecondBatch() {
+    appendLines(firstBatch + secondBatch - linesSent);
+  }
+
+  function finish() {
+    done = true;
+  }
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<button type="button" data-testid="append-first" on:click={appendFirstBatch}>
+  Append to {firstBatch}
+</button>
+<button type="button" data-testid="append-second" on:click={appendSecondBatch}>
+  Append to {firstBatch + secondBatch}
+</button>
+<button type="button" data-testid="finish" on:click={finish}>Finish</button>
+
+<HighlightStream
+  language={javascript}
+  {code}
+  {done}
+  data-testid="stream"
+  on:highlight={(e) => {
+    highlighted = e.detail.highlighted;
+    highlightCount += 1;
+  }}
+/>
+
+<span data-testid="lines-sent">{linesSent}</span>
+<span data-testid="highlight-count">{highlightCount}</span>
+<pre data-testid="highlighted-snapshot" style="display:none">{highlighted}</pre>
+<pre
+  data-testid="reference-highlighted-snapshot"
+  style="display:none"
+>{referenceHighlighted}</pre>
+
+<Highlight
+  language={javascript}
+  {code}
+  data-testid="reference"
+  on:highlight={(e) => {
+    referenceHighlighted = e.detail.highlighted;
+  }}
+/>

--- a/tests/e2e/HighlightVirtual.test.svelte
+++ b/tests/e2e/HighlightVirtual.test.svelte
@@ -23,4 +23,5 @@
   {overscan}
   data-testid="virtual"
   style="height: 300px; width: 600px;"
+  {...$$restProps}
 />

--- a/tests/e2e/HighlightVirtual.test.svelte
+++ b/tests/e2e/HighlightVirtual.test.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { HighlightVirtual } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  export const LINE_COUNT = 5000;
+
+  function generateCode(lines) {
+    let out = "";
+    for (let i = 0; i < lines; i++) out += `const x${i} = ${i}; // line ${i}\n`;
+    return out;
+  }
+
+  export let code = generateCode(LINE_COUNT);
+  export let overscan = 5;
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<HighlightVirtual
+  language={javascript}
+  {code}
+  {overscan}
+  data-testid="virtual"
+  style="height: 300px; width: 600px;"
+/>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -20,6 +20,7 @@ import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
 import HighlightEditableCssHighlights from "./HighlightEditable.cssHighlights.test.svelte";
 import HighlightEditableLanguageSwap from "./HighlightEditable.languageSwap.test.svelte";
 import HighlightEditable from "./HighlightEditable.test.svelte";
+import HighlightStreamSealing from "./HighlightStream.sealing.test.svelte";
 import HighlightStreamStability from "./HighlightStream.stability.test.svelte";
 import HighlightStreamTemplateLiteral from "./HighlightStream.templateLiteral.test.svelte";
 import HighlightStream from "./HighlightStream.test.svelte";
@@ -27,6 +28,7 @@ import HighlightStyleDedupe from "./HighlightStyle.dedupe.test.svelte";
 import HighlightStyleNoTheme from "./HighlightStyle.noTheme.test.svelte";
 import HighlightStyleThemeSwitch from "./HighlightStyle.themeSwitch.test.svelte";
 import HighlightSvelteEvents from "./HighlightSvelte.events.test.svelte";
+import HighlightVirtual from "./HighlightVirtual.test.svelte";
 import LangTag from "./LangTag.test.svelte";
 import LineNumbersCssVariables from "./LineNumbers.cssVariables.test.svelte";
 import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test.svelte";
@@ -1122,6 +1124,296 @@ test("HighlightStream - `done` hides the caret and fires on:done", async ({
   await page.getByTestId("finish").click();
   await expect(stream.locator(".highlight-stream-caret")).toHaveCount(0);
   await expect(page.getByTestId("done-count")).toHaveText("1");
+});
+
+test("HighlightStream sealing - text content stays byte-correct across sealed chunk boundaries", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamSealing);
+
+  const streamRoot = page.getByTestId("stream");
+  const stream = streamRoot.locator("code");
+
+  await page.getByTestId("append-first").click(); // 300 lines: seals chunk 0 (lines 0-255)
+  await expect(page.getByTestId("lines-sent")).toHaveText("300");
+  await expect(streamRoot.locator("[data-line='299']")).toBeVisible();
+
+  const expectedLine = (i: number) => `const x${i} = ${i}; // line ${i}`;
+  const textAfterFirst = (await stream.textContent()) ?? "";
+  const linesAfterFirst = textAfterFirst.split("\n");
+  for (const i of [0, 1, 255, 256, 299]) {
+    expect(linesAfterFirst[i]).toBe(expectedLine(i));
+  }
+
+  await page.getByTestId("append-second").click(); // 600 lines: seals chunk 1 (lines 256-511)
+  await expect(page.getByTestId("lines-sent")).toHaveText("600");
+  await expect(streamRoot.locator("[data-line='599']")).toBeVisible();
+
+  const textAfterSecond = (await stream.textContent()) ?? "";
+  const linesAfterSecond = textAfterSecond.split("\n");
+  for (const i of [0, 255, 256, 511, 512, 599]) {
+    expect(linesAfterSecond[i]).toBe(expectedLine(i));
+  }
+});
+
+test("HighlightStream sealing - data-line indices are globally correct across sealed and unsealed regions", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamSealing);
+
+  await page.getByTestId("append-first").click();
+  await page.getByTestId("append-second").click();
+  await expect(page.getByTestId("lines-sent")).toHaveText("600");
+
+  const stream = page.getByTestId("stream");
+  for (const i of [0, 100, 255, 256, 400, 511, 512, 599]) {
+    // biome-ignore lint/performance/noAwaitInLoops: each assertion is independent and cheap; sequential is clearer here
+    await expect(stream.locator(`[data-line='${i}']`)).toHaveText(
+      `const x${i} = ${i}; // line ${i}`,
+    );
+  }
+  // 600 committed lines plus one trailing empty preview line (code ends in "\n").
+  await expect(stream.locator("[data-line]")).toHaveCount(601);
+});
+
+test("HighlightStream sealing - sealed chunk DOM nodes are never replaced by later streaming", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamSealing);
+
+  const stream = page.getByTestId("stream");
+
+  // Still unsealed (only 1 line sent) - not a meaningful stability claim yet.
+  await expect(stream.locator("[data-line='0']")).toBeVisible();
+
+  await page.getByTestId("append-first").click(); // seals chunk 0 (lines 0-255)
+  await expect(page.getByTestId("lines-sent")).toHaveText("300");
+  await expect(stream.locator("[data-line='10']")).toBeVisible();
+
+  // Capture the DOM node for a line inside the now-sealed first chunk.
+  const sealedLine = stream.locator("[data-line='10']");
+  const handle = await sealedLine.elementHandle();
+  expect(await handle?.evaluate((el) => el.textContent)).toBe(
+    "const x10 = 10; // line 10",
+  );
+
+  await page.getByTestId("append-second").click(); // seals chunk 1 (lines 256-511)
+  await expect(page.getByTestId("lines-sent")).toHaveText("600");
+
+  // The line-10 element from before the second seal is untouched.
+  expect(await handle?.evaluate((el) => el.isConnected)).toBe(true);
+  expect(await handle?.evaluate((el) => el.textContent)).toBe(
+    "const x10 = 10; // line 10",
+  );
+});
+
+test("HighlightStream sealing - `done` still swaps to the canonical full render", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamSealing);
+
+  await page.getByTestId("append-first").click();
+  await page.getByTestId("append-second").click();
+  await expect(page.getByTestId("lines-sent")).toHaveText("600");
+
+  await page.getByTestId("finish").click();
+
+  const stream = page.getByTestId("stream").locator("code");
+  const reference = page.getByTestId("reference").locator("code");
+  await expect(stream).toHaveText((await reference.textContent()) ?? "");
+  expect(await stream.innerHTML()).toBe(await reference.innerHTML());
+  // The split-rendering markup (sealed chunks/data-line spans) is gone.
+  expect(await page.getByTestId("stream").locator("[data-line]").count()).toBe(
+    0,
+  );
+});
+
+test("HighlightStream sealing - dispatched `highlight` payload matches Highlight's output for the same code", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamSealing);
+
+  await page.getByTestId("append-first").click();
+  await page.getByTestId("append-second").click();
+  await expect(page.getByTestId("lines-sent")).toHaveText("600");
+  // The `highlight` dispatch for the last line is synchronous with the same
+  // repaint that renders it, so waiting for the line to appear guarantees
+  // the snapshot below reflects that repaint (not a stale, earlier one).
+  await expect(
+    page.getByTestId("stream").locator("[data-line='599']"),
+  ).toBeVisible();
+
+  const streamedHighlighted = await page
+    .getByTestId("highlighted-snapshot")
+    .textContent();
+  const referenceHighlighted = await page
+    .getByTestId("reference-highlighted-snapshot")
+    .textContent();
+
+  // Pre-`done`, `highlighted` is the streaming (non-canonicalized) parse -
+  // for this snippet (no multi-line lookahead constructs) it already
+  // matches Highlight's canonical output byte-for-byte. Comparing the raw
+  // dispatched strings (rather than rendered innerHTML) sidesteps Svelte's
+  // own internal block-boundary comment markers, which differ between the
+  // two components' unrelated template structures.
+  expect(streamedHighlighted).toBe(referenceHighlighted);
+});
+
+test("HighlightVirtual - renders a bounded number of line nodes for a 5,000-line document", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightVirtual);
+
+  const virtual = page.getByTestId("virtual");
+  const renderedLines = virtual.locator("[data-line]");
+  await expect(renderedLines.first()).toBeVisible();
+
+  const count = await renderedLines.count();
+  // viewport (300px) / a typical monospace line-height + 2*overscan(5) +
+  // slack - nowhere near the 5,000 total lines, which is the point.
+  expect(count).toBeGreaterThan(0);
+  expect(count).toBeLessThan(200);
+
+  await expect(virtual.locator("[data-line='0']")).toHaveText(
+    "const x0 = 0; // line 0",
+  );
+});
+
+test("HighlightVirtual - shows correct content at top, middle, and bottom of the scroll range", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightVirtual);
+
+  const virtual = page.getByTestId("virtual");
+  await expect(virtual.locator("[data-line='0']")).toBeVisible();
+  await expect(virtual.locator("[data-line='0']")).toHaveText(
+    "const x0 = 0; // line 0",
+  );
+
+  await virtual.evaluate((el) => {
+    el.scrollTop = (el.scrollHeight - el.clientHeight) / 2;
+  });
+  await expect(async () => {
+    const total = await virtual.locator("[data-line]").count();
+    expect(total).toBeGreaterThan(0);
+  }).toPass();
+  const middleLineHandle = virtual.locator("[data-line]").first();
+  const middleLine = await middleLineHandle.getAttribute("data-line");
+  const middleIndex = Number(middleLine);
+  expect(middleIndex).toBeGreaterThan(100);
+  expect(middleIndex).toBeLessThan(4900);
+  await expect(virtual.locator(`[data-line='${middleIndex}']`)).toHaveText(
+    `const x${middleIndex} = ${middleIndex}; // line ${middleIndex}`,
+  );
+
+  await virtual.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  await expect(virtual.locator("[data-line='4999']")).toHaveText(
+    "const x4999 = 4999; // line 4999",
+  );
+});
+
+test("HighlightVirtual - sizer height matches lineCount * measured line height", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightVirtual);
+
+  const virtual = page.getByTestId("virtual");
+  await expect(virtual.locator("[data-line='0']")).toBeVisible();
+
+  const { sizerHeight, lineHeight } = await virtual.evaluate((el) => {
+    const sizer = el.querySelector(".shl-virtual-sizer");
+    const line = el.querySelector("[data-line]");
+    if (!sizer || !line) throw new Error("expected sizer and line elements");
+    return {
+      sizerHeight: sizer.getBoundingClientRect().height,
+      lineHeight: line.getBoundingClientRect().height,
+    };
+  });
+
+  expect(sizerHeight).toBeGreaterThan(0);
+  expect(lineHeight).toBeGreaterThan(0);
+  // Within 1px/line of rounding across 5,000 lines.
+  expect(Math.abs(sizerHeight - 5000 * lineHeight)).toBeLessThan(5000);
+});
+
+test("HighlightVirtual - the scroll container carries the theme background across the whole scrollable area", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightVirtual);
+
+  const virtual = page.getByTestId("virtual");
+  await expect(virtual.locator("[data-line='0']")).toBeVisible();
+  await expect(virtual).toHaveClass(/hljs/);
+
+  // atom-one-dark's `.hljs` background is #282c34.
+  const bgAtTop = await virtual.evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  expect(bgAtTop).toBe("rgb(40, 44, 52)");
+
+  await virtual.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  await expect(virtual.locator("[data-line='4999']")).toBeVisible();
+  const bgAfterScroll = await virtual.evaluate(
+    (el) => getComputedStyle(el).backgroundColor,
+  );
+  expect(bgAfterScroll).toBe(bgAtTop);
+});
+
+test("HighlightVirtual - visible lines are separated by real newlines (selection/copy yields line breaks)", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightVirtual);
+
+  const virtual = page.getByTestId("virtual");
+  await expect(virtual.locator("[data-line='0']")).toBeVisible();
+
+  const windowText = await virtual.locator(".shl-virtual-window").textContent();
+  expect(windowText ?? "").toContain(
+    "const x0 = 0; // line 0\nconst x1 = 1; // line 1\n",
+  );
+});
+
+test("HighlightVirtual - rebuilds and clamps scroll when `code` shrinks", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(HighlightVirtual);
+
+  const virtual = page.getByTestId("virtual");
+  await expect(virtual.locator("[data-line='0']")).toBeVisible();
+
+  await virtual.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  await expect(virtual.locator("[data-line='4999']")).toBeVisible();
+
+  let shortCode = "";
+  for (let i = 0; i < 20; i++) shortCode += `const y${i} = ${i};\n`;
+  await component.update({ props: { code: shortCode } });
+
+  await expect(virtual.locator("[data-line='19']")).toBeVisible();
+  // 20 lines of content plus one trailing empty line (shortCode ends in "\n").
+  await expect(virtual.locator("[data-line]")).toHaveCount(21);
+  const scrollTop = await virtual.evaluate((el) => el.scrollTop);
+  const scrollHeight = await virtual.evaluate((el) => el.scrollHeight);
+  const clientHeight = await virtual.evaluate((el) => el.clientHeight);
+  expect(scrollTop).toBeLessThanOrEqual(
+    Math.max(0, scrollHeight - clientHeight),
+  );
 });
 
 test("Typewriter - animates then settles to the full highlighted content", async ({

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1061,9 +1061,13 @@ test("HighlightStream - streaming chunks (split mid-keyword and mid-template-lit
     await appendChunk.click();
     await expect(highlightCount).not.toHaveText(previousCount);
     previousCount = (await highlightCount.textContent()) ?? previousCount;
-    const text = (await stream.textContent()) ?? "";
-    expect(text.length).toBeGreaterThan(previousLength);
-    previousLength = text.length;
+    // `highlightCount`'s DOM update landing doesn't guarantee `stream`'s own
+    // (larger, differently-structured) DOM update has landed in the same
+    // paint, so poll this instead of a one-shot read.
+    await expect
+      .poll(async () => (await stream.textContent())?.length ?? 0)
+      .toBeGreaterThan(previousLength);
+    previousLength = (await stream.textContent())?.length ?? 0;
   }
 
   await page.getByTestId("finish").click();
@@ -1300,14 +1304,19 @@ test("HighlightVirtual - shows correct content at top, middle, and bottom of the
   await virtual.evaluate((el) => {
     el.scrollTop = (el.scrollHeight - el.clientHeight) / 2;
   });
+  // `[data-line]` elements exist even before scrolling, so waiting on their
+  // count alone would pass immediately without ever observing the
+  // scroll-triggered repaint. Poll the first rendered index itself until it
+  // reflects the new scroll position.
+  let middleIndex = 0;
   await expect(async () => {
-    const total = await virtual.locator("[data-line]").count();
-    expect(total).toBeGreaterThan(0);
+    const middleLine = await virtual
+      .locator("[data-line]")
+      .first()
+      .getAttribute("data-line");
+    middleIndex = Number(middleLine);
+    expect(middleIndex).toBeGreaterThan(100);
   }).toPass();
-  const middleLineHandle = virtual.locator("[data-line]").first();
-  const middleLine = await middleLineHandle.getAttribute("data-line");
-  const middleIndex = Number(middleLine);
-  expect(middleIndex).toBeGreaterThan(100);
   expect(middleIndex).toBeLessThan(4900);
   await expect(virtual.locator(`[data-line='${middleIndex}']`)).toHaveText(
     `const x${middleIndex} = ${middleIndex}; // line ${middleIndex}`,

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1372,6 +1372,32 @@ test("HighlightVirtual - the scroll container carries the theme background acros
   expect(bgAfterScroll).toBe(bgAtTop);
 });
 
+test("HighlightVirtual - a consumer-provided `class` merges with (not replaces) the component's own scoped styles", async ({
+  mount,
+  page,
+}) => {
+  // Regression test: a static `class="shl-virtual"` attribute combined with
+  // both a `class:hljs` directive and `{...$$restProps}` was silently
+  // dropped by Svelte's class-merging, which meant *any* consumer passing
+  // `class` (the normal way to theme/size the component) lost the
+  // component's own layout CSS entirely (overflow, white-space, sizer/
+  // window positioning) despite `hljs` itself surviving.
+  await mount(HighlightVirtual, { props: { class: "consumer-class" } });
+
+  const virtual = page.getByTestId("virtual");
+  await expect(virtual.locator("[data-line='0']")).toBeVisible();
+  await expect(virtual).toHaveClass(/consumer-class/);
+  await expect(virtual).toHaveClass(/hljs/);
+  await expect(virtual).toHaveClass(/shl-virtual/);
+
+  const { overflow, whiteSpace } = await virtual.evaluate((el) => {
+    const style = getComputedStyle(el);
+    return { overflow: style.overflow, whiteSpace: style.whiteSpace };
+  });
+  expect(overflow).toBe("auto");
+  expect(whiteSpace).toBe("pre");
+});
+
 test("HighlightVirtual - visible lines are separated by real newlines (selection/copy yields line breaks)", async ({
   mount,
   page,
@@ -1414,6 +1440,38 @@ test("HighlightVirtual - rebuilds and clamps scroll when `code` shrinks", async 
   expect(scrollTop).toBeLessThanOrEqual(
     Math.max(0, scrollHeight - clientHeight),
   );
+});
+
+test("HighlightVirtual - the sizer's huge intrinsic height never inflates the surrounding page's scroll height", async ({
+  mount,
+  page,
+}) => {
+  // Regression test: the hidden line-height probe is `position: absolute`
+  // with no `top`/`left` set, so it falls back to a "static position" -
+  // computed from unclipped document flow. Without `position: relative` on
+  // the component's own `<pre>`, the probe's containing block escaped past
+  // it (which correctly clips *visually* via `overflow: auto`) all the way
+  // up to the initial containing block, landing the probe near the sizer's
+  // full, un-clipped-for-this-purpose height and inflating
+  // `document.documentElement.scrollHeight` by the same amount - even
+  // though `document.body.scrollHeight` stayed small and correct.
+  await mount(HighlightVirtual);
+
+  const virtual = page.getByTestId("virtual");
+  await expect(virtual.locator("[data-line='0']")).toBeVisible();
+
+  const documentElementScrollHeight = await page.evaluate(
+    () => document.documentElement.scrollHeight,
+  );
+
+  // `documentElement.scrollHeight` is legitimately >= the viewport height
+  // even when actual content is shorter (nothing to do with this bug), so
+  // this isn't compared for exact equality against body.scrollHeight - the
+  // meaningful assertion is the bound: the leak this test guards against
+  // inflates it to roughly the sizer's full height (5,000 lines * a
+  // per-line height that would need to be in the thousands of pixels to
+  // reach this bound), many orders of magnitude past any real viewport.
+  expect(documentElementScrollHeight).toBeLessThan(20_000);
 });
 
 test("Typewriter - animates then settles to the full highlighted content", async ({

--- a/tests/highlight-virtual-ssr.test.ts
+++ b/tests/highlight-virtual-ssr.test.ts
@@ -1,0 +1,57 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+import typescript from "../src/languages/typescript.js";
+
+const componentPath = path.join(
+  import.meta.dir,
+  "../src/HighlightVirtual.svelte",
+);
+
+async function compileForServer() {
+  const source = fs.readFileSync(componentPath, "utf-8");
+  const { js } = compile(source, {
+    generate: "server",
+    filename: "HighlightVirtual.svelte",
+  });
+
+  // Written alongside the component (not in tests/) so its relative
+  // imports (e.g. "./tokenized-document.js") resolve.
+  const outPath = path.join(
+    import.meta.dir,
+    "../src/.tmp-highlight-virtual.server.js",
+  );
+  fs.writeFileSync(outPath, js.code);
+  try {
+    return await import(pathToFileURL(outPath).href);
+  } finally {
+    fs.unlinkSync(outPath);
+  }
+}
+
+describe("HighlightVirtual SSR", () => {
+  it("renders the full code as plain escaped text, not tokenized HTML", async () => {
+    const { default: HighlightVirtual } = await compileForServer();
+
+    const lines = Array.from({ length: 50 }, (_, i) => `const x${i} = ${i};`);
+    const code = `${lines.join("\n")}\na < b`;
+
+    const { body } = render(HighlightVirtual, {
+      props: { language: typescript, code },
+    });
+
+    // No tokenization: no scope spans, no windowed-line markup (the hidden
+    // line-height probe legitimately renders even pre-hydration, but it
+    // carries no `data-line`).
+    expect(body).not.toContain("hljs-keyword");
+    expect(body).not.toContain("data-line");
+    expect(body).not.toContain("shl-virtual-sizer");
+    expect(body).not.toContain("shl-virtual-window");
+
+    // The full document is present, plain-text-escaped.
+    expect(body).toContain("a &lt; b");
+    for (const line of lines) expect(body).toContain(line);
+  });
+});

--- a/tests/tokenized-document.test.ts
+++ b/tests/tokenized-document.test.ts
@@ -1,0 +1,322 @@
+/**
+ * The load-bearing invariant for windowed rendering: `TokenizedDocument`'s
+ * checkpoint/resume machinery must never change output relative to a plain,
+ * uncheckpointed parse of the *same truncated prefix* - i.e. checkpointing
+ * itself introduces zero divergence, at any checkpointInterval, for any
+ * window.
+ *
+ * Note this reference is intentionally *not* a full-document canonical
+ * parse: a window's `end` truncates the input, and constructs needing
+ * multi-line lookahead beyond that cut (documented in
+ * tokenized-document.js's "Fidelity caveat") can legitimately render
+ * differently near the boundary than they would with the rest of the
+ * document visible. That gap exists for *any* truncated-prefix parse,
+ * checkpointed or not (verified below), so it isn't something checkpointing
+ * could introduce or fix. Full-document equivalence is still asserted
+ * wherever a window's `end` reaches the true end of the document, where no
+ * truncation is in play.
+ */
+import { createRegistry, extendLines, registerAll } from "../src/engine.js";
+import type { LanguageType } from "../src/languages";
+import * as languages from "../src/languages/index.js";
+import javascript from "../src/languages/javascript.js";
+import { createTokenizedDocument } from "../src/tokenized-document.js";
+import { CUSTOM_SNIPPETS } from "./differential-corpus.ts";
+
+const registry = createRegistry();
+for (const language of Object.values(languages))
+  registerAll(registry, language);
+
+/** One entry per line-start offset, matching TokenizedDocument's own convention. */
+function lineStartOffsets(code: string): number[] {
+  const offsets = [0];
+  for (let i = 0; i < code.length; i++) {
+    if (code.charCodeAt(i) === 10) offsets.push(i + 1);
+  }
+  return offsets;
+}
+
+/** One-shot reference: full parse, single extendLines pass, no checkpoints. */
+function referenceLines(languageName: string, code: string): string[] {
+  const events = registry.tokenize(code, languageName).events;
+  const result = extendLines(events, [], "");
+  return [...result.completedLines, result.pendingHtml];
+}
+
+/**
+ * Reference for a window ending at line `end`: a plain (uncheckpointed,
+ * unresumed) parse of the prefix truncated at `end`'s boundary - the same
+ * input TokenizedDocument's checkpoint/resume path effectively sees.
+ */
+function referenceWindow(
+  languageName: string,
+  code: string,
+  offsets: number[],
+  end: number,
+): string[] {
+  const cut = end < offsets.length ? offsets[end] : code.length;
+  return referenceLines(languageName, code.slice(0, cut));
+}
+
+/** Deterministic PRNG (mulberry32) so a failing seed reproduces exactly. */
+function mulberry32(seed: number) {
+  let state = seed;
+  return () => {
+    state |= 0;
+    state = (state + 0x6d2b79f5) | 0;
+    let t = Math.imul(state ^ (state >>> 15), 1 | state);
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+  };
+}
+
+const CHECKPOINT_INTERVALS = [3, 100];
+
+describe("TokenizedDocument: checkpoint/resume equivalence (corpus, exhaustive small windows)", () => {
+  for (const [name, code] of Object.entries(CUSTOM_SNIPPETS)) {
+    const language = (
+      languages as unknown as Record<string, LanguageType<string>>
+    )[name];
+    if (!language) continue;
+
+    const offsets = lineStartOffsets(code);
+    const totalLines = offsets.length;
+
+    for (const checkpointInterval of CHECKPOINT_INTERVALS) {
+      it(`${name} (checkpointInterval=${checkpointInterval})`, () => {
+        const doc = createTokenizedDocument({ language, checkpointInterval });
+        doc.setCode(code);
+
+        expect(doc.lineCount()).toBe(totalLines);
+
+        for (let end = 0; end <= totalLines; end++) {
+          const windowRef = referenceWindow(name, code, offsets, end);
+          for (let start = 0; start <= end; start++) {
+            expect(doc.lineRange(start, end)).toEqual(
+              windowRef.slice(start, end),
+            );
+          }
+        }
+
+        // No truncation at the true end: matches the full canonical parse.
+        expect(doc.lineRange(0, totalLines)).toEqual(
+          referenceLines(name, code),
+        );
+      });
+    }
+  }
+});
+
+/**
+ * A multi-thousand-line synthetic document with periodic multi-line
+ * constructs (block comments, multi-line template literals) so checkpoint
+ * batches sometimes land mid-construct - the case where the tokenizer's
+ * committed position lags the fed line boundary. Unlike the mdx corpus
+ * case above, these constructs are simple scope continuations (no
+ * begin-match lookahead), so windows cut mid-construct still match the
+ * full-document reference - asserted directly below.
+ */
+function generateLargeJsDocument(lineCount: number): string {
+  const parts: string[] = [];
+  let i = 0;
+  while (i < lineCount) {
+    if (i % 137 === 0) {
+      parts.push(`/* comment start at line ${i}`);
+      parts.push("   still inside the comment");
+      parts.push(`   still inside the comment (${i})`);
+      parts.push("   comment end */");
+      i += 4;
+    } else if (i % 53 === 0) {
+      parts.push(`const s${i} = \`template line ${i} continues`);
+      parts.push(`  more text \${1 + ${i}}\`;`);
+      i += 2;
+    } else {
+      parts.push(`const x${i} = ${i} + 1; // line ${i}`);
+      i += 1;
+    }
+  }
+  return `${parts.join("\n")}\n`;
+}
+
+describe("TokenizedDocument: checkpoint/resume equivalence (large document, randomized windows)", () => {
+  const LargeCode = generateLargeJsDocument(3000);
+  const expected = referenceLines("javascript", LargeCode);
+
+  for (const checkpointInterval of CHECKPOINT_INTERVALS) {
+    it(`randomized windows (checkpointInterval=${checkpointInterval})`, () => {
+      const doc = createTokenizedDocument({
+        language: javascript,
+        checkpointInterval,
+      });
+      doc.setCode(LargeCode);
+      expect(doc.lineCount()).toBe(expected.length);
+
+      // Small, viewport-sized windows scattered across the document - the
+      // realistic access pattern (scrolling) this module is built for.
+      // Wide windows are already covered by the boundary/out-of-order tests
+      // below and by the full-document check; generating hundreds of
+      // large-random-width windows here would make this O(trials * n).
+      const rng = mulberry32(0xc0ffee ^ checkpointInterval);
+      for (let trial = 0; trial < 200; trial++) {
+        const start = Math.floor(rng() * expected.length);
+        const width = Math.floor(rng() * 150);
+        const end = Math.min(start + width, expected.length);
+        expect(doc.lineRange(start, end)).toEqual(expected.slice(start, end));
+      }
+    });
+
+    it(`windows straddling checkpoint boundaries (checkpointInterval=${checkpointInterval})`, () => {
+      const doc = createTokenizedDocument({
+        language: javascript,
+        checkpointInterval,
+      });
+      doc.setCode(LargeCode);
+
+      for (
+        let boundary = checkpointInterval;
+        boundary < expected.length;
+        boundary += checkpointInterval
+      ) {
+        // exactly at, and straddling, a checkpoint boundary
+        expect(doc.lineRange(boundary, boundary + 5)).toEqual(
+          expected.slice(boundary, boundary + 5),
+        );
+        expect(doc.lineRange(boundary - 2, boundary + 2)).toEqual(
+          expected.slice(boundary - 2, boundary + 2),
+        );
+      }
+
+      // the very end of the document, out of order relative to the boundary scan above
+      expect(doc.lineRange(expected.length - 3, expected.length)).toEqual(
+        expected.slice(expected.length - 3),
+      );
+    });
+
+    it(`out-of-order random access (checkpointInterval=${checkpointInterval})`, () => {
+      const doc = createTokenizedDocument({
+        language: javascript,
+        checkpointInterval,
+      });
+      doc.setCode(LargeCode);
+
+      // Jump straight to a distant window before anything nearby has been
+      // tokenized, then jump backward into earlier territory.
+      expect(doc.lineRange(2500, 2540)).toEqual(expected.slice(2500, 2540));
+      expect(doc.lineRange(10, 50)).toEqual(expected.slice(10, 50));
+      expect(doc.lineRange(1200, 1210)).toEqual(expected.slice(1200, 1210));
+      expect(doc.lineRange(0, expected.length)).toEqual(expected);
+    });
+  }
+
+  it("a document whose final line has no trailing newline", () => {
+    const code = LargeCode.slice(0, -1); // strip the trailing "\n"
+    const noTrailingExpected = referenceLines("javascript", code);
+    const doc = createTokenizedDocument({
+      language: javascript,
+      checkpointInterval: 100,
+    });
+    doc.setCode(code);
+    expect(doc.lineCount()).toBe(noTrailingExpected.length);
+    expect(doc.lineRange(0, doc.lineCount())).toEqual(noTrailingExpected);
+    expect(doc.lineRange(doc.lineCount() - 5, doc.lineCount())).toEqual(
+      noTrailingExpected.slice(-5),
+    );
+  });
+});
+
+describe("TokenizedDocument: behavior", () => {
+  it("lineCount never tokenizes", () => {
+    const doc = createTokenizedDocument({ language: javascript });
+    doc.setCode(generateLargeJsDocument(500));
+    expect(doc.lineCount()).toBeGreaterThan(0);
+    expect(doc.tokenizedThrough()).toBe(0);
+  });
+
+  it("laziness: lineRange(0, 40) leaves tokenizedThrough() bounded by one interval past 40", () => {
+    const doc = createTokenizedDocument({
+      language: javascript,
+      checkpointInterval: 100,
+    });
+    doc.setCode(generateLargeJsDocument(5000));
+    doc.lineRange(0, 40);
+    expect(doc.tokenizedThrough()).toBeGreaterThanOrEqual(40);
+    expect(doc.tokenizedThrough()).toBeLessThanOrEqual(140);
+  });
+
+  it("append is equivalent to setCode(old + chunk), across chunk shapes", () => {
+    const full = generateLargeJsDocument(400);
+    const expected = referenceLines("javascript", full);
+
+    const splitPoints = [
+      // no-newline chunk boundary (mid-token)
+      full.indexOf("const x5") + 3,
+      // multi-line chunk boundary
+      full.indexOf("\n", 200) + 1,
+    ].filter((i) => i > 0 && i < full.length);
+
+    for (const splitAt of splitPoints) {
+      const doc = createTokenizedDocument({
+        language: javascript,
+        checkpointInterval: 7,
+      });
+      doc.setCode(full.slice(0, splitAt));
+      doc.append(full.slice(splitAt));
+      expect(doc.lineRange(0, doc.lineCount())).toEqual(expected);
+    }
+  });
+
+  it("append never re-tokenizes already-checkpointed content", () => {
+    const doc = createTokenizedDocument({
+      language: javascript,
+      checkpointInterval: 50,
+    });
+    doc.setCode(generateLargeJsDocument(200));
+    doc.lineRange(0, 100);
+    const throughBeforeAppend = doc.tokenizedThrough();
+
+    doc.append(generateLargeJsDocument(50));
+    // Appending alone (no lineRange call) must not advance tokenization.
+    expect(doc.tokenizedThrough()).toBe(throughBeforeAppend);
+  });
+
+  it("window cache: repeated and overlapping calls return consistent results", () => {
+    const code = generateLargeJsDocument(600);
+    const expected = referenceLines("javascript", code);
+    const doc = createTokenizedDocument({
+      language: javascript,
+      checkpointInterval: 40,
+    });
+    doc.setCode(code);
+
+    const first = doc.lineRange(100, 140);
+    expect(first).toEqual(expected.slice(100, 140));
+    // Same call again (cache hit path).
+    expect(doc.lineRange(100, 140)).toEqual(first);
+    // Overlapping, larger window (cache extension or recompute - either way, correct).
+    expect(doc.lineRange(90, 160)).toEqual(expected.slice(90, 160));
+    // Back to the original window still matches.
+    expect(doc.lineRange(100, 140)).toEqual(first);
+  });
+
+  it("setCode with unrelated content fully resets (does not treat it as an append)", () => {
+    const doc = createTokenizedDocument({ language: javascript });
+    doc.setCode(generateLargeJsDocument(50));
+    doc.lineRange(0, 10);
+
+    const other = "const totally = 'different document';\nconst b = 2;\n";
+    doc.setCode(other);
+    expect(doc.tokenizedThrough()).toBe(0);
+    expect(doc.lineCount()).toBe(referenceLines("javascript", other).length);
+    expect(doc.lineRange(0, doc.lineCount())).toEqual(
+      referenceLines("javascript", other),
+    );
+  });
+
+  it("empty document", () => {
+    const doc = createTokenizedDocument({ language: javascript });
+    doc.setCode("");
+    expect(doc.lineCount()).toBe(1);
+    expect(doc.lineRange(0, 1)).toEqual([""]);
+    expect(doc.lineRange(0, 0)).toEqual([]);
+  });
+});

--- a/www/components/HighlightVirtual/Basic.svelte
+++ b/www/components/HighlightVirtual/Basic.svelte
@@ -1,0 +1,31 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { HighlightVirtual } from "svelte-highlight";
+  import json from "svelte-highlight/languages/json";
+  import {
+    generateJsonLog,
+    trackRenderedLineCount,
+  } from "./generate-large-code.js";
+
+  const LINE_COUNT = 80_000;
+  const code = generateJsonLog(LINE_COUNT);
+
+  let renderedLineCount = 0;
+</script>
+
+<p class="label-01 mb-3">
+  {LINE_COUNT.toLocaleString()}
+  lines, rendered instantly. Only
+  <strong>{renderedLineCount}</strong>
+  line nodes are ever in the DOM at once -- scroll to confirm the count stays
+  flat.
+</p>
+
+<div use:trackRenderedLineCount={(n) => (renderedLineCount = n)}>
+  <HighlightVirtual
+    language={json}
+    {code}
+    class={THEME_MODULE_NAME}
+    style="height: 320px"
+  />
+</div>

--- a/www/components/HighlightVirtual/CodeSwap.svelte
+++ b/www/components/HighlightVirtual/CodeSwap.svelte
@@ -1,0 +1,41 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import { HighlightVirtual } from "svelte-highlight";
+  import json from "svelte-highlight/languages/json";
+  import { generateJsonLog } from "./generate-large-code.js";
+
+  const documents = [
+    { label: "30,000 lines", code: generateJsonLog(30_000) },
+    { label: "3,000 lines", code: generateJsonLog(3_000) },
+  ];
+
+  let active = 0;
+  $: code = documents[active].code;
+</script>
+
+<p class="label-01 mb-3">
+  Swapping <code class="code">code</code> for a different (here, much shorter)
+  document rebuilds the underlying <code class="code">TokenizedDocument</code>
+  and clamps an out-of-range scroll position -- try scrolling to the bottom of
+  the long document, then switching.
+</p>
+
+<div style="display: flex; gap: 0.5rem; margin-bottom: 0.75rem">
+  {#each documents as doc, i}
+    <Button
+      size="small"
+      kind={active === i ? "primary" : "tertiary"}
+      on:click={() => (active = i)}
+    >
+      {doc.label}
+    </Button>
+  {/each}
+</div>
+
+<HighlightVirtual
+  language={json}
+  {code}
+  class={THEME_MODULE_NAME}
+  style="height: 260px"
+/>

--- a/www/components/HighlightVirtual/Controls.svelte
+++ b/www/components/HighlightVirtual/Controls.svelte
@@ -1,0 +1,80 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button, Slider } from "carbon-components-svelte";
+  import { HighlightVirtual } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import {
+    generateTypeScript,
+    trackRenderedLineCount,
+  } from "./generate-large-code.js";
+
+  const LINE_COUNT = 20_000;
+  const code = generateTypeScript(LINE_COUNT);
+
+  let overscan = 12;
+  let checkpointInterval = 100;
+  let renderedLineCount = 0;
+  let jumpToLine = 10_000;
+
+  /** @type {HTMLElement} */
+  let wrapper;
+
+  function jump() {
+    const pre = wrapper?.querySelector("pre");
+    if (!pre) return;
+    const target = Math.max(0, Math.min(jumpToLine, LINE_COUNT));
+    // Line height isn't known here; overshoot and let the browser clamp,
+    // then nudge back a viewport so the target line lands mid-screen.
+    pre.scrollTop = target * 20;
+  }
+</script>
+
+<div
+  bind:this={wrapper}
+  use:trackRenderedLineCount={(n) => (renderedLineCount = n)}
+>
+  <HighlightVirtual
+    language={typescript}
+    {code}
+    {overscan}
+    {checkpointInterval}
+    class={THEME_MODULE_NAME}
+    style="height: 320px"
+  />
+</div>
+
+<div
+  style="display: flex; flex-wrap: wrap; align-items: flex-end; gap: 1.5rem; margin-top: 1rem"
+>
+  <Slider
+    bind:value={overscan}
+    min={0}
+    max={100}
+    step={4}
+    labelText="overscan (extra lines above/below the viewport)"
+  />
+  <Slider
+    bind:value={checkpointInterval}
+    min={10}
+    max={500}
+    step={10}
+    labelText="checkpointInterval (lines between engine checkpoints)"
+  />
+  <div style="display: flex; align-items: flex-end; gap: 0.5rem">
+    <label class="label-01" for="jump-to-line">
+      Jump to line (of {LINE_COUNT.toLocaleString()})
+      <input
+        id="jump-to-line"
+        type="number"
+        min="0"
+        max={LINE_COUNT}
+        bind:value={jumpToLine}
+        style="display: block; margin-top: 0.25rem"
+      >
+    </label>
+    <Button size="small" kind="tertiary" on:click={jump}>Jump</Button>
+  </div>
+  <p class="label-01" style="margin-bottom: 0.5rem">
+    Rendered line nodes: <code class="code">{renderedLineCount}</code>
+  </p>
+</div>

--- a/www/components/HighlightVirtual/Headless.svelte
+++ b/www/components/HighlightVirtual/Headless.svelte
@@ -1,0 +1,73 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import typescript from "svelte-highlight/languages/typescript";
+  import { createTokenizedDocument } from "svelte-highlight/tokenized-document";
+  import { generateTypeScript } from "./generate-large-code.js";
+
+  const LINE_COUNT = 25_000;
+  const code = generateTypeScript(LINE_COUNT);
+
+  const doc = createTokenizedDocument({ language: typescript });
+  doc.setCode(code);
+
+  let start = 15_000;
+  let end = 15_010;
+  /** @type {string[]} */
+  let lines = [];
+  let tokenizedThrough = doc.tokenizedThrough();
+
+  function run() {
+    const clampedStart = Math.max(0, Math.min(start, LINE_COUNT));
+    const clampedEnd = Math.max(clampedStart, Math.min(end, LINE_COUNT));
+    lines = doc.lineRange(clampedStart, clampedEnd);
+    tokenizedThrough = doc.tokenizedThrough();
+  }
+
+  // Show a live result immediately rather than an empty box pre-interaction.
+  run();
+</script>
+
+<p class="label-01 mb-3">
+  <code class="code">TokenizedDocument</code>, headless -- no component, no DOM
+  virtualization, just <code class="code">lineRange(start, end)</code> for a
+  {LINE_COUNT.toLocaleString()}-line document. Useful for custom virtualization,
+  servers, or tests.
+</p>
+
+<div style="display: flex; flex-wrap: wrap; align-items: flex-end; gap: 1rem">
+  <label class="label-01" for="range-start">
+    start
+    <input
+      id="range-start"
+      type="number"
+      min="0"
+      max={LINE_COUNT}
+      bind:value={start}
+      style="display: block; margin-top: 0.25rem"
+    >
+  </label>
+  <label class="label-01" for="range-end">
+    end
+    <input
+      id="range-end"
+      type="number"
+      min="0"
+      max={LINE_COUNT}
+      bind:value={end}
+      style="display: block; margin-top: 0.25rem"
+    >
+  </label>
+  <Button size="small" kind="tertiary" on:click={run}
+    >lineRange(start, end)</Button
+  >
+  <p class="label-01" style="margin-bottom: 0.5rem">
+    tokenizedThrough(): <code class="code">{tokenizedThrough}</code>
+  </p>
+</div>
+
+{#if lines.length}
+  <pre class={THEME_MODULE_NAME} style="margin-top: 0.75rem"><code
+      class:hljs={true}>{#each lines as line, i}{#if i > 0}{"\n"}{/if}{@html line}{/each}</code
+    ></pre>
+{/if}

--- a/www/components/HighlightVirtual/InsideCodeWindow.svelte
+++ b/www/components/HighlightVirtual/InsideCodeWindow.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { CodeWindow, HighlightVirtual } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import { generateTypeScript } from "./generate-large-code.js";
+
+  const code = generateTypeScript(15_000);
+</script>
+
+<CodeWindow variant="macos" title="huge-file.ts">
+  <HighlightVirtual
+    language={typescript}
+    {code}
+    class={THEME_MODULE_NAME}
+    style="height: 260px"
+  />
+</CodeWindow>

--- a/www/components/HighlightVirtual/Languages.svelte
+++ b/www/components/HighlightVirtual/Languages.svelte
@@ -1,0 +1,38 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Column, Row } from "carbon-components-svelte";
+  import { HighlightVirtual } from "svelte-highlight";
+  import css from "svelte-highlight/languages/css";
+  import markdown from "svelte-highlight/languages/markdown";
+  import { generateCss, generateMarkdown } from "./generate-large-code.js";
+
+  const languages = [
+    {
+      name: "Markdown",
+      language: markdown,
+      code: generateMarkdown(3_000),
+    },
+    {
+      name: "CSS",
+      language: css,
+      code: generateCss(8_000),
+    },
+  ];
+</script>
+
+<Row>
+  {#each languages as { name, language, code }}
+    <Column xlg={8} lg={8} md={12} class="mb-5">
+      <div class="label-01 mb-3">
+        {name}
+        -- {code.split("\n").length.toLocaleString()} lines
+      </div>
+      <HighlightVirtual
+        {language}
+        {code}
+        class={THEME_MODULE_NAME}
+        style="height: 260px"
+      />
+    </Column>
+  {/each}
+</Row>

--- a/www/components/HighlightVirtual/generate-large-code.js
+++ b/www/components/HighlightVirtual/generate-large-code.js
@@ -1,0 +1,102 @@
+/**
+ * A JSON array log dump, the "huge log file" shape HighlightVirtual targets.
+ * One string per line (rather than an object with several keys) so a
+ * 100k-line demo stays comfortably under the engine's per-parse iteration
+ * ceiling - see the "one token per line" note on token density below.
+ * @param {number} lines
+ */
+export function generateJsonLog(lines) {
+  const parts = [];
+  for (let i = 0; i < lines; i++) {
+    const level = i % 97 === 0 ? "ERROR" : i % 11 === 0 ? "WARN " : "INFO ";
+    const comma = i < lines - 1 ? "," : "";
+    const timestamp = String(i).padStart(6, "0");
+    parts.push(`  "${timestamp} ${level} processed item ${i}"${comma}`);
+  }
+  return `[\n${parts.join("\n")}\n]\n`;
+}
+
+/**
+ * A TypeScript-shaped file with enough structural variety to look real.
+ * @param {number} lines
+ */
+export function generateTypeScript(lines) {
+  const parts = [];
+  let i = 0;
+  while (i < lines) {
+    if (i % 200 === 0) {
+      parts.push("/**", ` * Section starting at line ${i}.`, " */");
+      i += 3;
+    } else if (i % 50 === 0) {
+      parts.push(
+        `export interface Row${i} {`,
+        "  id: number;",
+        "  label: string;",
+        "}",
+      );
+      i += 4;
+    } else {
+      parts.push(`export const value${i} = ${i} * 2; // line ${i}`);
+      i += 1;
+    }
+  }
+  return `${parts.join("\n")}\n`;
+}
+
+/**
+ * A long, repetitive Markdown document (headings + prose + a list).
+ * @param {number} sections
+ */
+export function generateMarkdown(sections) {
+  const parts = [];
+  for (let i = 0; i < sections; i++) {
+    parts.push(
+      `## Section ${i}`,
+      "",
+      `Line ${i * 4 + 1} of a very long document. Lorem ipsum dolor sit amet.`,
+      "",
+      `- item ${i}.a`,
+      `- item ${i}.b`,
+      "",
+    );
+  }
+  return `${parts.join("\n")}\n`;
+}
+
+/**
+ * A long, repetitive CSS stylesheet (one rule block per generated selector).
+ * @param {number} rules
+ */
+export function generateCss(rules) {
+  const parts = [];
+  for (let i = 0; i < rules; i++) {
+    parts.push(
+      `.generated-${i} {`,
+      `  color: hsl(${(i * 37) % 360}deg 70% 50%);`,
+      `  padding: ${i % 8}px;`,
+      "}",
+    );
+  }
+  return `${parts.join("\n")}\n`;
+}
+
+/**
+ * Svelte action: counts `[data-line]` descendants (the actual rendered line
+ * nodes, excluding the hidden line-height probe) and reports it via
+ * `onCount`, re-measuring on every DOM mutation - hydration swapping in the
+ * windowed view, and every subsequent scroll-driven repaint.
+ * @param {HTMLElement} node
+ * @param {(count: number) => void} onCount
+ */
+export function trackRenderedLineCount(node, onCount) {
+  const measure = () => onCount(node.querySelectorAll("[data-line]").length);
+  const observer = new MutationObserver(measure);
+  observer.observe(node, {
+    childList: true,
+    subtree: true,
+    attributes: true,
+    attributeFilter: ["style"],
+  });
+  measure();
+  return { destroy: () => observer.disconnect() };
+}

--- a/www/components/HighlightVirtualPreview.svelte
+++ b/www/components/HighlightVirtualPreview.svelte
@@ -1,0 +1,43 @@
+<script>
+  import Basic from "@components/HighlightVirtual/Basic.svelte";
+  import CodeSwap from "@components/HighlightVirtual/CodeSwap.svelte";
+  import Controls from "@components/HighlightVirtual/Controls.svelte";
+  import Headless from "@components/HighlightVirtual/Headless.svelte";
+  import InsideCodeWindow from "@components/HighlightVirtual/InsideCodeWindow.svelte";
+  import Languages from "@components/HighlightVirtual/Languages.svelte";
+  import { Column, Row } from "carbon-components-svelte";
+</script>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Basic: a 50,000-line JSON log</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Basic /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}>
+    <h3>overscan / checkpointInterval / random access</h3>
+  </Column>
+  <Column xlg={12} lg={12} md={12}> <Controls /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Across languages</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Languages /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Swapping documents</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <CodeSwap /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Composing with CodeWindow</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <InsideCodeWindow /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}>
+    <h3>Headless: svelte-highlight/tokenized-document</h3>
+  </Column>
+  <Column xlg={12} lg={12} md={12}> <Headless /> </Column>
+</Row>

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -72,6 +72,7 @@
     "/preview-dual-theme": "Dual light/dark HighlightStyle preview",
     "/preview-editable": "Editable highlight preview",
     "/preview-highlight-stream": "HighlightStream preview",
+    "/preview-virtual": "HighlightVirtual preview",
     "/preview-jq": "jq language preview",
     "/preview-kql": "KQL language preview",
     "/preview-logql": "LogQL language preview",

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -14,6 +14,9 @@
   import EditableCssHighlights from "@components/HighlightEditable/CssHighlights.svelte";
   import HighlightStreamBasic from "@components/HighlightStream/Basic.svelte";
   import HighlightStreamControls from "@components/HighlightStream/Controls.svelte";
+  import HighlightVirtualBasic from "@components/HighlightVirtual/Basic.svelte";
+  import HighlightVirtualControls from "@components/HighlightVirtual/Controls.svelte";
+  import HighlightVirtualHeadless from "@components/HighlightVirtual/Headless.svelte";
   import Basic from "@components/LineNumbers/Basic.svelte";
   import ContainerStyle from "@components/LineNumbers/ContainerStyle.svelte";
   import FocusLines from "@components/LineNumbers/FocusLines.svelte";
@@ -565,10 +568,67 @@
       hideCloseButton
       kind="info"
       title="Performance"
-      subtitle="O(buffer) per highlighted frame, DOM updates proportional to changed lines—fine for chat-sized output up to a few thousand lines, not a virtualized log viewer."
+      subtitle="Per-chunk work is O(tail), not O(stream length so far): finished output is sealed into immutable chunks the DOM never re-diffs. Fine for very long responses, but not a substitute for HighlightVirtual below if you also need to scroll through a huge, already-complete document."
     />
   </Column>
   <Column xlg={10} lg={10} md={12}> <HighlightStreamControls /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Large Documents</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">HighlightVirtual</code>
+      renders only the visible lines of a huge document (plus a small
+      <code class="code">overscan</code>
+      margin) inside its own scroll container—a 100k-line file costs a couple
+      dozen DOM line nodes, not one per line. It reuses the same engine
+      checkpoint/resume primitive
+      <code class="code">HighlightStream</code>
+      uses for streaming, but for random-access windows into a static document
+      instead of a growing tail.
+    </p>
+    <p class="mb-5">
+      The rendered <code class="code">pre</code> is the scroll container
+      itself—size it with <code class="code">style</code>/
+      <code class="code">class</code>/other props, same as
+      <code class="code">Highlight</code>. Content doesn't wrap (uniform line
+      height is a v1 constraint, measured once from a rendered probe line).
+      Server-rendered output is the full document as plain escaped text; the
+      windowed, highlighted view takes over after hydration.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <HighlightVirtualBasic /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">overscan</code>
+      (default <code class="code">12</code>) controls how many extra lines
+      render above/below the viewport;
+      <code class="code">checkpointInterval</code>
+      (default <code class="code">100</code>) controls how often the engine
+      snapshots its parse state, trading a little memory for cheaper random
+      access. Try jumping to a distant line below.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <HighlightVirtualControls /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      For custom virtualization, servers, or tests,
+      <code class="code">svelte-highlight/tokenized-document</code>
+      exposes the same windowing primitive headlessly via
+      <code class="code">createTokenizedDocument</code>
+      and its <code class="code">lineRange(start, end)</code> method, which
+      tokenizes lazily and caches the most recently resolved window.
+    </p>
+    <InlineNotification
+      lowContrast
+      hideCloseButton
+      kind="info"
+      title="Note:"
+      subtitle="Output matches HighlightStream's live (non-canonicalized) parse: constructs needing multi-line lookahead across a window's edge can render slightly differently than Highlight's canonical output. No mid-document edits—append and full setCode resets only."
+    />
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <HighlightVirtualHeadless /> </Column>
 </Row>
 
 <Row class="mb-9">

--- a/www/pages/preview-virtual.astro
+++ b/www/pages/preview-virtual.astro
@@ -1,0 +1,8 @@
+---
+import HighlightVirtualPreview from "@components/HighlightVirtualPreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="HighlightVirtual preview">
+  <HighlightVirtualPreview client:idle />
+</Layout>


### PR DESCRIPTION
HighlightStream's per-chunk repaint cost grows with total stream
length, and there was no way to render a huge static document
without tokenizing and painting all of it up front.

Adds `TokenizedDocument`, an engine-backed index that checkpoints
the tokenizer every N lines so any line range resolves in
O(window + interval), and `HighlightVirtual`, a windowed-scrolling
component built on it. Restructures `HighlightStream` to seal
finished output into immutable chunks with append-only bookkeeping,
so repaint cost is O(live tail) instead of O(stream so far), with
its props, events, and output unchanged. Also fixes two bugs
surfaced while writing the `HighlightVirtual` docs: a class-merging
bug that dropped the component's own layout CSS whenever a consumer
passed `class`, and a CSS positioning bug where the hidden
line-height probe inflated the page's scroll height. Adds a "Large
Documents" docs section and an unlisted `preview-virtual` page.

Additive for the library: one new component, one new module, no API
changes to existing components. The riskiest piece is the
`HighlightStream` internal restructure; it's covered by the existing
stream test suite plus new DOM-stability tests, but a subtle sealing
bug could show up as stale or duplicated line content in very long
streams.
