### PR TITLE
perf(highlight-editable): binary-search ranges for single-line repaints

### DIFF
--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -289,8 +289,23 @@
     if (textNode) {
       const lineStart = lineStartOffset(index);
       const lineEnd = lineStart + lineLengths[index];
-      for (const token of tokenRanges) {
-        if (token.end <= lineStart || token.start >= lineEnd) continue;
+      // `tokenRanges` is sorted by, and disjoint on, `start` (see the
+      // comment on `paintAllLineHighlights`), so `end` is monotonically
+      // increasing too. Binary-search the first range that can possibly
+      // intersect the line instead of scanning the whole document.
+      let lo = 0;
+      let hi = tokenRanges.length;
+      while (lo < hi) {
+        const mid = (lo + hi) >>> 1;
+        if (tokenRanges[mid].end <= lineStart) lo = mid + 1;
+        else hi = mid;
+      }
+      for (
+        let j = lo;
+        j < tokenRanges.length && tokenRanges[j].start < lineEnd;
+        j++
+      ) {
+        const token = tokenRanges[j];
         const start = Math.max(token.start, lineStart) - lineStart;
         const end = Math.min(token.end, lineEnd) - lineStart;
         if (start === end) continue;


### PR DESCRIPTION
The single-line repaint fast path in `paintLineHighlights`
(the common case, one keystroke editing one line) scanned every
token range in the document to find the handful that intersect
that one line. For a 5k-line, ~50k-token document that is a
full document-wide scan on every keystroke.

`toRanges` emits ranges sorted by, and disjoint on, document
offset, so this now binary-searches for the first range that
can intersect the line and walks forward only while it still
does. The keystroke as a whole is still O(tokens) because of
the `toRanges` call that precedes it; this change only removes
the second full scan.

## Benchmark

Measured the selection logic in isolation (DOM APIs are
unavailable under the bun runtime used for benchmarking): 5k
lines, ~50k sorted disjoint token ranges, targeting a late line
(index 4900), 1k simulated keystrokes.

| approach              | total    | per keystroke |
|------------------------|----------|----------------|
| linear scan             | 64.5ms   | 0.064ms        |
| binary search + walk    | 0.25ms   | 0.00025ms      |

About 258x faster for this step.

## Risk

Change is scoped to `paintLineHighlights` in the
`"css-highlights"` engine's single-line fast path. Behavior is
unchanged; only the search strategy differs, relying on the
same sortedness invariant `paintAllLineHighlights` already
exploits. Worst case is a regression limited to per-keystroke
highlight repaint in that engine.