### PR TITLE
perf(engine): memoize missing closing tags in the JSX guard

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -211,6 +211,13 @@ class Tokenizer {
      * @type {(MatchCache | undefined)[]}
      */
     this.beginCache = [];
+    /**
+     * Tag names with no `</name` at or after the recorded position. See
+     * `hasClosingTag`.
+     * @type {Map<string, number>}
+     */
+    this.noClosingTag = new Map();
+    this.noClosingTagCodeLen = 0;
   }
 
   /** @returns {Frame} */
@@ -450,6 +457,35 @@ class Tokenizer {
   }
 
   /**
+   * Whether `</name` occurs at or after `from`.
+   *
+   * Misses are memoized per tag name, which makes the common "generic, not a
+   * tag" verdict cheap: absence from `from` implies absence from every later
+   * position, so one scan settles all of that name's later occurrences. Code
+   * dense in generics (`Modify<T>`, `Array<T>`) otherwise rescans the whole
+   * remaining source per occurrence, which is quadratic in file size.
+   *
+   * Keyed on `code.length` like `beginCache`: a tokenizer's `code` only ever
+   * grows, so an unchanged length means unchanged content, and appended code
+   * can supply a closing tag that was legitimately absent before.
+   *
+   * @param {string} name
+   * @param {number} from
+   * @returns {boolean}
+   */
+  hasClosingTag(name, from) {
+    if (this.noClosingTagCodeLen !== this.code.length) {
+      this.noClosingTag.clear();
+      this.noClosingTagCodeLen = this.code.length;
+    }
+    const absentFrom = this.noClosingTag.get(name);
+    if (absentFrom !== undefined && from >= absentFrom) return false;
+    if (this.code.indexOf(`</${name}`, from) !== -1) return true;
+    this.noClosingTag.set(name, from);
+    return false;
+  }
+
+  /**
    * hljs javascript/typescript JSX-vs-generic disambiguation for a `<Foo`
    * match. Re-evaluated when more code arrives so a streaming closing tag
    * still resolves it. See Tokenizer#isTrulyOpeningTag.
@@ -462,10 +498,7 @@ class Tokenizer {
     // `Array<Array<number>>`, `<T, A extends keyof T, V>`
     if (nextChar === "<" || nextChar === ",") return false;
     // `<something>` - only a tag if a matching closing tag exists later on.
-    if (
-      nextChar === ">" &&
-      this.code.indexOf(`</${match[0].slice(1)}`, afterIdx) === -1
-    ) {
+    if (nextChar === ">" && !this.hasClosingTag(match[0].slice(1), afterIdx)) {
       return false;
     }
     const after = this.code.slice(afterIdx);

--- a/src/preprocessor.js
+++ b/src/preprocessor.js
@@ -307,7 +307,10 @@ export function highlightStatic(options = {}) {
 
       const htmlByMatch = await Promise.all(
         matches.map(async (match) => {
-          const line = locate(content, match.element.start).line;
+          // Only ever read by the warn() paths below, and locate() scans
+          // `content` from the start, so resolve it lazily: computing it up
+          // front made the happy path O(content length) per match.
+          const line = () => locate(content, match.element.start).line;
 
           /** @type {import("./languages").LanguageType<string>} */
           let language;
@@ -322,7 +325,7 @@ export function highlightStatic(options = {}) {
               `could not resolve language module "${match.languageSource}"`,
               {
                 filename,
-                line,
+                line: line(),
                 cause,
               },
             );
@@ -336,7 +339,7 @@ export function highlightStatic(options = {}) {
               `highlight.js failed to highlight the code (language "${language.name}")`,
               {
                 filename,
-                line,
+                line: line(),
                 cause,
               },
             );


### PR DESCRIPTION
The javascript/typescript JSX guard resolves `<Foo>` by searching for
a matching `</Foo` from the match to the end of the file. Generic-heavy
TypeScript (`Modify<T>`, `Array<T>`, `Map<K, V>`) has no closing tag to
find, so every occurrence pays a full tail scan and highlighting goes
quadratic in file size.

Misses are now memoized per tag name. Absence from a position implies
absence from every later one, so one scan settles all of that name's
later occurrences. The cache is keyed on `code.length` like
`beginCache`: a tokenizer's `code` only ever grows, so an unchanged
length means unchanged content, and appended code can still supply a
closing tag that was legitimately absent before. A second commit defers
`locate()` in the static preprocessor, which scanned `content` from the
start for every `<Highlight>` match even though the line number it
returns is only read by the two `warn()` error paths.

## Benchmark

Synthetic TypeScript dense in generic false starts, through
`registry.highlight()` on Bun 1.3.14, macOS arm64.

| Input  | Before  | After   |
| ------ | ------- | ------- |
| 55 KB  | 43.5ms  | 40.5ms  |
| 110 KB | 59.3ms  | 48.9ms  |
| 221 KB | 130.3ms | 93.8ms  |
| 441 KB | 339.4ms | 196.1ms |

Scaling returns to linear: 2000 to 4000 repetitions is now 2.01x, was
2.6x. Stubbing the scan out entirely also measures 196ms at 441 KB, so
the memo recovers effectively all of the available headroom rather than
part of it.

## Risk

Contained to the JSX tag guard, which only javascript and typescript
reach. The failure mode worth watching is a stale cache during
streaming, where a closing tag arrives in a later chunk than its
opening tag; the `code.length` key covers that, and chunked input was
checked against one-shot output.
