### PR TITLE
chore(lint): allow HighlightStream self-assign for Svelte reactivity

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -146,6 +146,16 @@
       }
     },
     {
+      "includes": ["src/HighlightStream.svelte"],
+      "linter": {
+        "rules": {
+          "correctness": {
+            "noSelfAssign": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["src/**/*.d.ts"],
       "linter": {
         "rules": {


### PR DESCRIPTION
#482's push + reassignment is intentional so Svelte 4 invalidates
`{#each}` without an O(c) array copy. Biome treats that write as a
no-op, so disable `noSelfAssign` for this file instead of an inline
ignore.