### PR TITLE
feat(components): add a css-highlights engine to Highlight

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,32 @@ See [SUPPORTED_LANGUAGES.md](SUPPORTED_LANGUAGES.md) for a list of supported lan
 <Highlight language={typescript} {code} />
 ```
 
+## CSS Custom Highlight engine
+
+`engine="css-highlights"` paints tokens with the [CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API) (`CSS.highlights`, `::highlight()`) instead of wrapping each one in a `<span>`. `Highlight` renders the code as a single text node plus painted ranges — a 5,000-token file adds zero extra elements, instead of thousands of `<span>`s.
+
+Requires Chrome 105+, Safari 17.2+, or Firefox 140+. There is no `CSS.highlights` on the server, so SSR always renders the same span markup as `engine="dom"`; once hydrated in a supporting browser, the client swaps to the single-text-node rendering. Where `CSS.highlights` is unavailable, `Highlight` falls back to `engine="dom"` silently — check what actually ran with `highlight.resolvedEngine()`.
+
+Pass `theme` (a theme string, or a `ThemePalette` from `svelte-highlight/themes`) to generate `::highlight()` rules from it. Only `color`/`background-color` convert — `::highlight()` doesn't support `font-style`/`font-weight`/`text-decoration` across browsers, so bold/italic scopes render in plain color. `theme` only covers token colors — you still need `HighlightStyle` (or an injected stylesheet) for the base `.hljs` layout rules (padding, overflow, background), exactly as with the default engine.
+
+```svelte
+<script>
+  import { Highlight, HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/themes/atom-one-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<HighlightStyle theme={atomOneDark}>
+  <Highlight language={typescript} {code} engine="css-highlights" theme={atomOneDark} />
+</HighlightStyle>
+```
+
+This only takes effect when `Highlight` renders its own default markup — a custom default slot (e.g. to feed `LineNumbers`) has no `Highlight`-owned `<code>` element to paint into, so `engine` has no effect there; consume the slot's `events` prop directly (see [Headless usage](#headless-usage)) to build a custom renderer instead.
+
+`HighlightEditable` has the same engine, with the same theme/color-only rules — see [Experimental: CSS Custom Highlight engine](#experimental-css-custom-highlight-engine) for its editable-specific behavior (per-line painting, caret preservation).
+
 ## Theming
 
 Every `highlight.js` theme is also compiled into a **`ThemePalette`**: a typed object of `--shl-*` CSS custom properties plus a shared structural stylesheet (`svelte-highlight/themes/base.css`) that maps `.hljs*` classes to those variables. This is the recommended way to theme new projects — themes are data, scoping is an inline `style` attribute (SSR-safe by construction), and any token is overridable with one CSS line or a Svelte style prop. See [SUPPORTED_THEMES.md](SUPPORTED_THEMES.md) for a list of compiled themes.

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -8,7 +8,50 @@
   /** @type {boolean} */
   export let langtag = false;
 
-  import { afterUpdate, createEventDispatcher } from "svelte";
+  /**
+   * Rendering engine. `"css-highlights"` paints tokens via the CSS Custom
+   * Highlight API (`CSS.highlights`) over a single text node instead of
+   * wrapping each token in a `<span>`, so a highlighted block never grows
+   * a `<span>` per token — a 5,000-token file adds zero extra elements.
+   * Falls back to `"dom"` silently where `CSS.highlights` is unavailable
+   * (SSR, or a browser without support); check what was actually used
+   * with the `resolvedEngine()` method.
+   *
+   * SSR always renders the `"dom"` engine's span markup — there is no
+   * `CSS.highlights` on the server. With `"css-highlights"` resolved
+   * client-side, the swap to a single text node plus painted ranges
+   * happens after hydration, mirroring `HighlightEditable`.
+   *
+   * Only takes effect when this component renders its own default
+   * markup: if a custom default slot is provided (e.g. to feed
+   * `LineNumbers`), there is no `Highlight`-owned `<code>` element to
+   * paint into and this prop has no effect — consume `events` directly
+   * (see `svelte-highlight/engine`) to build a custom renderer instead.
+   *
+   * Colors only: `::highlight()` doesn't support `font-style`/
+   * `font-weight`/`text-decoration` across browsers, so bold/italic scopes
+   * render plain in this mode.
+   * @type {"dom" | "css-highlights"}
+   */
+  export let engine = "dom";
+
+  /**
+   * Theme CSS from `svelte-highlight/styles/<theme>`, or a `ThemePalette`
+   * from `svelte-highlight/themes/<theme>`, used only in `"css-highlights"`
+   * mode to generate `::highlight()` rules. Colors only
+   * (`color`/`background-color`); other declarations are dropped.
+   * @type {string | import("./theme.d.ts").ThemePalette | undefined}
+   */
+  export let theme = undefined;
+
+  import { afterUpdate, createEventDispatcher, onMount } from "svelte";
+  import {
+    createHighlightPainter,
+    instanceHighlightRules,
+    nextInstanceId,
+    resolveEngine,
+  } from "./css-highlights.js";
+  import { toRanges } from "./engine.js";
   import LangTag from "./LangTag.svelte";
   import { ensureRegistered, registry } from "./registry.js";
 
@@ -18,24 +61,75 @@
    */
   const dispatch = createEventDispatcher();
 
+  const instanceId = nextInstanceId();
+  const painter = createHighlightPainter(instanceId);
+
   /** @type {string} */
   let highlighted = "";
 
   /** @type {import("./engine.d.ts").ScopeEvent[]} */
   let events = [];
 
-  afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted, events });
-  });
+  /** @type {HTMLElement | undefined} */
+  let codeElement;
+
+  let previousEngine;
+
+  $: resolvedEngineValue = resolveEngine(engine);
+
+  $: cssHighlightStyle =
+    resolvedEngineValue === "css-highlights" && theme !== undefined
+      ? `<style>${instanceHighlightRules(theme, instanceId)}</style>`
+      : "";
+
+  $: source = typeof code === "string" ? code : String(code ?? "");
 
   $: {
     ensureRegistered(language);
-    const source = typeof code === "string" ? code : String(code ?? "");
     const result = registry.highlight(source, { language: language.name });
     highlighted = result.value;
     events = result.events;
   }
+
+  // Bypasses LangTag's own `{@html highlighted}` markup with a single text
+  // node plus CSS.highlights ranges. Runs after every update (not just
+  // code/language/theme changes matter here — an engine-only toggle must
+  // also repaint), since LangTag may skip re-writing innerHTML when
+  // `highlighted` itself didn't change this cycle.
+  function paintCssHighlights() {
+    painter.clear();
+    if (!codeElement) return;
+    codeElement.textContent = source;
+    const textNode = codeElement.firstChild;
+    if (!(textNode instanceof Text)) return;
+    painter.paintNode(textNode, toRanges(events), 0, source.length);
+  }
+
+  afterUpdate(() => {
+    if (highlighted) dispatch("highlight", { highlighted, events });
+
+    if (resolvedEngineValue === "css-highlights") {
+      paintCssHighlights();
+    } else if (previousEngine === "css-highlights" && codeElement) {
+      painter.clear();
+      codeElement.innerHTML = highlighted;
+    }
+    previousEngine = resolvedEngineValue;
+  });
+
+  onMount(() => () => painter.clear());
+
+  /** The engine actually in use: `engine`, or `"dom"` if it was requested but unsupported. */
+  export function resolvedEngine() {
+    return resolvedEngineValue;
+  }
 </script>
+
+<svelte:head
+  >{#if cssHighlightStyle}
+    {@html cssHighlightStyle}
+  {/if}</svelte:head
+>
 
 <slot {highlighted} {langtag} languageName={language.name} {events}>
   <LangTag
@@ -44,5 +138,6 @@
     {langtag}
     {highlighted}
     {code}
+    bind:codeElement
   />
 </slot>

--- a/src/Highlight.svelte.d.ts
+++ b/src/Highlight.svelte.d.ts
@@ -2,6 +2,7 @@ import type { SvelteComponentTyped } from "svelte";
 import type { HTMLAttributes } from "svelte/elements";
 import type { ScopeEvent } from "./engine.d.ts";
 import type { LanguageType } from "./languages";
+import type { ThemePalette } from "./theme.d.ts";
 
 export type LangtagProps = {
   /**
@@ -70,6 +71,39 @@ export type HighlightProps = HTMLAttributes<HTMLPreElement> &
      * import typescript from "svelte-highlight/languages/typescript";
      */
     language: LanguageType<string>;
+
+    /**
+     * Rendering engine. `"css-highlights"` paints tokens via the CSS
+     * Custom Highlight API (`CSS.highlights`) over a single text node
+     * instead of wrapping each token in a `<span>`, so a highlighted
+     * block never grows a `<span>` per token. Falls back to `"dom"`
+     * silently where `CSS.highlights` is unavailable (SSR, or a browser
+     * without support); check what was actually used with the
+     * `resolvedEngine()` method.
+     *
+     * Only takes effect when this component renders its own default
+     * markup — a custom default slot (e.g. to feed `LineNumbers`) has no
+     * `Highlight`-owned `<code>` element to paint into, so this prop has
+     * no effect in that case.
+     *
+     * Colors only: `::highlight()` doesn't support `font-style`/
+     * `font-weight`/`text-decoration` across browsers, so bold/italic
+     * scopes render plain in this mode.
+     * @default "dom"
+     */
+    engine?: "dom" | "css-highlights";
+
+    /**
+     * Theme CSS from `svelte-highlight/styles/<theme>`, or a
+     * `ThemePalette` from `svelte-highlight/themes/<theme>`, used only in
+     * `"css-highlights"` mode to generate `::highlight()` rules. Colors
+     * only (`color`/`background-color`); other declarations are dropped.
+     * @example
+     * import a11yDark from "svelte-highlight/styles/a11y-dark";
+     * @example
+     * import atomOneDark from "svelte-highlight/themes/atom-one-dark";
+     */
+    theme?: string | ThemePalette;
   };
 
 export type HighlightEvents = {
@@ -110,4 +144,10 @@ export default class Highlight extends SvelteComponentTyped<
   HighlightProps,
   HighlightEvents,
   HighlightSlots
-> {}
+> {
+  /**
+   * The engine actually in use: `engine`, or `"dom"` if `"css-highlights"`
+   * was requested but `CSS.highlights` is unavailable.
+   */
+  resolvedEngine(): "dom" | "css-highlights";
+}

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -1,10 +1,3 @@
-<script context="module">
-  let instanceCount = 0;
-  function nextInstanceId() {
-    return ++instanceCount;
-  }
-</script>
-
 <script>
   /** @type {import("./languages").LanguageType<string>} */
   export let language;
@@ -39,11 +32,13 @@
   export let theme = undefined;
 
   import { createEventDispatcher, onMount } from "svelte";
-  import { renderHtml, toRanges } from "./engine.js";
   import {
-    highlightRules,
-    highlightRulesFromPalette,
-  } from "./highlight-theme.js";
+    createHighlightPainter,
+    instanceHighlightRules,
+    nextInstanceId,
+    resolveEngine,
+  } from "./css-highlights.js";
+  import { renderHtml, toRanges } from "./engine.js";
   import {
     parseIncremental,
     reparseIncremental,
@@ -87,12 +82,7 @@
     return incrementalParse.events;
   }
 
-  $: resolvedEngineValue =
-    engine === "css-highlights" &&
-    typeof CSS !== "undefined" &&
-    typeof CSS.highlights !== "undefined"
-      ? "css-highlights"
-      : "dom";
+  $: resolvedEngineValue = resolveEngine(engine);
 
   let previousLanguageName;
   let previousEngine;
@@ -113,14 +103,7 @@
   $: if (mounted && code !== internalCode) syncExternal();
   $: cssHighlightStyle =
     resolvedEngineValue === "css-highlights" && theme !== undefined
-      ? `<style>${(
-          typeof theme === "object"
-            ? highlightRulesFromPalette(theme)
-            : highlightRules(theme)
-        ).replaceAll(
-          "::highlight(hljs-",
-          `::highlight(hljs-${instanceId}-`,
-        )}</style>`
+      ? `<style>${instanceHighlightRules(theme, instanceId)}</style>`
       : "";
 
   function getSelectionRange() {
@@ -248,34 +231,20 @@
     return prevLen === newLen && changedCount === 1 ? changedIndex : null;
   }
 
-  /** @type {Map<string, InstanceType<typeof Highlight>>} scope -> registered Highlight. */
-  let cssHighlights = new Map();
+  const painter = createHighlightPainter(instanceId);
   /** @type {{ scope: string; range: Range }[][]} Ranges registered per line. */
   let lineHighlightRanges = [];
-
-  function cssHighlightFor(scope) {
-    let highlight = cssHighlights.get(scope);
-    if (!highlight) {
-      highlight = new Highlight();
-      cssHighlights.set(scope, highlight);
-      CSS.highlights.set(`hljs-${instanceId}-${scope}`, highlight);
-    }
-    return highlight;
-  }
 
   function clearLineHighlights(index) {
     const previous = lineHighlightRanges[index];
     if (!previous) return;
     for (const { scope, range } of previous) {
-      cssHighlights.get(scope)?.delete(range);
+      painter.highlightFor(scope).delete(range);
     }
   }
 
   function clearCssHighlights() {
-    for (const scope of cssHighlights.keys()) {
-      CSS.highlights.delete(`hljs-${instanceId}-${scope}`);
-    }
-    cssHighlights = new Map();
+    painter.clear();
     lineHighlightRanges = [];
   }
 
@@ -285,23 +254,14 @@
   function paintLineHighlights(index, tokenRanges) {
     clearLineHighlights(index);
     const textNode = lineEls[index].firstChild;
-    const next = [];
-    if (textNode) {
-      const lineStart = lineStartOffset(index);
-      const lineEnd = lineStart + lineLengths[index];
-      for (const token of tokenRanges) {
-        if (token.end <= lineStart || token.start >= lineEnd) continue;
-        const start = Math.max(token.start, lineStart) - lineStart;
-        const end = Math.min(token.end, lineEnd) - lineStart;
-        if (start === end) continue;
-        const range = new Range();
-        range.setStart(textNode, start);
-        range.setEnd(textNode, end);
-        cssHighlightFor(token.scope).add(range);
-        next.push({ scope: token.scope, range });
-      }
-    }
-    lineHighlightRanges[index] = next;
+    lineHighlightRanges[index] = textNode
+      ? painter.paintNode(
+          textNode,
+          tokenRanges,
+          lineStartOffset(index),
+          lineLengths[index],
+        )
+      : [];
   }
 
   function paintCssHighlights() {

--- a/src/HighlightStyle.svelte
+++ b/src/HighlightStyle.svelte
@@ -23,7 +23,7 @@
 </script>
 
 <script>
-  import { onDestroy } from "svelte";
+  import { onMount } from "svelte";
   import { dualStyle, scopeClassFor, scopeStyle } from "./scoped.js";
   import { dualPaletteStyle, paletteStyle } from "./theme-style.js";
 
@@ -128,7 +128,7 @@
   $: owners = $registry ?? [];
   $: shouldRender = !isBrowser || owners[0] === token;
 
-  onDestroy(unregister);
+  onMount(() => unregister);
 </script>
 
 <svelte:head

--- a/src/LangTag.svelte
+++ b/src/LangTag.svelte
@@ -10,6 +10,14 @@
 
   /** @type {boolean} */
   export let langtag = false;
+
+  /**
+   * Bindable reference to the rendered `<code>` element, for callers (e.g.
+   * `Highlight`'s "css-highlights" engine) that need to manage its DOM
+   * imperatively after mount without duplicating this markup.
+   * @type {HTMLElement | undefined}
+   */
+  export let codeElement = undefined;
 </script>
 
 <pre
@@ -22,6 +30,7 @@
   style:max-width="var(--max-width, none)"
   {...$$restProps}
 ><code
+    bind:this={codeElement}
     class:hljs={true}
     >{#if highlighted}{@html highlighted}{:else}{code}{/if}</code
   ></pre>

--- a/src/LangTag.svelte.d.ts
+++ b/src/LangTag.svelte.d.ts
@@ -20,6 +20,11 @@ export type LangTagProps = HTMLAttributes<HTMLPreElement> &
      * @default "plaintext"
      */
     languageName?: LanguageName | (string & {});
+
+    /**
+     * Bindable reference to the rendered `<code>` element.
+     */
+    codeElement?: HTMLElement;
   };
 
 export type LangTagEvents = {};

--- a/src/css-highlights.d.ts
+++ b/src/css-highlights.d.ts
@@ -1,0 +1,31 @@
+import type { TokenRange } from "./engine.d.ts";
+import type { ThemePalette } from "./theme.d.ts";
+
+/** "css-highlights" when requested AND CSS.highlights is available; else "dom". */
+export function resolveEngine(requested: string): "dom" | "css-highlights";
+
+/** Monotonic per-page instance ids (moved from HighlightEditable). */
+export function nextInstanceId(): number;
+
+/** Instance-scoped ::highlight() rules for a theme string or ThemePalette. */
+export function instanceHighlightRules(
+  theme: string | ThemePalette,
+  instanceId: number,
+): string;
+
+/** Scope -> Highlight registry for one component instance. */
+export interface HighlightPainter {
+  /** Lazily creates the Highlight for `scope` and registers `hljs-<id>-<scope>`. */
+  highlightFor(scope: string): Highlight;
+  /** Register ranges for token ranges intersecting [start, end) of `textNode`'s text, offsets relative to `textOffset`. Returns the created ranges for caller bookkeeping. */
+  paintNode(
+    textNode: Text,
+    tokenRanges: TokenRange[],
+    textOffset: number,
+    textLength: number,
+  ): Array<{ scope: string; range: Range }>;
+  /** Delete all CSS.highlights registrations for this instance. */
+  clear(): void;
+}
+
+export function createHighlightPainter(instanceId: number): HighlightPainter;

--- a/src/css-highlights.js
+++ b/src/css-highlights.js
@@ -1,0 +1,115 @@
+/**
+ * Shared CSS Custom Highlight API painter, extracted from
+ * `HighlightEditable`'s experimental "css-highlights" engine so `Highlight`
+ * can offer the same rendering: plain text nodes plus `Range` objects
+ * registered on `CSS.highlights`, themed via generated `::highlight()`
+ * rules, instead of one `<span>` per token.
+ */
+
+import {
+  highlightRules,
+  highlightRulesFromPalette,
+} from "./highlight-theme.js";
+
+/**
+ * `"css-highlights"` when requested AND `CSS.highlights` is available;
+ * `"dom"` otherwise (unsupported browser, or SSR where `CSS` doesn't exist).
+ * @param {string} requested
+ * @returns {"dom" | "css-highlights"}
+ */
+export function resolveEngine(requested) {
+  return requested === "css-highlights" &&
+    typeof CSS !== "undefined" &&
+    typeof CSS.highlights !== "undefined"
+    ? "css-highlights"
+    : "dom";
+}
+
+let instanceCount = 0;
+
+/** Monotonic per-page instance ids, used to namespace `::highlight()` names. */
+export function nextInstanceId() {
+  return ++instanceCount;
+}
+
+/**
+ * Instance-scoped `::highlight()` rules for a theme string or `ThemePalette`:
+ * converts via `highlightRulesFromPalette`/`highlightRules`, then renames
+ * every `::highlight(hljs-` to `::highlight(hljs-<instanceId>-` so multiple
+ * instances on the same page don't collide.
+ * @param {string | import("./theme.d.ts").ThemePalette} theme
+ * @param {number} instanceId
+ * @returns {string}
+ */
+export function instanceHighlightRules(theme, instanceId) {
+  const rules =
+    typeof theme === "object"
+      ? highlightRulesFromPalette(theme)
+      : highlightRules(theme);
+  return rules.replaceAll(
+    "::highlight(hljs-",
+    `::highlight(hljs-${instanceId}-`,
+  );
+}
+
+/**
+ * Scope -> `Highlight` registry for one component instance.
+ * @param {number} instanceId
+ */
+export function createHighlightPainter(instanceId) {
+  /** @type {Map<string, Highlight>} */
+  let highlights = new Map();
+
+  /**
+   * Lazily creates the `Highlight` for `scope` and registers it as
+   * `hljs-<instanceId>-<scope>`.
+   * @param {string} scope
+   * @returns {Highlight}
+   */
+  function highlightFor(scope) {
+    let highlight = highlights.get(scope);
+    if (!highlight) {
+      highlight = new Highlight();
+      highlights.set(scope, highlight);
+      CSS.highlights.set(`hljs-${instanceId}-${scope}`, highlight);
+    }
+    return highlight;
+  }
+
+  /**
+   * Registers ranges for token ranges intersecting
+   * `[textOffset, textOffset + textLength)` of `textNode`'s text, with
+   * `tokenRanges` given as absolute document offsets.
+   * @param {Text} textNode
+   * @param {import("./engine.d.ts").TokenRange[]} tokenRanges
+   * @param {number} textOffset
+   * @param {number} textLength
+   * @returns {Array<{ scope: string; range: Range }>}
+   */
+  function paintNode(textNode, tokenRanges, textOffset, textLength) {
+    const windowEnd = textOffset + textLength;
+    const created = [];
+    for (const token of tokenRanges) {
+      if (token.end <= textOffset || token.start >= windowEnd) continue;
+      const start = Math.max(token.start, textOffset) - textOffset;
+      const end = Math.min(token.end, windowEnd) - textOffset;
+      if (start === end) continue;
+      const range = new Range();
+      range.setStart(textNode, start);
+      range.setEnd(textNode, end);
+      highlightFor(token.scope).add(range);
+      created.push({ scope: token.scope, range });
+    }
+    return created;
+  }
+
+  /** Deletes all `CSS.highlights` registrations for this instance. */
+  function clear() {
+    for (const scope of highlights.keys()) {
+      CSS.highlights.delete(`hljs-${instanceId}-${scope}`);
+    }
+    highlights = new Map();
+  }
+
+  return { highlightFor, paintNode, clear };
+}

--- a/tests/css-highlights.test.ts
+++ b/tests/css-highlights.test.ts
@@ -1,0 +1,188 @@
+import {
+  createHighlightPainter,
+  instanceHighlightRules,
+  nextInstanceId,
+  resolveEngine,
+} from "../src/css-highlights.js";
+import github from "../src/styles/github.js";
+import githubPalette from "../src/themes/github.js";
+
+describe("resolveEngine", () => {
+  afterEach(() => {
+    // @ts-expect-error test cleanup — CSS isn't a real Bun/Node global.
+    globalThis.CSS = undefined;
+  });
+
+  it("stays dom when dom is requested, even with CSS.highlights present", () => {
+    // @ts-expect-error test stub
+    globalThis.CSS = { highlights: new Map() };
+    expect(resolveEngine("dom")).toBe("dom");
+  });
+
+  it("resolves to css-highlights when requested and CSS.highlights is present", () => {
+    // @ts-expect-error test stub
+    globalThis.CSS = { highlights: new Map() };
+    expect(resolveEngine("css-highlights")).toBe("css-highlights");
+  });
+
+  it("falls back to dom when css-highlights is requested but CSS is undefined", () => {
+    expect(globalThis.CSS).toBeUndefined();
+    expect(resolveEngine("css-highlights")).toBe("dom");
+  });
+
+  it("falls back to dom when css-highlights is requested but CSS.highlights is undefined", () => {
+    // @ts-expect-error test stub — CSS present, no Custom Highlight API support
+    globalThis.CSS = {};
+    expect(resolveEngine("css-highlights")).toBe("dom");
+  });
+});
+
+describe("nextInstanceId", () => {
+  it("returns increasing, unique ids across calls", () => {
+    const a = nextInstanceId();
+    const b = nextInstanceId();
+    const c = nextInstanceId();
+    expect(b).toBe(a + 1);
+    expect(c).toBe(b + 1);
+  });
+});
+
+describe("instanceHighlightRules", () => {
+  it("renames a string theme's rules with the instance id", () => {
+    const out = instanceHighlightRules(".hljs-keyword{color:#c678dd}", 7);
+    expect(out).toBe("::highlight(hljs-7-keyword){color:#c678dd}");
+  });
+
+  it("renames a ThemePalette's rules with the instance id", () => {
+    const out = instanceHighlightRules(
+      {
+        name: "test",
+        colorScheme: "dark",
+        vars: { "--shl-keyword": "#c678dd" },
+      },
+      7,
+    );
+    expect(out).toBe("::highlight(hljs-7-keyword){color:#c678dd}");
+  });
+
+  it("produces the same instance-scoped rule name for equivalent string and palette themes", () => {
+    const fromString = instanceHighlightRules(github, 3);
+    const fromPalette = instanceHighlightRules(githubPalette, 3);
+    expect(fromString).toContain("::highlight(hljs-3-keyword){color:#d73a49}");
+    expect(fromPalette).toContain("::highlight(hljs-3-keyword){color:#d73a49}");
+  });
+});
+
+describe("createHighlightPainter", () => {
+  class FakeRange {
+    startNode: unknown;
+    startOffset = 0;
+    endNode: unknown;
+    endOffset = 0;
+    setStart(node: unknown, offset: number) {
+      this.startNode = node;
+      this.startOffset = offset;
+    }
+    setEnd(node: unknown, offset: number) {
+      this.endNode = node;
+      this.endOffset = offset;
+    }
+  }
+
+  class FakeHighlight {
+    ranges = new Set<FakeRange>();
+    add(range: FakeRange) {
+      this.ranges.add(range);
+    }
+    delete(range: FakeRange) {
+      return this.ranges.delete(range);
+    }
+  }
+
+  /** @type {Map<string, FakeHighlight>} */
+  let registrations: Map<string, FakeHighlight>;
+
+  beforeEach(() => {
+    registrations = new Map();
+    // @ts-expect-error test stub
+    globalThis.Range = FakeRange;
+    // @ts-expect-error test stub
+    globalThis.Highlight = FakeHighlight;
+    // @ts-expect-error test stub
+    globalThis.CSS = { highlights: registrations };
+  });
+
+  afterEach(() => {
+    // @ts-expect-error test cleanup
+    globalThis.Range = undefined;
+    // @ts-expect-error test cleanup
+    globalThis.Highlight = undefined;
+    // @ts-expect-error test cleanup
+    globalThis.CSS = undefined;
+  });
+
+  it("highlightFor lazily creates and registers a Highlight per scope, reusing it on repeat calls", () => {
+    const painter = createHighlightPainter(1);
+    const keyword = painter.highlightFor("keyword");
+    expect(registrations.get("hljs-1-keyword")).toBe(keyword);
+    expect(painter.highlightFor("keyword")).toBe(keyword);
+    expect(registrations.size).toBe(1);
+  });
+
+  it("paintNode clips a token spanning the node boundary", () => {
+    const painter = createHighlightPainter(1);
+    const textNode = {} as Text;
+    // Window is [10, 20); token runs 5..15, so only 10..15 is in range.
+    const created = painter.paintNode(
+      textNode,
+      [{ start: 5, end: 15, scope: "string" }],
+      10,
+      10,
+    );
+    expect(created).toHaveLength(1);
+    const [entry] = created;
+    expect(entry?.scope).toBe("string");
+    const range = entry?.range as unknown as FakeRange;
+    expect(range.startNode).toBe(textNode);
+    expect(range.startOffset).toBe(0);
+    expect(range.endOffset).toBe(5);
+  });
+
+  it("paintNode skips a token entirely outside the window", () => {
+    const painter = createHighlightPainter(1);
+    const created = painter.paintNode(
+      {} as Text,
+      [{ start: 0, end: 5, scope: "keyword" }],
+      10,
+      10,
+    );
+    expect(created).toHaveLength(0);
+    expect(registrations.size).toBe(0);
+  });
+
+  it("paintNode skips a token that becomes zero-length after clipping", () => {
+    const painter = createHighlightPainter(1);
+    // Window is [10, 10) (empty); the token overlaps its bounds but clips to nothing.
+    const created = painter.paintNode(
+      {} as Text,
+      [{ start: 8, end: 12, scope: "keyword" }],
+      10,
+      0,
+    );
+    expect(created).toHaveLength(0);
+  });
+
+  it("clear removes exactly this instance's registrations, leaving a coexisting instance untouched", () => {
+    const painterA = createHighlightPainter(1);
+    const painterB = createHighlightPainter(2);
+    painterA.highlightFor("keyword");
+    painterB.highlightFor("keyword");
+    expect(registrations.has("hljs-1-keyword")).toBe(true);
+    expect(registrations.has("hljs-2-keyword")).toBe(true);
+
+    painterA.clear();
+
+    expect(registrations.has("hljs-1-keyword")).toBe(false);
+    expect(registrations.has("hljs-2-keyword")).toBe(true);
+  });
+});

--- a/tests/e2e/Highlight.cssHighlights.test.svelte
+++ b/tests/e2e/Highlight.cssHighlights.test.svelte
@@ -1,0 +1,56 @@
+<script>
+  import Highlight from "svelte-highlight";
+  import { toRanges } from "svelte-highlight/engine";
+  import javascript from "svelte-highlight/languages/javascript";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+  import atomOneDark from "svelte-highlight/themes/atom-one-dark";
+
+  const codeA = "const a = 1;";
+  const codeB = "const b = 2;";
+
+  let code = codeA;
+  let language = typescript;
+  let theme = github;
+
+  let instance;
+  $: resolvedEngine = instance?.resolvedEngine();
+
+  /** @type {import("svelte-highlight/engine").ScopeEvent[]} */
+  let events = [];
+  $: expectedRangesJson = JSON.stringify(toRanges(events));
+</script>
+
+<Highlight
+  bind:this={instance}
+  {language}
+  {code}
+  engine="css-highlights"
+  {theme}
+  on:highlight={(e) => (events = e.detail.events)}
+/>
+
+<div data-testid="resolved-engine" data-value={resolvedEngine}></div>
+<div data-testid="expected-ranges" data-value={expectedRangesJson}></div>
+
+<button
+  type="button"
+  data-testid="toggle-code"
+  on:click={() => (code = code === codeA ? codeB : codeA)}
+>
+  toggle code
+</button>
+<button
+  type="button"
+  data-testid="switch-language"
+  on:click={() => (language = javascript)}
+>
+  switch language
+</button>
+<button
+  type="button"
+  data-testid="switch-theme"
+  on:click={() => (theme = atomOneDark)}
+>
+  switch theme
+</button>

--- a/tests/e2e/Highlight.cssHighlights.twoInstances.test.svelte
+++ b/tests/e2e/Highlight.cssHighlights.twoInstances.test.svelte
@@ -1,0 +1,25 @@
+<script>
+  import Highlight from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+  import atomOneDark from "svelte-highlight/themes/atom-one-dark";
+
+  const code = "const a = 1;";
+</script>
+
+<div data-testid="one">
+  <Highlight
+    language={typescript}
+    {code}
+    engine="css-highlights"
+    theme={github}
+  />
+</div>
+<div data-testid="two">
+  <Highlight
+    language={typescript}
+    {code}
+    engine="css-highlights"
+    theme={atomOneDark}
+  />
+</div>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -8,6 +8,8 @@ import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
 import CopyButton from "./CopyButton.test.svelte";
 import CopyButtonTransform from "./CopyButton.transform.test.svelte";
 import FileTabs from "./FileTabs.test.svelte";
+import HighlightCssHighlights from "./Highlight.cssHighlights.test.svelte";
+import HighlightCssHighlightsTwoInstances from "./Highlight.cssHighlights.twoInstances.test.svelte";
 import HighlightEvents from "./Highlight.events.test.svelte";
 import Highlight from "./Highlight.test.svelte";
 import HighlightActionOmittedCode from "./HighlightAction.omittedCode.test.svelte";
@@ -337,6 +339,157 @@ test("Highlight - exposes the scope-event stream via slot prop and on:highlight 
   expect(expected).not.toBe("");
   await expect(page.getByTestId("slot-events")).toHaveText(expected ?? "");
   await expect(page.getByTestId("dispatch-events")).toHaveText(expected ?? "");
+});
+
+test("Highlight css-highlights engine - code renders as a single text node with no per-token spans", async ({
+  mount,
+  page,
+}) => {
+  const supported = await page.evaluate(
+    () => typeof CSS !== "undefined" && "highlights" in CSS,
+  );
+  test.skip(!supported, "CSS Custom Highlight API not supported");
+
+  await mount(HighlightCssHighlights);
+
+  await expect(page.getByTestId("resolved-engine")).toHaveAttribute(
+    "data-value",
+    "css-highlights",
+  );
+
+  const code = page.locator("code.hljs");
+  await expect(code.locator("span")).toHaveCount(0);
+
+  const textNodeInfo = await code.evaluate((el) => ({
+    childCount: el.childNodes.length,
+    isText: el.firstChild?.nodeType === Node.TEXT_NODE,
+    text: el.textContent,
+  }));
+  expect(textNodeInfo).toEqual({
+    childCount: 1,
+    isText: true,
+    text: "const a = 1;",
+  });
+});
+
+test("Highlight css-highlights engine - registered ranges match toRanges(events) exactly", async ({
+  mount,
+  page,
+}) => {
+  const supported = await page.evaluate(
+    () => typeof CSS !== "undefined" && "highlights" in CSS,
+  );
+  test.skip(!supported, "CSS Custom Highlight API not supported");
+
+  await mount(HighlightCssHighlights);
+
+  type TokenRange = { start: number; end: number; scope: string };
+
+  const expectedRanges: TokenRange[] = JSON.parse(
+    (await page.getByTestId("expected-ranges").getAttribute("data-value")) ??
+      "[]",
+  );
+  expect(expectedRanges.length).toBeGreaterThan(0);
+
+  const actualRanges: TokenRange[] = await page.evaluate(() => {
+    const out: TokenRange[] = [];
+    for (const [name, highlight] of CSS.highlights) {
+      const match = /^hljs-\d+-(.+)$/.exec(name);
+      const scope = match?.[1];
+      if (!scope) continue;
+      for (const range of highlight) {
+        out.push({ start: range.startOffset, end: range.endOffset, scope });
+      }
+    }
+    return out;
+  });
+
+  const sortKey = (r: TokenRange) => `${r.start}:${r.end}:${r.scope}`;
+  actualRanges.sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
+  expectedRanges.sort((a, b) => sortKey(a).localeCompare(sortKey(b)));
+  expect(actualRanges).toEqual(expectedRanges);
+});
+
+test("Highlight css-highlights engine - theme/code/language changes repaint without leaking registrations", async ({
+  mount,
+  page,
+}) => {
+  const supported = await page.evaluate(
+    () => typeof CSS !== "undefined" && "highlights" in CSS,
+  );
+  test.skip(!supported, "CSS Custom Highlight API not supported");
+
+  await mount(HighlightCssHighlights);
+
+  const instanceEntryCount = () =>
+    page.evaluate(
+      () =>
+        [...CSS.highlights.keys()].filter((k) => /^hljs-\d+-/.test(k)).length,
+    );
+
+  const initialCount = await instanceEntryCount();
+  expect(initialCount).toBeGreaterThan(0);
+
+  await page.getByTestId("switch-theme").click();
+  expect(await instanceEntryCount()).toBe(initialCount);
+
+  await page.getByTestId("toggle-code").click();
+  await page.getByTestId("toggle-code").click();
+  expect(await instanceEntryCount()).toBe(initialCount);
+
+  await page.getByTestId("switch-language").click();
+  await page.getByTestId("toggle-code").click();
+  expect(await instanceEntryCount()).toBeGreaterThan(0);
+});
+
+test("Highlight css-highlights engine - CSS.highlights entries are gone after unmount", async ({
+  mount,
+  page,
+}) => {
+  const supported = await page.evaluate(
+    () => typeof CSS !== "undefined" && "highlights" in CSS,
+  );
+  test.skip(!supported, "CSS Custom Highlight API not supported");
+
+  const component = await mount(HighlightCssHighlights);
+
+  const beforeCount = await page.evaluate(() => CSS.highlights.size);
+  expect(beforeCount).toBeGreaterThan(0);
+
+  await component.unmount();
+
+  const afterCount = await page.evaluate(() => CSS.highlights.size);
+  expect(afterCount).toBe(0);
+});
+
+test("Highlight css-highlights engine - two instances with different themes don't cross-contaminate", async ({
+  mount,
+  page,
+}) => {
+  const supported = await page.evaluate(
+    () => typeof CSS !== "undefined" && "highlights" in CSS,
+  );
+  test.skip(!supported, "CSS Custom Highlight API not supported");
+
+  await mount(HighlightCssHighlightsTwoInstances);
+
+  const { names, distinctHighlights } = await page.evaluate(() => {
+    const keywordEntries = [...CSS.highlights].filter(([name]) =>
+      name.endsWith("-keyword"),
+    );
+    return {
+      names: keywordEntries.map(([name]) => name),
+      distinctHighlights: new Set(keywordEntries.map(([, h]) => h)).size,
+    };
+  });
+
+  expect(names).toHaveLength(2);
+  expect(new Set(names).size).toBe(2);
+  expect(distinctHighlights).toBe(2);
+
+  const styleText = (await page.locator("style").allTextContents()).join("");
+  expect(styleText).toContain("color:#d73a49"); // github's keyword color
+  expect(styleText).toContain("color:#c678dd"); // atom-one-dark's keyword color
 });
 
 test("HighlightAuto - exposes the scope-event stream via slot prop and on:highlight detail", async ({

--- a/tests/highlight-css-highlights-ssr.test.ts
+++ b/tests/highlight-css-highlights-ssr.test.ts
@@ -1,0 +1,53 @@
+/**
+ * `resolveEngine` falls back to `"dom"` on the server (no `CSS` global), so
+ * `Highlight` with `engine="css-highlights"` must render identically to
+ * `engine="dom"` during SSR - the client-side swap to a single text node
+ * plus painted ranges happens after hydration (see css-highlights.js).
+ */
+import fs from "node:fs";
+import path from "node:path";
+import { plugin } from "bun";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+import typescript from "../src/languages/typescript.js";
+import atomOneDark from "../src/themes/atom-one-dark.js";
+
+plugin({
+  name: "svelte-server-compile",
+  setup(build) {
+    build.onLoad({ filter: /\.svelte$/ }, ({ path: filePath }) => {
+      const source = fs.readFileSync(filePath, "utf-8");
+      const { js } = compile(source, {
+        generate: "server",
+        filename: path.basename(filePath),
+      });
+      return { contents: js.code, loader: "js" };
+    });
+  },
+});
+
+const srcDir = path.join(import.meta.dir, "../src");
+
+describe("Highlight css-highlights engine - SSR fallback", () => {
+  it('renders the same span markup as engine="dom", with no CSS reference errors', async () => {
+    const { default: Highlight } = await import(
+      path.join(srcDir, "Highlight.svelte")
+    );
+
+    const code = "const add = (a, b) => a + b;";
+    const domResult = render(Highlight, {
+      props: { language: typescript, code, engine: "dom" },
+    });
+    const cssHighlightsResult = render(Highlight, {
+      props: {
+        language: typescript,
+        code,
+        engine: "css-highlights",
+        theme: atomOneDark,
+      },
+    });
+
+    expect(cssHighlightsResult.body).toBe(domResult.body);
+    expect(cssHighlightsResult.body).toContain("hljs-keyword");
+  });
+});


### PR DESCRIPTION
HighlightEditable has had an experimental CSS Custom Highlight API
renderer for a while: plain text nodes plus Range objects registered
on CSS.highlights, themed via generated ::highlight() rules, instead
of one <span> per token. That renderer was trapped behind
HighlightEditable's own internals, so the read-only Highlight
component had no way to offer the same span-free rendering for large
files.

This extracts the shared parts into src/css-highlights.js (engine
resolution with capability fallback, per-instance highlight naming
and scope registry, ::highlight() rule generation, and
token-range-to-text-node painting with window clipping), refactors
HighlightEditable onto it with no behavior change, and adds
engine="css-highlights" plus a theme prop to Highlight. SSR and
unsupported browsers keep today's span markup; the swap to a single
text node happens after hydration, mirroring how HighlightEditable
already behaves. LangTag gained one small addition, a bindable
codeElement prop, so Highlight can reach its rendered `<code>` element
without introducing a second code path that could drift from SSR
output.

## Risk

Isolated to Highlight, HighlightEditable, LangTag, and the new
css-highlights module; engine defaults to "dom" everywhere, so
existing consumers are unaffected. The main risk is in
HighlightEditable's refactor, since it's a widely used component,
but its full existing test suite passes unchanged against the
extracted module.