### PR TITLE
test: raise sealed-chunk perf ratio threshold to reduce flakiness

### DIFF
--- a/tests/perf-regression-guards.test.ts
+++ b/tests/perf-regression-guards.test.ts
@@ -137,8 +137,10 @@ describe("HighlightStream sealed-chunk append", () => {
 
     // Measured at this scale: a true O(c) implementation costs ~4-6x for
     // 8x more seals; the O(c^2) spread-copy pattern this guards against
-    // costs ~30-40x. 15 sits clear of both with margin on either side.
-    expect(large / Math.max(small, 0.01)).toBeLessThan(15);
+    // costs ~30-40x. 22 sits clear of both, with more margin against CI
+    // timing noise than 15 (which flaked under load) while still well
+    // short of the O(c^2) range.
+    expect(large / Math.max(small, 0.01)).toBeLessThan(22);
   }, 10_000);
 });
 


### PR DESCRIPTION
The 8x-seals timing ratio guard in perf-regression-guards.test.ts
flaked on master, passing on a prior run and failing on the next with
no code changes. Bumps the threshold from 15x to 22x, which stays well
clear of the ~30-40x ratio an actual O(c^2) regression produces while
giving more headroom against CI timing noise.