### PR TITLE
feat(highlight-stream): add virtualize prop for windowed rendering

### DIFF
--- a/README.md
+++ b/README.md
@@ -1379,7 +1379,13 @@ Set `autoScroll` to keep the container pinned to the bottom as output grows -- i
 <HighlightStream language={typescript} {code} {done} autoScroll style="max-height: 20em; overflow-y: auto;" />
 ```
 
-Per-chunk work is O(tail), not O(stream length so far): finished output is sealed into immutable chunks the DOM never re-diffs, so a response that's ten times longer doesn't cost ten times more per repaint. DOM updates stay proportional to the changed lines -- fine for chat-sized output up to very long responses, not a substitute for `HighlightVirtual` below if you also need to *scroll* through a huge, already-complete document.
+Per-chunk work is O(tail), not O(stream length so far): finished output is sealed into immutable chunks the DOM never re-diffs, so a response that's ten times longer doesn't cost ten times more per repaint. DOM updates stay proportional to the changed lines -- fine for chat-sized output up to very long responses, but every line ever streamed still stays in the DOM; for a stream that runs long enough to *scroll* through, set `virtualize` to bound that too.
+
+```svelte
+<HighlightStream language={typescript} {code} {done} virtualize style="height: 20em;" />
+```
+
+`virtualize` renders only the lines within the scrolled viewport (plus `overscan`), the same windowing `HighlightVirtual` does for static documents -- a stream that runs to tens of thousands of lines still costs a couple dozen DOM nodes. It swaps the sealed-chunk session for `TokenizedDocument` (see [Large documents](#large-documents) below), so output always reflects the streaming (non-canonicalized) parse, even once `done` -- unlike the default mode, which upgrades to a canonical final render. `on:highlight` isn't dispatched in this mode, since materializing the full HTML on every repaint would defeat the point of windowing; `on:done`, the caret, and `autoScroll` all keep working.
 
 ## Large documents
 
@@ -1737,19 +1743,22 @@ Use `bind:this`, then call `undo()`, `redo()`, `focus()`, `selectAll()`, `insert
 
 #### Props
 
-| Name       | Type                                           | Default value  |
-| :--------- | :--------------------------------------------- | :------------- |
-| code       | `string`                                       | `""`           |
-| language   | { name: `string`; register: `object` } | N/A (required) |
-| done       | `boolean`                                      | `false`        |
-| caret      | `boolean`                                      | `true`         |
-| autoScroll | `boolean`                                      | `false`        |
+| Name               | Type                                    | Default value  |
+| :----------------- | :-------------------------------------- | :------------- |
+| code               | `string`                                | `""`           |
+| language           | { name: `string`; register: `object` }  | N/A (required) |
+| done               | `boolean`                               | `false`        |
+| caret              | `boolean`                               | `true`         |
+| autoScroll         | `boolean`                               | `false`        |
+| virtualize         | `boolean`                               | `false`        |
+| overscan           | `number`                                | `12`           |
+| checkpointInterval | `number`                                | `100`          |
 
-`$$restProps` are forwarded to the top-level `pre` element.
+`$$restProps` are forwarded to the top-level `pre` element. `overscan` and `checkpointInterval` only apply when `virtualize` is set.
 
 #### Dispatched Events
 
-- **on:highlight**: fired after each highlight pass, with `{ highlighted }`
+- **on:highlight**: fired after each highlight pass, with `{ highlighted }` -- not dispatched when `virtualize` is set
 - **on:done**: fired after the final full highlight once `done` is set
 
 ```svelte

--- a/src/HighlightStream.svelte
+++ b/src/HighlightStream.svelte
@@ -28,10 +28,39 @@
    */
   export let autoScroll = false;
 
+  /**
+   * Render only the lines within the scrolled viewport (plus `overscan`)
+   * instead of the whole growing buffer, so a long-running stream costs a
+   * bounded number of DOM nodes instead of one per line. Backed by
+   * `createTokenizedDocument` rather than the default sealed-chunk session,
+   * so output always reflects the streaming (non-canonicalized) parse, even
+   * once `done` - the same tradeoff `HighlightVirtual` makes. `on:highlight`
+   * is not dispatched in this mode, since materializing the full HTML on
+   * every repaint would defeat the point of windowing.
+   * @type {boolean}
+   */
+  export let virtualize = false;
+
+  /**
+   * Extra lines rendered above and below the viewport when `virtualize` is
+   * set.
+   * @type {number}
+   */
+  export let overscan = 12;
+
+  /**
+   * Lines between engine checkpoints when `virtualize` is set (forwarded to
+   * `createTokenizedDocument`).
+   * @type {number}
+   */
+  export let checkpointInterval = 100;
+
   import { createEventDispatcher, onMount, tick } from "svelte";
   import { extendLines } from "./engine.js";
   import { ensureRegistered, registry } from "./registry.js";
   import { createCompletedHtmlBuffer } from "./stream-highlighted.js";
+  import { createTokenizedDocument } from "./tokenized-document.js";
+  import { watchLineHeight, windowRange } from "./virtual-window.js";
 
   // Lines between sealed chunks. Once a chunk fills, its line spans are
   // joined into one immutable HTML string and never touched again - keyed
@@ -59,6 +88,28 @@
 
   // Stick to bottom until the user scrolls away from it.
   let stickToBottom = true;
+
+  // `virtualize` state: a random-access tokenized document (rather than the
+  // sealed-chunk session above) windowed the same way `HighlightVirtual`
+  // windows a static document.
+  /** @type {HTMLElement} */
+  let probe;
+  let vLineHeight = 16;
+  let vScrollTop = 0;
+  let vClientHeight = 0;
+  /** @type {ReturnType<typeof requestAnimationFrame> | undefined} */
+  let vFrame;
+  /** @type {ResizeObserver | undefined} */
+  let resizeObserver;
+  /** @type {ReturnType<typeof createTokenizedDocument> | undefined} */
+  let vdoc;
+  let vdocLanguageName = "";
+  let vdocCheckpointInterval;
+  let vLineCount = 0;
+  let vStart = 0;
+  let vEnd = 0;
+  /** @type {string[]} */
+  let vVisibleLines = [];
 
   /** @type {ReturnType<typeof registry.createSession> | undefined} */
   let session;
@@ -204,6 +255,7 @@
     const gap =
       container.scrollHeight - container.scrollTop - container.clientHeight;
     stickToBottom = gap <= 4;
+    if (virtualize) scheduleVirtualRepaint();
   }
 
   function cancelFrame() {
@@ -222,10 +274,94 @@
     });
   }
 
+  function ensureVirtualDoc() {
+    if (
+      vdoc &&
+      vdocLanguageName === language.name &&
+      vdocCheckpointInterval === checkpointInterval
+    ) {
+      return;
+    }
+    vdoc = createTokenizedDocument({ language, checkpointInterval });
+    vdocLanguageName = language.name;
+    vdocCheckpointInterval = checkpointInterval;
+  }
+
+  function computeVirtualWindow() {
+    if (!vdoc) return;
+    const total = vdoc.lineCount();
+    vLineCount = total;
+    ({ start: vStart, end: vEnd } = windowRange({
+      scrollTop: vScrollTop,
+      clientHeight: vClientHeight,
+      lineHeight: vLineHeight,
+      overscan,
+      total,
+    }));
+    vVisibleLines = vdoc.lineRange(vStart, vEnd);
+  }
+
+  // Mirrors `scrollToBottom`/the shrink-clamp in `HighlightVirtual`, merged:
+  // while streaming with `autoScroll`, stick to the (growing) bottom; once
+  // the user scrolls away, just keep the scroll position in bounds.
+  async function syncVirtualFromContainer() {
+    await tick();
+    if (!container) return;
+    if (autoScroll && stickToBottom) {
+      container.scrollTop = container.scrollHeight;
+    } else {
+      const maxScrollTop = Math.max(
+        0,
+        container.scrollHeight - container.clientHeight,
+      );
+      if (container.scrollTop > maxScrollTop) {
+        container.scrollTop = maxScrollTop;
+      }
+    }
+    vScrollTop = container.scrollTop;
+    vClientHeight = container.clientHeight;
+  }
+
+  function cancelVirtualFrame() {
+    if (vFrame != null) {
+      cancelAnimationFrame(vFrame);
+      vFrame = undefined;
+    }
+  }
+
+  // Coalesce scroll bursts into one window recompute per frame.
+  function scheduleVirtualRepaint() {
+    if (vFrame != null) return;
+    vFrame = requestAnimationFrame(() => {
+      vFrame = undefined;
+      if (container) vScrollTop = container.scrollTop;
+    });
+  }
+
+  function measureVirtualLineHeight() {
+    return watchLineHeight(
+      () => probe,
+      () => vLineHeight,
+      (height) => (vLineHeight = height),
+    );
+  }
+
   $: {
     void code;
     void language;
-    if (mounted && !done) {
+    if (virtualize) {
+      // Content/window updates are handled by the virtualize-specific
+      // reactive blocks below; this block only tracks `done` dispatch so
+      // both modes share the same guard/reset semantics.
+      if (mounted && done) {
+        if (!doneDispatched) {
+          doneDispatched = true;
+          dispatch("done");
+        }
+      } else {
+        doneDispatched = false;
+      }
+    } else if (mounted && !done) {
       doneDispatched = false;
       scheduleRepaint();
     } else {
@@ -239,20 +375,99 @@
     }
   }
 
+  // Rebuilds/updates the virtualized document whenever its content or shape
+  // changes. Deliberately separate from the scroll-driven block below, same
+  // reasoning as `HighlightVirtual`.
+  $: if (virtualize && mounted) {
+    void code;
+    void language;
+    void checkpointInterval;
+    ensureVirtualDoc();
+    vdoc.setCode(code);
+    vLineCount = vdoc.lineCount();
+    computeVirtualWindow();
+    syncVirtualFromContainer();
+  }
+
+  // Scroll/resize/overscan/lineHeight-driven window recompute.
+  $: if (virtualize && mounted) {
+    void overscan;
+    void vLineHeight;
+    void vScrollTop;
+    void vClientHeight;
+    void vLineCount;
+    computeVirtualWindow();
+  }
+
   $: useSplitRendering = mounted && !done;
   $: showCaret = useSplitRendering && caret;
 
   onMount(() => {
     mounted = true;
-    return cancelFrame;
+    if (virtualize) {
+      measureVirtualLineHeight();
+      syncVirtualFromContainer();
+      if (typeof ResizeObserver !== "undefined" && container) {
+        resizeObserver = new ResizeObserver(() => {
+          if (container) vClientHeight = container.clientHeight;
+        });
+        resizeObserver.observe(container);
+      }
+    }
+    return () => {
+      cancelFrame();
+      cancelVirtualFrame();
+      resizeObserver?.disconnect();
+    };
   });
 </script>
 
-<pre bind:this={container} on:scroll={onScroll} {...$$restProps}><code
+{#if virtualize}
+  <pre
+    bind:this={container}
+    class:hljs={true}
+    class:shl-virtual={true}
+    on:scroll={onScroll}
+    {...$$restProps}
+  ><code>{#if !mounted}{code}{:else}<span class="shl-virtual-sizer" style="height: {vLineCount * vLineHeight}px;"><span class="shl-virtual-window" style="transform: translateY({vStart * vLineHeight}px);">{#each vVisibleLines as line, i (vStart + i)}<span class="highlight-stream-line" data-line={vStart + i}>{@html line}</span>{#if showCaret && vEnd === vLineCount && i === vVisibleLines.length - 1}<span class="highlight-stream-caret" aria-hidden="true"></span>{/if}{"\n"}{/each}</span></span>{/if}</code><span
+  bind:this={probe}
+  class="shl-virtual-probe highlight-stream-line"
+  aria-hidden="true"
+>&nbsp;</span></pre>
+{:else}
+  <pre bind:this={container} on:scroll={onScroll} {...$$restProps}><code
   class:hljs={true}
 >{#if useSplitRendering}{#each sealedChunks as chunk, c (c)}{@html chunk}{/each}{#each tailLines as line, li (sealedLineCount + li)}{#if sealedLineCount + li > 0}{"\n"}{/if}<span class="highlight-stream-line" data-line={sealedLineCount + li}>{@html line}</span>{/each}{#if showCaret}<span class="highlight-stream-caret" aria-hidden="true"></span>{/if}{:else}{@html highlighted}{/if}</code></pre>
+{/if}
 
 <style>
+  .shl-virtual {
+    display: block;
+    position: relative;
+    overflow: auto;
+    white-space: pre;
+    margin: 0;
+  }
+
+  .shl-virtual-sizer {
+    display: block;
+    position: relative;
+  }
+
+  .shl-virtual-window {
+    display: block;
+    position: absolute;
+    top: 0;
+    left: 0;
+    right: 0;
+  }
+
+  .shl-virtual-probe {
+    position: absolute;
+    visibility: hidden;
+    pointer-events: none;
+  }
+
   .highlight-stream-caret {
     display: inline-block;
     width: var(--caret-width, 0.6em);

--- a/src/HighlightStream.svelte.d.ts
+++ b/src/HighlightStream.svelte.d.ts
@@ -38,6 +38,31 @@ export type HighlightStreamProps = HTMLAttributes<HTMLPreElement> & {
   autoScroll?: boolean;
 
   /**
+   * Render only the lines within the scrolled viewport (plus `overscan`)
+   * instead of the whole growing buffer, so a long-running stream costs a
+   * bounded number of DOM nodes instead of one per line. Backed by
+   * `createTokenizedDocument` rather than the sealed-chunk session used
+   * otherwise, so output always reflects the streaming (non-canonicalized)
+   * parse, even once `done` -- the same tradeoff `HighlightVirtual` makes.
+   * `on:highlight` is not dispatched in this mode.
+   * @default false
+   */
+  virtualize?: boolean;
+
+  /**
+   * Extra lines rendered above and below the viewport when `virtualize` is set.
+   * @default 12
+   */
+  overscan?: number;
+
+  /**
+   * Lines between engine checkpoints when `virtualize` is set (forwarded to
+   * `createTokenizedDocument`).
+   * @default 100
+   */
+  checkpointInterval?: number;
+
+  /**
    * Width of the blinking caret.
    * @default "0.6em"
    */

--- a/src/HighlightVirtual.svelte
+++ b/src/HighlightVirtual.svelte
@@ -23,6 +23,7 @@
 
   import { onMount, tick } from "svelte";
   import { createTokenizedDocument } from "./tokenized-document.js";
+  import { watchLineHeight, windowRange } from "./virtual-window.js";
 
   /** @type {HTMLElement} */
   let container;
@@ -78,13 +79,13 @@
     if (!doc) return;
     const total = doc.lineCount();
     lineCount = total;
-    const first = Math.max(0, Math.floor(scrollTop / lineHeight) - overscan);
-    const last = Math.min(
+    ({ start, end } = windowRange({
+      scrollTop,
+      clientHeight,
+      lineHeight,
+      overscan,
       total,
-      Math.ceil((scrollTop + clientHeight) / lineHeight) + overscan,
-    );
-    start = Math.min(first, total);
-    end = Math.max(start, last);
+    }));
     visibleLines = doc.lineRange(start, end);
   }
 
@@ -124,20 +125,12 @@
     scheduleRepaint();
   }
 
-  async function measureLineHeight() {
-    await tick();
-    if (probe) {
-      const height = probe.getBoundingClientRect().height;
-      if (height > 0) lineHeight = height;
-    }
-    if (typeof document !== "undefined" && document.fonts?.ready) {
-      document.fonts.ready.then(async () => {
-        await tick();
-        if (!probe) return;
-        const height = probe.getBoundingClientRect().height;
-        if (height > 0 && height !== lineHeight) lineHeight = height;
-      });
-    }
+  function measureLineHeight() {
+    return watchLineHeight(
+      () => probe,
+      () => lineHeight,
+      (height) => (lineHeight = height),
+    );
   }
 
   // Rebuilds/updates the document whenever its content or shape changes.

--- a/src/virtual-window.js
+++ b/src/virtual-window.js
@@ -1,0 +1,67 @@
+/**
+ * Windowing math and probe-based line-height measurement shared by
+ * components that render a scroll-position-driven slice of lines
+ * (`HighlightVirtual`, `HighlightStream`'s `virtualize` mode).
+ */
+
+import { tick } from "svelte";
+
+/**
+ * The `[start, end)` line range to render for a given scroll position,
+ * padded by `overscan` lines on each side and clamped to `[0, total]`.
+ * @param {{
+ *   scrollTop: number,
+ *   clientHeight: number,
+ *   lineHeight: number,
+ *   overscan: number,
+ *   total: number,
+ * }} params
+ * @returns {{ start: number, end: number }}
+ */
+export function windowRange({
+  scrollTop,
+  clientHeight,
+  lineHeight,
+  overscan,
+  total,
+}) {
+  const first = Math.max(0, Math.floor(scrollTop / lineHeight) - overscan);
+  const last = Math.min(
+    total,
+    Math.ceil((scrollTop + clientHeight) / lineHeight) + overscan,
+  );
+  const start = Math.min(first, total);
+  const end = Math.max(start, last);
+  return { start, end };
+}
+
+/**
+ * Measures a hidden probe line's rendered height, once after the next tick
+ * and again once webfonts finish loading (a late font swap can change line
+ * height after the first measurement). Rounded to a whole pixel: the sizer
+ * height and window `translateY` are both `lineCount * lineHeight` /
+ * `start * lineHeight`, and a fractional line height makes those fall on a
+ * different sub-pixel offset than the (always-integer) scroll position on
+ * every repaint - harmless for a one-off scroll, but a visible 1px jitter
+ * during continuous high-frequency repaints like streaming.
+ * @param {() => HTMLElement | undefined} getProbe
+ * @param {() => number} getLineHeight
+ * @param {(height: number) => void} setLineHeight
+ */
+export async function watchLineHeight(getProbe, getLineHeight, setLineHeight) {
+  await tick();
+  const probe = getProbe();
+  if (probe) {
+    const height = Math.round(probe.getBoundingClientRect().height);
+    if (height > 0) setLineHeight(height);
+  }
+  if (typeof document !== "undefined" && document.fonts?.ready) {
+    document.fonts.ready.then(async () => {
+      await tick();
+      const p = getProbe();
+      if (!p) return;
+      const height = Math.round(p.getBoundingClientRect().height);
+      if (height > 0 && height !== getLineHeight()) setLineHeight(height);
+    });
+  }
+}

--- a/tests/e2e/HighlightStream.virtualize.test.svelte
+++ b/tests/e2e/HighlightStream.virtualize.test.svelte
@@ -1,0 +1,53 @@
+<script>
+  import { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  export let overscan = 5;
+  export let autoScroll = false;
+
+  let code = "";
+  let done = false;
+  let doneCount = 0;
+
+  function appendLines(n) {
+    let extra = "";
+    for (let i = 0; i < n; i++) extra += `const x${i} = ${i}; // line ${i}\n`;
+    code += extra;
+  }
+
+  function appendMany() {
+    appendLines(2000);
+  }
+
+  function appendFew() {
+    appendLines(3);
+  }
+
+  function finish() {
+    done = true;
+  }
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<button type="button" data-testid="append-many" on:click={appendMany}>
+  Append 2000 lines
+</button>
+<button type="button" data-testid="append-few" on:click={appendFew}>
+  Append 3 lines
+</button>
+<button type="button" data-testid="finish" on:click={finish}>Finish</button>
+<span data-testid="done-count">{doneCount}</span>
+
+<HighlightStream
+  language={javascript}
+  {code}
+  {done}
+  {autoScroll}
+  virtualize
+  {overscan}
+  data-testid="stream"
+  style="height: 300px; width: 600px;"
+  on:done={() => (doneCount += 1)}
+/>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -25,6 +25,7 @@ import HighlightStreamSealing from "./HighlightStream.sealing.test.svelte";
 import HighlightStreamStability from "./HighlightStream.stability.test.svelte";
 import HighlightStreamTemplateLiteral from "./HighlightStream.templateLiteral.test.svelte";
 import HighlightStream from "./HighlightStream.test.svelte";
+import HighlightStreamVirtualize from "./HighlightStream.virtualize.test.svelte";
 import HighlightStyleDedupe from "./HighlightStyle.dedupe.test.svelte";
 import HighlightStyleNoTheme from "./HighlightStyle.noTheme.test.svelte";
 import HighlightStyleThemeSwitch from "./HighlightStyle.themeSwitch.test.svelte";
@@ -1306,6 +1307,107 @@ test("HighlightStream sealing - dispatched `highlight` payload matches Highlight
   // own internal block-boundary comment markers, which differ between the
   // two components' unrelated template structures.
   expect(streamedHighlighted).toBe(referenceHighlighted);
+});
+
+test("HighlightStream virtualize - renders a bounded number of line nodes for a long-running stream", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamVirtualize);
+
+  const stream = page.getByTestId("stream");
+  await page.getByTestId("append-many").click();
+
+  const renderedLines = stream.locator("[data-line]");
+  await expect(renderedLines.first()).toBeVisible();
+
+  const count = await renderedLines.count();
+  // Same bound as HighlightVirtual's equivalent test: nowhere near the 2,000
+  // (+1 trailing) lines streamed in, which is the point.
+  expect(count).toBeGreaterThan(0);
+  expect(count).toBeLessThan(200);
+});
+
+test("HighlightStream virtualize - shows correct content at a scrolled position", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamVirtualize);
+
+  const stream = page.getByTestId("stream");
+  await page.getByTestId("append-many").click();
+  await expect(stream.locator("[data-line='0']")).toHaveText(
+    "const x0 = 0; // line 0",
+  );
+
+  await stream.evaluate((el) => {
+    el.scrollTop = (el.scrollHeight - el.clientHeight) / 2;
+  });
+
+  let middleIndex = 0;
+  await expect(async () => {
+    const middleLine = await stream
+      .locator("[data-line]")
+      .first()
+      .getAttribute("data-line");
+    middleIndex = Number(middleLine);
+    expect(middleIndex).toBeGreaterThan(100);
+  }).toPass();
+
+  await expect(stream.locator(`[data-line='${middleIndex}']`)).toHaveText(
+    `const x${middleIndex} = ${middleIndex}; // line ${middleIndex}`,
+  );
+});
+
+test("HighlightStream virtualize - the caret only renders once the window reaches the live tail", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamVirtualize);
+
+  const stream = page.getByTestId("stream");
+  await page.getByTestId("append-many").click();
+  await expect(stream.locator("[data-line]").first()).toBeVisible();
+
+  // Scrolled to the top (default): the window doesn't reach the still-
+  // streaming last line, so no caret renders anywhere.
+  await expect(stream.locator(".highlight-stream-caret")).toHaveCount(0);
+
+  await stream.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+  await expect(stream.locator(".highlight-stream-caret")).toBeVisible();
+});
+
+test("HighlightStream virtualize - autoScroll keeps the window pinned to the growing tail", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamVirtualize, { props: { autoScroll: true } });
+
+  const stream = page.getByTestId("stream");
+  await page.getByTestId("append-many").click();
+
+  // The most recently completed line is visible without any manual
+  // scrolling, and the caret (which only renders at the live tail) shows too.
+  await expect(stream.locator("[data-line='1999']")).toBeVisible();
+  await expect(stream.locator(".highlight-stream-caret")).toBeVisible();
+});
+
+test("HighlightStream virtualize - `done` hides the caret and fires on:done", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamVirtualize);
+
+  const stream = page.getByTestId("stream");
+  await page.getByTestId("append-few").click();
+  await expect(stream.locator(".highlight-stream-caret")).toBeVisible();
+  await expect(page.getByTestId("done-count")).toHaveText("0");
+
+  await page.getByTestId("finish").click();
+  await expect(stream.locator(".highlight-stream-caret")).toHaveCount(0);
+  await expect(page.getByTestId("done-count")).toHaveText("1");
 });
 
 test("HighlightVirtual - renders a bounded number of line nodes for a 5,000-line document", async ({

--- a/tests/highlight-stream-virtualize-ssr.test.ts
+++ b/tests/highlight-stream-virtualize-ssr.test.ts
@@ -1,0 +1,68 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+import typescript from "../src/languages/typescript.js";
+
+const componentPath = path.join(
+  import.meta.dir,
+  "../src/HighlightStream.svelte",
+);
+
+async function compileForServer() {
+  const source = fs.readFileSync(componentPath, "utf-8");
+  const { js } = compile(source, {
+    generate: "server",
+    filename: "HighlightStream.svelte",
+  });
+
+  // Written alongside the component (not in tests/) so its relative imports
+  // (e.g. "./tokenized-document.js") resolve.
+  const outPath = path.join(
+    import.meta.dir,
+    "../src/.tmp-highlight-stream.server.js",
+  );
+  fs.writeFileSync(outPath, js.code);
+  try {
+    return await import(pathToFileURL(outPath).href);
+  } finally {
+    fs.unlinkSync(outPath);
+  }
+}
+
+describe("HighlightStream `virtualize` SSR", () => {
+  it("renders the full code as plain escaped text, not tokenized HTML", async () => {
+    const { default: HighlightStream } = await compileForServer();
+
+    const lines = Array.from({ length: 50 }, (_, i) => `const x${i} = ${i};`);
+    const code = `${lines.join("\n")}\na < b`;
+
+    const { body } = render(HighlightStream, {
+      props: { language: typescript, code, virtualize: true },
+    });
+
+    // No tokenization: no scope spans, no windowed-line markup (the hidden
+    // line-height probe legitimately renders even pre-hydration, but it
+    // carries no `data-line`).
+    expect(body).not.toContain("hljs-keyword");
+    expect(body).not.toContain("data-line");
+    expect(body).not.toContain("shl-virtual-sizer");
+    expect(body).not.toContain("shl-virtual-window");
+
+    // The full document is present, plain-text-escaped.
+    expect(body).toContain("a &lt; b");
+    for (const line of lines) expect(body).toContain(line);
+  });
+
+  it("non-virtualized SSR is unaffected (still highlights up front)", async () => {
+    const { default: HighlightStream } = await compileForServer();
+
+    const { body } = render(HighlightStream, {
+      props: { language: typescript, code: "const a: number = 1;" },
+    });
+
+    expect(body).toContain("hljs-keyword");
+    expect(body).not.toContain("shl-virtual");
+  });
+});

--- a/tests/virtual-window.test.ts
+++ b/tests/virtual-window.test.ts
@@ -1,0 +1,56 @@
+import { windowRange } from "../src/virtual-window.js";
+
+describe("windowRange", () => {
+  it("pads the visible range by overscan on both sides", () => {
+    const { start, end } = windowRange({
+      scrollTop: 100,
+      clientHeight: 50,
+      lineHeight: 10,
+      overscan: 2,
+      total: 1000,
+    });
+
+    // Visible lines 10-15 (100/10 to 150/10), padded by 2 on each side.
+    expect(start).toBe(8);
+    expect(end).toBe(17);
+  });
+
+  it("clamps start to 0 near the top", () => {
+    const { start, end } = windowRange({
+      scrollTop: 0,
+      clientHeight: 50,
+      lineHeight: 10,
+      overscan: 10,
+      total: 1000,
+    });
+
+    expect(start).toBe(0);
+    expect(end).toBe(15);
+  });
+
+  it("clamps end to total near the bottom", () => {
+    const { start, end } = windowRange({
+      scrollTop: 990,
+      clientHeight: 50,
+      lineHeight: 10,
+      overscan: 10,
+      total: 100,
+    });
+
+    expect(end).toBe(100);
+    expect(start).toBeLessThan(end);
+  });
+
+  it("returns an empty, clamped range for an empty document", () => {
+    const { start, end } = windowRange({
+      scrollTop: 0,
+      clientHeight: 50,
+      lineHeight: 10,
+      overscan: 5,
+      total: 0,
+    });
+
+    expect(start).toBe(0);
+    expect(end).toBe(0);
+  });
+});

--- a/www/components/HighlightStream/Virtualize.svelte
+++ b/www/components/HighlightStream/Virtualize.svelte
@@ -1,0 +1,85 @@
+<script>
+  import { trackRenderedLineCount } from "@components/HighlightVirtual/generate-large-code.js";
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button, Toggle } from "carbon-components-svelte";
+  import { onDestroy, onMount } from "svelte";
+  import { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import { simulateStream } from "./stream-demo.js";
+
+  const LINE_COUNT = 1500;
+  const full = Array.from(
+    { length: LINE_COUNT },
+    (_, i) => `console.log("line ${i}: ${(i * 7) % 13} items processed");`,
+  ).join("\n");
+
+  let autoScroll = true;
+  let code = "";
+  let done = false;
+  let paused = false;
+  let renderedLineCount = 0;
+  let stop = () => {};
+
+  function run() {
+    stop();
+    code = "";
+    done = false;
+    paused = false;
+    stop = simulateStream(full, {
+      intervalMs: 4,
+      minChunk: 20,
+      maxChunk: 60,
+      onChunk: (chunk) => (code += chunk),
+      onDone: () => (done = true),
+    });
+  }
+
+  function togglePause() {
+    paused = !paused;
+    if (paused) stop.pause();
+    else stop.resume();
+  }
+
+  onMount(run);
+  onDestroy(() => stop());
+</script>
+
+<p class="label-01 mb-3">
+  {LINE_COUNT.toLocaleString()}
+  lines stream in fast; only the scrolled window is ever in the DOM.
+</p>
+
+<div use:trackRenderedLineCount={(n) => (renderedLineCount = n)}>
+  <HighlightStream
+    language={javascript}
+    {code}
+    {done}
+    {autoScroll}
+    virtualize
+    class={THEME_MODULE_NAME}
+    style="height: 320px"
+  />
+</div>
+
+<div
+  style="display: flex; flex-wrap: wrap; align-items: flex-end; gap: 1.5rem; margin-top: 1rem"
+>
+  <Toggle
+    bind:toggled={autoScroll}
+    labelText="Auto-scroll"
+    labelA="Off"
+    labelB="On"
+  />
+  <Button size="small" kind="tertiary" disabled={done} on:click={togglePause}>
+    {paused ? "Resume" : "Pause"}
+  </Button>
+  <Button size="small" kind="tertiary" on:click={run}>Replay</Button>
+  <p class="label-01" style="margin-bottom: 0.5rem">
+    Status:{" "}
+    <code class="code">{done ? "done" : paused ? "paused" : "streaming…"}</code>
+  </p>
+  <p class="label-01" style="margin-bottom: 0.5rem">
+    Rendered line nodes: <code class="code">{renderedLineCount}</code> of
+    {LINE_COUNT.toLocaleString()}
+  </p>
+</div>

--- a/www/components/HighlightStream/stream-demo.js
+++ b/www/components/HighlightStream/stream-demo.js
@@ -1,8 +1,10 @@
 /**
  * Feed `text` into `onChunk` in randomly-sized pieces on an interval, so demos
  * can show `HighlightStream` without a real streaming backend (fetch,
- * WebSocket, SSE, ...). Returns a stop function; call it on replay/unmount to
- * clear the interval.
+ * WebSocket, SSE, ...). Returns a stop function (call it on replay/unmount to
+ * clear the interval for good); the same function also carries `.pause()`
+ * and `.resume()` for demos that want to freeze mid-stream without losing
+ * position, then continue from where they left off.
  * @param {string} text
  * @param {{
  *   onChunk: (chunk: string) => void;
@@ -11,15 +13,17 @@
  *   minChunk?: number;
  *   maxChunk?: number;
  * }} options
- * @returns {() => void}
+ * @returns {(() => void) & { pause(): void; resume(): void }}
  */
 export function simulateStream(
   text,
   { onChunk, onDone, intervalMs = 35, minChunk = 1, maxChunk = 4 },
 ) {
   let i = 0;
+  let paused = false;
 
   const id = setInterval(() => {
+    if (paused) return;
     if (i >= text.length) {
       clearInterval(id);
       onDone?.();
@@ -32,5 +36,12 @@ export function simulateStream(
     i += size;
   }, intervalMs);
 
-  return () => clearInterval(id);
+  const stop = () => clearInterval(id);
+  stop.pause = () => {
+    paused = true;
+  };
+  stop.resume = () => {
+    paused = false;
+  };
+  return stop;
 }

--- a/www/components/HighlightStreamPreview.svelte
+++ b/www/components/HighlightStreamPreview.svelte
@@ -5,6 +5,7 @@
   import Controls from "@components/HighlightStream/Controls.svelte";
   import Retokenize from "@components/HighlightStream/Retokenize.svelte";
   import Stepper from "@components/HighlightStream/Stepper.svelte";
+  import Virtualize from "@components/HighlightStream/Virtualize.svelte";
   import { Column, Row } from "carbon-components-svelte";
 </script>
 
@@ -36,4 +37,9 @@
 <Row class="mb-9">
   <Column xlg={12}> <h3>Custom caret</h3> </Column>
   <Column xlg={12} lg={12} md={12}> <Caret /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Virtualized (windowed) streaming</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Virtualize /> </Column>
 </Row>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -14,6 +14,7 @@
   import EditableCssHighlights from "@components/HighlightEditable/CssHighlights.svelte";
   import HighlightStreamBasic from "@components/HighlightStream/Basic.svelte";
   import HighlightStreamControls from "@components/HighlightStream/Controls.svelte";
+  import HighlightStreamVirtualize from "@components/HighlightStream/Virtualize.svelte";
   import HighlightVirtualBasic from "@components/HighlightVirtual/Basic.svelte";
   import HighlightVirtualControls from "@components/HighlightVirtual/Controls.svelte";
   import HighlightVirtualHeadless from "@components/HighlightVirtual/Headless.svelte";
@@ -587,6 +588,24 @@ export default {
     />
   </Column>
   <Column xlg={10} lg={10} md={12}> <HighlightStreamControls /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Set <code class="code">virtualize</code> to render only the lines within
+      the scrolled viewport (plus <code class="code">overscan</code>) instead of
+      the whole growing buffer, so a long-running stream costs a bounded number
+      of DOM nodes instead of one per line—the same windowing
+      <code class="code">HighlightVirtual</code>
+      does for static documents.
+    </p>
+    <InlineNotification
+      lowContrast
+      hideCloseButton
+      kind="info"
+      title="Note:"
+      subtitle="Backed by the same TokenizedDocument used below, so output stays the streaming (non-canonicalized) parse even once done. on:highlight isn't dispatched in this mode; on:done, the caret, and autoScroll all keep working."
+    />
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <HighlightStreamVirtualize /> </Column>
 </Row>
 
 <Row class="mb-9">


### PR DESCRIPTION
`HighlightStream` renders every streamed line into the DOM, so a
long-running stream keeps growing the page's node count even though
each repaint stays cheap. There was no way to bound it the way
HighlightVirtual bounds a static document, and no shared windowing
code between the two components.

Add a `virtualize` prop that swaps the sealed-chunk session for
`TokenizedDocument` and renders only the scrolled window (plus
`overscan`), reusing the same checkpoint/resume primitive
`HighlightVirtual` uses. Caret, `autoScroll`, and `on:done` keep
working; `on:highlight` is skipped in this mode since materializing
full HTML every repaint would defeat the point of windowing, and
`done` no longer upgrades to a canonical re-parse, matching the
tradeoff `HighlightVirtual` already makes. The windowing math and
line-height measurement moved into a shared `src/virtual-window.js`,
which `HighlightVirtual` now uses too, with line height rounded to a
whole pixel so the sizer/`translateY` math stays aligned with the
always-integer `scrollTop` under frequent repaints.

Docs and an example (streaming 1,500 lines with a live rendered-node
counter and pause/resume controls) are included on the main docs page
and the HighlightStream preview route.

## Risk

Scoped to a new opt-in prop (default `false`) plus a pure refactor of
`HighlightVirtual`'s existing windowing code into a shared module; the
non-`virtualize` path is unchanged. Main risk is in the shared
`virtual-window.js` math, covered by unit tests and the existing
`HighlightVirtual` e2e suite plus new `virtualize`-specific e2e tests.