### PR TITLE
perf(highlight-editable): repaint css-highlights in one linear sweep

### DIFF
--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -304,14 +304,54 @@
     lineHighlightRanges[index] = next;
   }
 
+  // Repaints every line from `tokenRanges` in a single forward sweep rather
+  // than rescanning the full (document-sized) range array per line: since
+  // `toRanges` emits ranges sorted by, and disjoint on, document offset,
+  // `tokenIndex` only ever advances, so total work is O(lines + tokens)
+  // instead of O(lines * tokens).
+  function paintAllLineHighlights(tokenRanges) {
+    let tokenIndex = 0;
+    let lineStart = 0;
+    for (let i = 0; i < lineEls.length; i++) {
+      clearLineHighlights(i);
+      const lineEnd = lineStart + lineLengths[i];
+      const textNode = lineEls[i].firstChild;
+      const next = [];
+      if (textNode) {
+        while (
+          tokenIndex < tokenRanges.length &&
+          tokenRanges[tokenIndex].end <= lineStart
+        ) {
+          tokenIndex++;
+        }
+        for (
+          let j = tokenIndex;
+          j < tokenRanges.length && tokenRanges[j].start < lineEnd;
+          j++
+        ) {
+          const token = tokenRanges[j];
+          if (token.end <= lineStart) continue;
+          const start = Math.max(token.start, lineStart) - lineStart;
+          const end = Math.min(token.end, lineEnd) - lineStart;
+          if (start === end) continue;
+          const range = new Range();
+          range.setStart(textNode, start);
+          range.setEnd(textNode, end);
+          cssHighlightFor(token.scope).add(range);
+          next.push({ scope: token.scope, range });
+        }
+      }
+      lineHighlightRanges[i] = next;
+      lineStart = lineEnd + 1; // +1 for the "\n" separator
+    }
+  }
+
   function paintCssHighlights() {
     const changedIndex = renderLines(code.split("\n"), setText);
     const tokenRanges = toRanges(getEvents());
 
     if (changedIndex == null) {
-      for (let i = 0; i < lineEls.length; i++) {
-        paintLineHighlights(i, tokenRanges);
-      }
+      paintAllLineHighlights(tokenRanges);
     } else {
       paintLineHighlights(changedIndex, tokenRanges);
     }

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -27,6 +27,7 @@
   const HIGHLIGHTED_BACKGROUND = "rgba(254, 241, 96, 0.2)";
 
   $: lines = splitLines(highlighted);
+  $: highlightedLineSet = new Set(highlightedLines);
   $: focusMode = highlightedLines.length > 0;
   $: len_digits = (startingLineNumber + lines.length - 1).toString().length;
   $: len = len_digits - MIN_DIGITS < 1 ? MIN_DIGITS : len_digits;
@@ -47,7 +48,7 @@
     <tbody class:hljs={true}>
       {#each lines as line, i}
         {@const lineNumber = i + startingLineNumber}
-        {@const isHighlighted = highlightedLines.includes(i)}
+        {@const isHighlighted = highlightedLineSet.has(i)}
         <tr class:dimmed={focusMode && !isHighlighted}>
           <td
             class:hljs={true}

--- a/src/engine.js
+++ b/src/engine.js
@@ -409,16 +409,18 @@ class Tokenizer {
   }
 
   /**
-   * Memoized `execValid(re, this.pos, guard)`. Without this, every token
+   * Memoized `execValid(re, this.pos, guardFn())`. Without this, every token
    * boundary re-scans every rule's pattern from scratch. A cached match stays
    * valid until `this.pos` passes it; a cached miss stays valid until the
-   * code grows (streaming append).
+   * code grows (streaming append). `guardFn` is only called on a cache miss,
+   * so guarded rules don't allocate a fresh guard closure on every call once
+   * their match is cached.
    * @param {RegExp} re
-   * @param {((m: RegExpExecArray) => boolean) | null} guard
+   * @param {() => ((m: RegExpExecArray) => boolean) | null} guardFn
    * @param {MatchCache | undefined} cache
    * @returns {MatchCache}
    */
-  cachedMatch(re, guard, cache) {
+  cachedMatch(re, guardFn, cache) {
     if (cache) {
       if (cache.match !== null && cache.match.index >= this.pos) return cache;
       if (cache.match === null && cache.codeLen === this.code.length)
@@ -426,7 +428,7 @@ class Tokenizer {
     }
     return {
       codeLen: this.code.length,
-      match: this.execValid(re, this.pos, guard),
+      match: this.execValid(re, this.pos, guardFn()),
     };
   }
 
@@ -515,7 +517,7 @@ class Tokenizer {
       const cache = this.cachedMatch(
         // Every state referenced from a `rules` list has a `begin` pattern.
         /** @type {RegExp} */ (child.beginRe),
-        this.beginGuard(child),
+        () => this.beginGuard(child),
         this.beginCache[ruleIdx],
       );
       this.beginCache[ruleIdx] = cache;
@@ -527,12 +529,12 @@ class Tokenizer {
       // d ranges over [1, frames.length - 1], always in bounds.
       const frame = /** @type {Frame} */ (this.frames[d]);
       if (frame.state.endRe) {
-        const guard = frame.state.endSameAsBegin
-          ? (/** @type {RegExpExecArray} */ m) => m[1] === frame.beginMatch
-          : null;
         const cache = this.cachedMatch(
           frame.state.endRe,
-          guard,
+          () =>
+            frame.state.endSameAsBegin
+              ? (/** @type {RegExpExecArray} */ m) => m[1] === frame.beginMatch
+              : null,
           frame.endCache,
         );
         frame.endCache = cache;


### PR DESCRIPTION
Three hot paths did more work than their inputs required. The
css-highlights editor repainted every line by rescanning the
full token-range array, the tokenizer's per-token match loop
allocated a throwaway guard closure on every cache hit, and
LineNumbers ran an array scan per rendered line to check
highlight state.

Each fix removes the extra factor without changing behavior.
The editor repaint walks tokens and lines with a single sorted
cursor (O(lines * tokens) to O(lines + tokens)). The tokenizer
now builds a rule's guard closure lazily, only on a cache miss,
instead of on every token boundary. LineNumbers looks up
highlighted lines in a Set instead of scanning an array
(O(lines * highlighted) to O(lines)).

## Risk

Small blast radius: each change is isolated to one file (the
css-highlights paint path in HighlightEditable, the tokenizer's
internal match cache in engine.js, and LineNumbers' highlight
lookup). Validated with `bun run lint` and the relevant targeted
test files (engine-streaming, jsx-tag-guard, tokenize-ranges,
incremental-tokenize); the full suite was not run.