### PR TITLE
perf(engine): cache reopen tags across line breaks in extendLines

### DIFF
--- a/src/engine.js
+++ b/src/engine.js
@@ -871,17 +871,29 @@ export function extendLines(
   const stack = [...openScopes];
   /** @type {string[]} */
   const completedLines = [];
-  const reopenTags = () =>
-    stack
-      .map((scope) => `<span class="${scopeToCssClass(scope, classPrefix)}">`)
-      .join("");
+  // Cache the concatenated open/close tag strings for the current stack so a
+  // run of newlines between OPEN/CLOSE events reuses them instead of
+  // re-joining the whole stack per line break.
+  /** @type {string[]} */
+  const tags = stack.map(
+    (scope) => `<span class="${scopeToCssClass(scope, classPrefix)}">`,
+  );
+  let reopen = tags.join("");
+  let closeAll = "</span>".repeat(stack.length);
   let current = pendingHtml;
   for (const event of newEvents) {
     if (event.t === OPEN) {
       stack.push(event.s);
-      current += `<span class="${scopeToCssClass(event.s, classPrefix)}">`;
+      const tag = `<span class="${scopeToCssClass(event.s, classPrefix)}">`;
+      tags.push(tag);
+      reopen += tag;
+      closeAll += "</span>";
+      current += tag;
     } else if (event.t === CLOSE) {
       stack.pop();
+      const tag = /** @type {string} */ (tags.pop());
+      reopen = reopen.slice(0, reopen.length - tag.length);
+      closeAll = closeAll.slice(0, closeAll.length - "</span>".length);
       current += "</span>";
     } else {
       const text = event.v;
@@ -889,9 +901,9 @@ export function extendLines(
       for (let i = 0; i < text.length; i++) {
         if (text.charCodeAt(i) === 10) {
           current += escapeHtml(text.slice(start, i));
-          current += "</span>".repeat(stack.length);
+          current += closeAll;
           completedLines.push(current);
-          current = reopenTags();
+          current = reopen;
           start = i + 1;
         }
       }


### PR DESCRIPTION
extendLines is the incremental line renderer used per append by
HighlightStream (twice per frame) and by tokenized-document for
streaming/hydration. On every newline it rebuilt the
close/reopen tag strings from the whole scope stack via
`.repeat()` and `.map().join()`, even when OPEN/CLOSE hadn't
changed since the previous line.

The close and reopen tag strings are now cached alongside the
scope stack and updated incrementally on OPEN/CLOSE, so a run of
newlines between scope changes reuses the cached strings instead
of re-deriving them per line.

## Benchmark

Measured with a local (uncommitted) bench script against a
synthesized 200k-line stream (nesting depth ~3, a scope
OPEN/CLOSE every few lines). Reference is the previous
`extendLines`, alternated with the new one across 11 runs to
average out GC/JIT noise.

|         | median | min   |
|---------|--------|-------|
| before  | 182ms  | 141ms |
| after   | 101ms  | 94ms  |
| speedup | ~45%   | ~34%  |

Risk: `extendLines` is a pure function with no external state;
the change only alters how tag strings are tracked internally.
Output must stay byte-identical, verified by existing tests plus
a bench-time equality check against the reference
implementation.