### PR TITLE
perf(highlight-editable): O(delta) DOM paint for pure appends

### DIFF
--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -39,7 +39,8 @@
   export let theme = undefined;
 
   import { createEventDispatcher, onMount } from "svelte";
-  import { renderHtml, toRanges } from "./engine.js";
+  import { createDomLinePainter } from "./editable-dom-paint.js";
+  import { toRanges } from "./engine.js";
   import {
     highlightRules,
     highlightRulesFromPalette,
@@ -49,7 +50,6 @@
     reparseIncremental,
   } from "./incremental-tokenize.js";
   import { ensureRegistered, registry } from "./registry.js";
-  import { splitLines } from "./split-lines.js";
   import { diffText } from "./text-diff.js";
 
   const dispatch = createEventDispatcher();
@@ -79,6 +79,10 @@
   // convergence. getEvents() full-parses on first call and language change.
   /** @type {import("./incremental-tokenize.js").IncrementalParse | undefined} */
   let incrementalParse;
+
+  // DOM-engine line HTML: pure appends feed a stream session so renderHtml is
+  // not re-run over the whole document on every keystroke.
+  const domLinePainter = createDomLinePainter({ registry });
 
   function getEvents() {
     incrementalParse = incrementalParse
@@ -455,10 +459,11 @@
 
   function paint() {
     if (resolvedEngineValue === "css-highlights") return paintCssHighlights();
-    const html = renderHtml(getEvents());
-    // Trailing empty line needs a phantom `\n` for caret placement.
-    const paintHtml = code === "" || code.endsWith("\n") ? `${html}\n` : html;
-    return renderLines(splitLines(paintHtml), setHtml);
+    const events = getEvents();
+    return renderLines(
+      domLinePainter.paint(events, code, language.name),
+      setHtml,
+    );
   }
 
   function renderAt(start, end) {
@@ -485,6 +490,8 @@
   }
 
   function repaintForLanguageChange() {
+    incrementalParse = undefined;
+    domLinePainter.reset();
     const caret = document.activeElement === editor ? getCaretOffset() : null;
     if (caret == null) paint();
     else renderAt(caret, caret);

--- a/src/editable-dom-paint.js
+++ b/src/editable-dom-paint.js
@@ -1,0 +1,193 @@
+/**
+ * Incremental DOM-engine paint helpers for HighlightEditable.
+ *
+ * Tokenization via `reparseIncremental` is already incremental, but the
+ * default `"dom"` engine still ran `renderHtml` + `splitLines` over the full
+ * event stream every keystroke. For pure appends (typing at the end — the
+ * common path when growing a document), a dedicated stream session feeds only
+ * the new suffix through `extendLines`, so HTML work is O(delta) per keystroke
+ * and O(n) total to type a document of size n.
+ */
+
+import { extendLines, renderHtml } from "./engine.js";
+import { splitLines } from "./split-lines.js";
+
+/**
+ * @param {string} previousCode
+ * @param {string} nextCode
+ */
+export function isPureAppend(previousCode, nextCode) {
+  return (
+    nextCode.length >= previousCode.length && nextCode.startsWith(previousCode)
+  );
+}
+
+/**
+ * Full line-HTML paint via `renderHtml` + `splitLines` (the historical path).
+ * @param {import("./engine.d.ts").ScopeEvent[]} events
+ * @param {string} code
+ * @returns {string[]}
+ */
+export function lineHtmlFromEvents(events, code) {
+  const html = renderHtml(events);
+  const paintHtml = code === "" || code.endsWith("\n") ? `${html}\n` : html;
+  return splitLines(paintHtml);
+}
+
+/**
+ * Build the visible line list from incremental extendLines state, matching
+ * `lineHtmlFromEvents` (including the historical phantom trailing newline
+ * when `code` is empty or ends in `\n`).
+ *
+ * @param {string[]} completedLines
+ * @param {string[]} previewLines unsealed + pending preview from resume
+ * @param {string} code
+ * @returns {string[]}
+ */
+export function linesFromStreamState(completedLines, previewLines, code) {
+  /** @type {string[]} */
+  const lines = completedLines.concat(previewLines);
+  // Historical paint does `html + "\n"` before splitLines when the source ends
+  // on a line boundary, which yields one extra empty caret line beyond the
+  // stream-style completed+pending list.
+  if (code === "" || code.endsWith("\n")) {
+    lines.push("");
+  }
+  return lines;
+}
+
+/**
+ * @typedef {import("./engine.d.ts").Registry} Registry
+ * @typedef {import("./engine.d.ts").ScopeEvent} ScopeEvent
+ * @typedef {import("./engine.d.ts").StreamSession} StreamSession
+ */
+
+/**
+ * Stateful incremental painter driven by pure-append stream sessions.
+ *
+ * @param {{
+ *   registry: Registry,
+ * }} options
+ */
+export function createDomLinePainter({ registry }) {
+  /** @type {StreamSession | undefined} */
+  let session;
+  let sessionLanguage = "";
+  let fedCode = "";
+  let renderedEventCount = 0;
+  /** @type {string[]} */
+  let openScopes = [];
+  let pendingHtml = "";
+  /** @type {string[]} */
+  let completedLines = [];
+  let lastUsedIncremental = false;
+  /** Whether the current session has already accepted at least one append. */
+  let hasAppended = false;
+
+  /** @param {string} nextLanguage */
+  function resetSession(nextLanguage) {
+    session = registry.createSession(nextLanguage);
+    sessionLanguage = nextLanguage;
+    fedCode = "";
+    renderedEventCount = 0;
+    openScopes = [];
+    pendingHtml = "";
+    completedLines = [];
+    hasAppended = false;
+  }
+
+  /**
+   * @param {ScopeEvent[]} committed
+   */
+  function consumeCommitted(committed) {
+    if (!session || committed.length <= renderedEventCount) return;
+    const result = extendLines(
+      committed.slice(renderedEventCount),
+      openScopes,
+      pendingHtml,
+    );
+    if (result.completedLines.length > 0) {
+      completedLines = completedLines.concat(result.completedLines);
+    }
+    openScopes = result.openScopes;
+    pendingHtml = result.pendingHtml;
+    renderedEventCount = committed.length;
+  }
+
+  /**
+   * @param {string} code
+   * @returns {string[]}
+   */
+  function linesForCurrentCode(code) {
+    if (!session) return linesFromStreamState([], [""], code);
+    const snapshot = session.snapshot();
+    /** @type {string[]} */
+    let previewLines = [pendingHtml];
+    if (snapshot.pos < fedCode.length) {
+      const preview = registry.resume(fedCode, sessionLanguage, snapshot);
+      const result = extendLines(
+        preview.events,
+        openScopes,
+        pendingHtml,
+      );
+      previewLines = result.completedLines.concat(result.pendingHtml);
+    }
+    return linesFromStreamState(completedLines, previewLines, code);
+  }
+
+  return {
+    reset() {
+      session = undefined;
+      sessionLanguage = "";
+      fedCode = "";
+      renderedEventCount = 0;
+      openScopes = [];
+      pendingHtml = "";
+      completedLines = [];
+      lastUsedIncremental = false;
+      hasAppended = false;
+    },
+    lastUsedIncremental() {
+      return lastUsedIncremental;
+    },
+    /**
+     * @param {ScopeEvent[]} events Full events from getEvents() — used only
+     *   for the non-append fallback path (mid-document edits).
+     * @param {string} code
+     * @param {string} languageName
+     * @returns {string[]}
+     */
+    paint(events, code, languageName) {
+      if (session === undefined || languageName !== sessionLanguage) {
+        resetSession(languageName);
+      }
+
+      if (!isPureAppend(fedCode, code)) {
+        lastUsedIncremental = false;
+        const lines = lineHtmlFromEvents(events, code);
+        // Resync the stream session so a later pure append can continue.
+        resetSession(languageName);
+        if (code.length > 0) {
+          session.append(code);
+          fedCode = code;
+          hasAppended = true;
+          consumeCommitted(session.events());
+        }
+        return lines;
+      }
+
+      const hadContent = hasAppended;
+      if (code.length > fedCode.length) {
+        session.append(code.slice(fedCode.length));
+        fedCode = code;
+        hasAppended = true;
+        consumeCommitted(session.events());
+      } else if (code.length === 0 && fedCode.length === 0) {
+        // Empty document paint.
+      }
+
+      lastUsedIncremental = hadContent;
+      return linesForCurrentCode(code);
+    },
+  };
+}

--- a/src/editable-dom-paint.js
+++ b/src/editable-dom-paint.js
@@ -83,8 +83,17 @@ export function createDomLinePainter({ registry }) {
   let lastUsedIncremental = false;
   /** Whether the current session has already accepted at least one append. */
   let hasAppended = false;
+  /**
+   * Mid-document edits mark the stream session dirty instead of eagerly
+   * re-tokenizing. The next pure append pays one full resync, then resumes
+   * O(delta) painting.
+   */
+  let needsResync = false;
 
-  /** @param {string} nextLanguage */
+  /**
+   * @param {string} nextLanguage
+   * @returns {StreamSession}
+   */
   function resetSession(nextLanguage) {
     session = registry.createSession(nextLanguage);
     sessionLanguage = nextLanguage;
@@ -94,6 +103,24 @@ export function createDomLinePainter({ registry }) {
     pendingHtml = "";
     completedLines = [];
     hasAppended = false;
+    needsResync = false;
+    return session;
+  }
+
+  /**
+   * Rebuild the stream session from `base` so a subsequent delta append can
+   * continue incrementally. Preserves `fedCode` across the reset.
+   * @param {string} languageName
+   * @param {string} base
+   */
+  function resyncSession(languageName, base) {
+    session = resetSession(languageName);
+    if (base.length > 0) {
+      session.append(base);
+      hasAppended = true;
+      consumeCommitted(session.events());
+    }
+    fedCode = base;
   }
 
   /**
@@ -125,11 +152,7 @@ export function createDomLinePainter({ registry }) {
     let previewLines = [pendingHtml];
     if (snapshot.pos < fedCode.length) {
       const preview = registry.resume(fedCode, sessionLanguage, snapshot);
-      const result = extendLines(
-        preview.events,
-        openScopes,
-        pendingHtml,
-      );
+      const result = extendLines(preview.events, openScopes, pendingHtml);
       previewLines = result.completedLines.concat(result.pendingHtml);
     }
     return linesFromStreamState(completedLines, previewLines, code);
@@ -146,6 +169,7 @@ export function createDomLinePainter({ registry }) {
       completedLines = [];
       lastUsedIncremental = false;
       hasAppended = false;
+      needsResync = false;
     },
     lastUsedIncremental() {
       return lastUsedIncremental;
@@ -159,21 +183,20 @@ export function createDomLinePainter({ registry }) {
      */
     paint(events, code, languageName) {
       if (session === undefined || languageName !== sessionLanguage) {
-        resetSession(languageName);
+        session = resetSession(languageName);
       }
 
       if (!isPureAppend(fedCode, code)) {
         lastUsedIncremental = false;
         const lines = lineHtmlFromEvents(events, code);
-        // Resync the stream session so a later pure append can continue.
-        resetSession(languageName);
-        if (code.length > 0) {
-          session.append(code);
-          fedCode = code;
-          hasAppended = true;
-          consumeCommitted(session.events());
-        }
+        // Defer the O(n) stream resync until the next pure append.
+        needsResync = true;
+        fedCode = code;
         return lines;
+      }
+
+      if (needsResync) {
+        resyncSession(languageName, fedCode);
       }
 
       const hadContent = hasAppended;

--- a/tests/editable-dom-paint.test.ts
+++ b/tests/editable-dom-paint.test.ts
@@ -50,6 +50,7 @@ describe("createDomLinePainter", () => {
 
     const steps = [
       "function greet(name) {\n",
+      // biome-ignore lint/suspicious/noTemplateCurlyInString: this is JS *source text* fed to the tokenizer, not a template literal to evaluate
       "  const msg = `hi ${name}`;\n",
       "  return msg;\n",
       "}\n",

--- a/tests/editable-dom-paint.test.ts
+++ b/tests/editable-dom-paint.test.ts
@@ -1,0 +1,95 @@
+import {
+  createDomLinePainter,
+  isPureAppend,
+  lineHtmlFromEvents,
+} from "../src/editable-dom-paint.js";
+import { createRegistry, registerAll } from "../src/engine.js";
+import {
+  parseIncremental,
+  reparseIncremental,
+} from "../src/incremental-tokenize.js";
+import * as languages from "../src/languages/index.js";
+
+const registry = createRegistry();
+for (const language of Object.values(languages))
+  registerAll(registry, language);
+
+function eventsFor(code: string) {
+  return registry.tokenize(code, "javascript").events;
+}
+
+describe("isPureAppend", () => {
+  it("accepts growth at the end only", () => {
+    expect(isPureAppend("ab", "abc")).toBe(true);
+    expect(isPureAppend("", "x")).toBe(true);
+    expect(isPureAppend("ab", "ab")).toBe(true);
+  });
+
+  it("rejects mid-document edits and deletes", () => {
+    expect(isPureAppend("abc", "ab")).toBe(false);
+    expect(isPureAppend("abc", "xabc")).toBe(false);
+    expect(isPureAppend("abc", "axc")).toBe(false);
+  });
+});
+
+describe("createDomLinePainter", () => {
+  it("matches the historical renderHtml+splitLines path on a one-shot paint", () => {
+    const code = `function add(a, b) {\n  return a + b;\n}\n`;
+    const painter = createDomLinePainter({ registry });
+    const events = eventsFor(code);
+    // First paint is a pure append from "" → code, still must match historical.
+    expect(painter.paint(events, code, "javascript")).toEqual(
+      lineHtmlFromEvents(events, code),
+    );
+  });
+
+  it("uses the incremental path across pure appends and matches full paint", () => {
+    const painter = createDomLinePainter({ registry });
+    let state = parseIncremental(registry, "javascript", "");
+    let code = "";
+
+    const steps = [
+      "function greet(name) {\n",
+      "  const msg = `hi ${name}`;\n",
+      "  return msg;\n",
+      "}\n",
+      "console.log(greet('ada'));\n",
+    ];
+
+    for (const chunk of steps) {
+      code += chunk;
+      state = reparseIncremental(registry, "javascript", state, code);
+      const lines = painter.paint(state.events, code, "javascript");
+      expect(lines).toEqual(lineHtmlFromEvents(state.events, code));
+    }
+    expect(painter.lastUsedIncremental()).toBe(true);
+  });
+
+  it("falls back to a full rebuild after a mid-document edit", () => {
+    const painter = createDomLinePainter({ registry });
+    let code = "const a = 1;\nconst b = 2;\n";
+    let state = parseIncremental(registry, "javascript", code);
+    painter.paint(state.events, code, "javascript");
+
+    code = "const a = 99;\nconst b = 2;\n";
+    state = reparseIncremental(registry, "javascript", state, code);
+    const lines = painter.paint(state.events, code, "javascript");
+    expect(lines).toEqual(lineHtmlFromEvents(state.events, code));
+    expect(painter.lastUsedIncremental()).toBe(false);
+  });
+
+  it("character-by-character append stays equivalent to full paint", () => {
+    const painter = createDomLinePainter({ registry });
+    const target =
+      "export function sum(xs) {\n  return xs.reduce((a, b) => a + b, 0);\n}\n";
+    let state = parseIncremental(registry, "javascript", "");
+    let code = "";
+    for (let i = 1; i <= target.length; i++) {
+      code = target.slice(0, i);
+      state = reparseIncremental(registry, "javascript", state, code);
+      const lines = painter.paint(state.events, code, "javascript");
+      expect(lines).toEqual(lineHtmlFromEvents(state.events, code));
+    }
+    expect(painter.lastUsedIncremental()).toBe(true);
+  });
+});

--- a/tests/editable-dom-paint.test.ts
+++ b/tests/editable-dom-paint.test.ts
@@ -34,7 +34,7 @@ describe("isPureAppend", () => {
 
 describe("createDomLinePainter", () => {
   it("matches the historical renderHtml+splitLines path on a one-shot paint", () => {
-    const code = `function add(a, b) {\n  return a + b;\n}\n`;
+    const code = "function add(a, b) {\n  return a + b;\n}\n";
     const painter = createDomLinePainter({ registry });
     const events = eventsFor(code);
     // First paint is a pure append from "" → code, still must match historical.
@@ -91,5 +91,76 @@ describe("createDomLinePainter", () => {
       expect(lines).toEqual(lineHtmlFromEvents(state.events, code));
     }
     expect(painter.lastUsedIncremental()).toBe(true);
+  });
+
+  it("resumes incremental paint after append → mid-edit → append", () => {
+    const painter = createDomLinePainter({ registry });
+    let code = "const a = 1;\n";
+    let state = parseIncremental(registry, "javascript", code);
+    expect(painter.paint(state.events, code, "javascript")).toEqual(
+      lineHtmlFromEvents(state.events, code),
+    );
+
+    code += "const b = 2;\n";
+    state = reparseIncremental(registry, "javascript", state, code);
+    expect(painter.paint(state.events, code, "javascript")).toEqual(
+      lineHtmlFromEvents(state.events, code),
+    );
+    expect(painter.lastUsedIncremental()).toBe(true);
+
+    code = "const a = 99;\nconst b = 2;\n";
+    state = reparseIncremental(registry, "javascript", state, code);
+    expect(painter.paint(state.events, code, "javascript")).toEqual(
+      lineHtmlFromEvents(state.events, code),
+    );
+    expect(painter.lastUsedIncremental()).toBe(false);
+
+    code += "const c = 3;\n";
+    state = reparseIncremental(registry, "javascript", state, code);
+    expect(painter.paint(state.events, code, "javascript")).toEqual(
+      lineHtmlFromEvents(state.events, code),
+    );
+
+    code += "console.log(a + b + c);\n";
+    state = reparseIncremental(registry, "javascript", state, code);
+    expect(painter.paint(state.events, code, "javascript")).toEqual(
+      lineHtmlFromEvents(state.events, code),
+    );
+    expect(painter.lastUsedIncremental()).toBe(true);
+  });
+
+  it("does not call session.append on every mid-document edit", () => {
+    let appendCount = 0;
+    const createSession = registry.createSession.bind(registry);
+    registry.createSession = ((...args: Parameters<typeof createSession>) => {
+      const session = createSession(...args);
+      const append = session.append.bind(session);
+      session.append = (chunk: string) => {
+        appendCount++;
+        return append(chunk);
+      };
+      return session;
+    }) as typeof registry.createSession;
+
+    try {
+      const painter = createDomLinePainter({ registry });
+      let code = "const a = 1;\nconst b = 2;\nconst c = 3;\n";
+      painter.paint(eventsFor(code), code, "javascript");
+      const appendsAfterInit = appendCount;
+      expect(appendsAfterInit).toBeGreaterThan(0);
+
+      // Use one-shot tokenize (not reparseIncremental) so the spy only
+      // observes painter-driven createSession/append calls.
+      for (let i = 0; i < 20; i++) {
+        code = `const a = ${i};\nconst b = 2;\nconst c = 3;\n`;
+        const events = eventsFor(code);
+        const lines = painter.paint(events, code, "javascript");
+        expect(lines).toEqual(lineHtmlFromEvents(events, code));
+      }
+      // Mid-edits must not eagerly resync (createSession + append per keystroke).
+      expect(appendCount).toBe(appendsAfterInit);
+    } finally {
+      registry.createSession = createSession;
+    }
   });
 });


### PR DESCRIPTION
## Summary

- The default `"dom"` engine rebuilt highlighted HTML for the whole document on every keystroke (`renderHtml` + `splitLines`), so typing a file of size n was O(n²) HTML work.
- Tokenization was already incremental; only the HTML paint path was not.
- Pure appends (typing at the end) now feed a stream session and run `extendLines` only on the new suffix. Mid-document edits still use the full historical path and resync the session for later appends.

## Test plan

- [x] `bun test tests/editable-dom-paint.test.ts` (append chains, mid-doc fallback, char-by-char equivalence to historical paint)
- [x] `bun test tests/highlight-editable-ssr.test.ts`