### PR TITLE
ci: use preinstalled Chrome channel for chromium e2e in CI

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -26,7 +26,10 @@ export default defineConfig({
   projects: [
     {
       name: "chromium",
-      use: { ...devices["Desktop Chrome"] },
+      use: {
+        ...devices["Desktop Chrome"],
+        channel: process.env.CI ? "chrome" : undefined,
+      },
     },
     {
       name: "firefox",


### PR DESCRIPTION
CI downloads and caches Playwright's own bundled Chromium build for
the chromium e2e project, even though the macOS runner already ships
Google Chrome.

In CI, the chromium project now sets channel: "chrome" to run against
the preinstalled browser instead. Locally it still falls back to
Playwright's bundled Chromium. Firefox and WebKit projects are
unchanged: Playwright always uses its own patched builds for those,
since the channel option only supports Chromium-family browsers.

Risk is limited to the e2e job; a channel mismatch would only affect
CI test results, not the published package.