### PR TITLE
feat(typewriter): add easing curve module

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,7 +1333,22 @@ Set `speed` (milliseconds per character) and pause with `play`. Turn `play` back
 </Highlight>
 ```
 
+Control the pacing curve with `easing`: a function mapping elapsed-time fraction (`0`-`1`) to revealed-fraction (`0`-`1`). It defaults to `linear`; import a named curve or pass your own. Total typing duration is always `speed` × character count, no matter the curve -- only the pacing within that duration changes.
+
+```svelte
+<script>
+  import Highlight, { Typewriter, easeOutCubic } from "svelte-highlight";
+</script>
+
+<Highlight language={typescript} {code} let:highlighted>
+  <Typewriter {highlighted} easing={easeOutCubic} />
+</Highlight>
+```
+
+Named curves: `linear` (default), `easeInQuad`/`easeOutQuad`/`easeInOutQuad`, `easeInCubic`/`easeOutCubic`/`easeInOutCubic`, `easeInSine`/`easeOutSine`/`easeInOutSine`.
+
 `Typewriter` doesn't gate itself on `prefers-reduced-motion` -- if you want to honor it, check `matchMedia("(prefers-reduced-motion: reduce)")` yourself and skip rendering `Typewriter` (or set a very low `speed`). Customize the caret with `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink`.
+
 
 Each tick reveals one already-rendered unit rather than re-rendering the block, so animating stays smooth up to tens of thousands of characters; past that it falls back to the coarser whole-block reveal.
 
@@ -1815,11 +1830,12 @@ See [Large documents](#large-documents) above.
 
 #### Props
 
-| Name        | Type      | Default value |
-| :---------- | :-------- | :------------ |
-| highlighted | `string`  | `""`          |
-| speed       | `number`  | `30`          |
-| play        | `boolean` | `true`        |
+| Name        | Type                     | Default value |
+| :---------- | :----------------------- | :------------ |
+| highlighted | `string`                 | `""`          |
+| speed       | `number`                 | `30`          |
+| play        | `boolean`                | `true`        |
+| easing      | `(t: number) => number`  | `linear`      |
 
 `$$restProps` are forwarded to the top-level `pre` element.
 

--- a/src/Typewriter.svelte
+++ b/src/Typewriter.svelte
@@ -18,10 +18,21 @@
   export let play = true;
 
   import { createEventDispatcher, onMount } from "svelte";
+  import { linear } from "./typewriter-easing.js";
   import {
     createTypewriterSplitter,
     tokenizeTypewriter as tokenize,
   } from "./typewriter-units.js";
+
+  /**
+   * Reveal-progress curve: maps elapsed-time fraction (0-1) to
+   * revealed-fraction (0-1). Total typing duration is always
+   * `speed * <visible character count>` regardless of curve -- only the
+   * pacing within that duration changes. Import a named curve
+   * (`easeOutQuad`, `easeInOutCubic`, ...) or pass your own function.
+   * @type {(t: number) => number}
+   */
+  export let easing = linear;
 
   const dispatch = createEventDispatcher();
 
@@ -40,8 +51,14 @@
   /** Number of visible characters currently revealed. @type {number} */
   let revealed = 0;
 
-  /** @type {ReturnType<typeof setInterval> | undefined} */
-  let timerId;
+  /** @type {number | undefined} */
+  let rafId;
+
+  /** Active ms elapsed for the current run (excludes paused time). @type {number} */
+  let elapsedMs = 0;
+
+  /** `performance.now()` at the last tick, or `undefined` right after a (re)start. @type {number | undefined} */
+  let frameTime;
 
   /** @type {string | undefined} */
   let prevHighlighted;
@@ -107,9 +124,9 @@
     }
   }
 
-  function clearTimer() {
-    clearInterval(timerId);
-    timerId = undefined;
+  function stopLoop() {
+    if (rafId !== undefined) cancelAnimationFrame(rafId);
+    rafId = undefined;
   }
 
   function fireDone() {
@@ -119,24 +136,50 @@
     }
   }
 
-  function advance() {
-    if (revealed < total) revealed += 1;
+  /**
+   * One animation frame: advance `elapsedMs` by the real time since the last
+   * frame (zero on the first frame after a start/resume, so pausing never
+   * counts the paused gap), then derive `revealed` from `easing` applied to
+   * the elapsed fraction of the total duration. Total duration is always
+   * `speed * total`, so only the pacing within it -- not its length --
+   * depends on `easing`. Clamped to `[0, total]` since a custom `easing` may
+   * overshoot outside `[0, 1]` (e.g. a "back"/"elastic" curve).
+   * @param {number} now
+   */
+  function tick(now) {
+    if (frameTime !== undefined) elapsedMs += now - frameTime;
+    frameTime = now;
+
+    const duration = Math.max(0, speed) * total;
+    const t = duration > 0 ? Math.min(1, elapsedMs / duration) : 1;
+    const target = Math.round(easing(t) * total);
+    const next = Math.min(total, Math.max(0, target));
+    if (next > revealed) revealed = next;
+
     if (useUnitReveal) syncUnitDom();
+
     if (revealed >= total) {
-      clearTimer();
+      stopLoop();
       fireDone();
+      return;
     }
+    rafId = requestAnimationFrame(tick);
   }
 
-  /** Start/stop/retime the typing interval. */
+  function startLoop() {
+    frameTime = undefined;
+    rafId = requestAnimationFrame(tick);
+  }
+
+  /** Start/stop/retime the typing loop. */
   function sync() {
-    clearTimer();
+    stopLoop();
     if (!mounted) return;
 
     if (useUnitReveal) syncUnitDom();
 
     if (play && revealed < total) {
-      timerId = setInterval(advance, Math.max(0, speed));
+      startLoop();
     } else if (revealed >= total) {
       fireDone();
     }
@@ -155,14 +198,15 @@
   $: if (highlighted !== prevHighlighted) {
     prevHighlighted = highlighted;
     doneFired = false;
+    elapsedMs = 0;
     revealed = 0;
     void useUnitReveal;
     sync();
   }
 
-  // Re-sync on play/speed/mount. Skip `total` (handled above).
+  // Re-sync on play/speed/easing/mount. Skip `total` (handled above).
   $: {
-    void [play, speed, mounted, useUnitReveal];
+    void [play, speed, easing, mounted, useUnitReveal];
     sync();
   }
 
@@ -178,7 +222,7 @@
     mounted = true;
 
     return () => {
-      clearTimer();
+      stopLoop();
     };
   });
 </script>

--- a/src/Typewriter.svelte.d.ts
+++ b/src/Typewriter.svelte.d.ts
@@ -21,6 +21,15 @@ export type TypewriterProps = HTMLAttributes<HTMLPreElement> & {
   play?: boolean;
 
   /**
+   * Reveal-progress curve: maps elapsed-time fraction (0-1) to
+   * revealed-fraction (0-1). Total typing duration is always
+   * `speed * <visible character count>` regardless of curve. Import a named
+   * curve (`easeOutQuad`, `easeInOutCubic`, ...) or pass your own function.
+   * @default linear
+   */
+  easing?: (t: number) => number;
+
+  /**
    * Width of the blinking caret.
    * @default "0.6em"
    */

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -25,3 +25,15 @@ export {
 } from "./scoped";
 export { default as Typewriter } from "./Typewriter.svelte";
 export type { ThemePalette } from "./theme";
+export {
+  easeInCubic,
+  easeInOutCubic,
+  easeInOutQuad,
+  easeInOutSine,
+  easeInQuad,
+  easeInSine,
+  easeOutCubic,
+  easeOutQuad,
+  easeOutSine,
+  linear,
+} from "./typewriter-easing";

--- a/src/index.js
+++ b/src/index.js
@@ -21,3 +21,15 @@ export {
   scopeStyle,
 } from "./scoped.js";
 export { default as Typewriter } from "./Typewriter.svelte";
+export {
+  easeInCubic,
+  easeInOutCubic,
+  easeInOutQuad,
+  easeInOutSine,
+  easeInQuad,
+  easeInSine,
+  easeOutCubic,
+  easeOutQuad,
+  easeOutSine,
+  linear,
+} from "./typewriter-easing.js";

--- a/src/typewriter-easing.d.ts
+++ b/src/typewriter-easing.d.ts
@@ -1,0 +1,14 @@
+/** Constant rate; `Typewriter`'s default. */
+export declare function linear(t: number): number;
+
+export declare function easeInQuad(t: number): number;
+export declare function easeOutQuad(t: number): number;
+export declare function easeInOutQuad(t: number): number;
+
+export declare function easeInCubic(t: number): number;
+export declare function easeOutCubic(t: number): number;
+export declare function easeInOutCubic(t: number): number;
+
+export declare function easeInSine(t: number): number;
+export declare function easeOutSine(t: number): number;
+export declare function easeInOutSine(t: number): number;

--- a/src/typewriter-easing.js
+++ b/src/typewriter-easing.js
@@ -1,0 +1,57 @@
+/**
+ * Reveal-progress curves for `Typewriter`'s `easing` prop: each maps an
+ * elapsed-time fraction (0 to 1) to a revealed-fraction (0 to 1). Total
+ * typing duration is always `speed * <visible character count>` regardless
+ * of which curve is used -- only the pacing within that duration changes.
+ * Formulas from easings.net.
+ */
+
+/** @param {number} t @returns {number} */
+export function linear(t) {
+  return t;
+}
+
+/** @param {number} t @returns {number} */
+export function easeInQuad(t) {
+  return t * t;
+}
+
+/** @param {number} t @returns {number} */
+export function easeOutQuad(t) {
+  return 1 - (1 - t) * (1 - t);
+}
+
+/** @param {number} t @returns {number} */
+export function easeInOutQuad(t) {
+  return t < 0.5 ? 2 * t * t : 1 - (-2 * t + 2) ** 2 / 2;
+}
+
+/** @param {number} t @returns {number} */
+export function easeInCubic(t) {
+  return t * t * t;
+}
+
+/** @param {number} t @returns {number} */
+export function easeOutCubic(t) {
+  return 1 - (1 - t) ** 3;
+}
+
+/** @param {number} t @returns {number} */
+export function easeInOutCubic(t) {
+  return t < 0.5 ? 4 * t * t * t : 1 - (-2 * t + 2) ** 3 / 2;
+}
+
+/** @param {number} t @returns {number} */
+export function easeInSine(t) {
+  return 1 - Math.cos((t * Math.PI) / 2);
+}
+
+/** @param {number} t @returns {number} */
+export function easeOutSine(t) {
+  return Math.sin((t * Math.PI) / 2);
+}
+
+/** @param {number} t @returns {number} */
+export function easeInOutSine(t) {
+  return -(Math.cos(Math.PI * t) - 1) / 2;
+}

--- a/www/components/Typewriter/Controls.svelte
+++ b/www/components/Typewriter/Controls.svelte
@@ -1,7 +1,26 @@
 <script>
   import { THEME_MODULE_NAME } from "@www/constants";
-  import { Button, Slider, Toggle } from "carbon-components-svelte";
-  import Highlight, { CodeWindow, Typewriter } from "svelte-highlight";
+  import {
+    Button,
+    Select,
+    SelectItem,
+    Slider,
+    Toggle,
+  } from "carbon-components-svelte";
+  import Highlight, {
+    CodeWindow,
+    easeInCubic,
+    easeInOutCubic,
+    easeInOutQuad,
+    easeInOutSine,
+    easeInQuad,
+    easeInSine,
+    easeOutCubic,
+    easeOutQuad,
+    easeOutSine,
+    linear,
+    Typewriter,
+  } from "svelte-highlight";
   import typescript from "svelte-highlight/languages/typescript";
 
   const code = `async function load(url) {
@@ -9,10 +28,26 @@
   return res.json();
 }`;
 
+  const EASINGS = {
+    linear,
+    easeInQuad,
+    easeOutQuad,
+    easeInOutQuad,
+    easeInCubic,
+    easeOutCubic,
+    easeInOutCubic,
+    easeInSine,
+    easeOutSine,
+    easeInOutSine,
+  };
+
   let speed = 40;
   let play = true;
   let done = false;
   let runId = 0;
+  let easingName = "linear";
+
+  $: easing = EASINGS[easingName];
 
   function replay() {
     done = false;
@@ -28,6 +63,7 @@
         {highlighted}
         {speed}
         {play}
+        {easing}
         class={THEME_MODULE_NAME}
         --caret-color="#2996cf"
         --caret-width="2px"
@@ -47,6 +83,11 @@
     step={5}
     labelText="Speed (ms / character)"
   />
+  <Select labelText="Easing" bind:selected={easingName}>
+    {#each Object.keys(EASINGS) as name}
+      <SelectItem value={name} />
+    {/each}
+  </Select>
   <Toggle
     bind:toggled={play}
     labelText="Playback"

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -529,6 +529,18 @@ export default {
       inside a
       <code class="code">CodeWindow</code>.
     </p>
+    <p class="mb-5">
+      Control the pacing curve with <code class="code">easing</code>: a function
+      mapping elapsed-time fraction (0-1) to revealed-fraction (0-1). It
+      defaults to <code class="code">linear</code>; import a named curve (<code
+        class="code"
+        >easeOutQuad</code
+      >,
+      <code class="code">easeInOutCubic</code>, ...) or pass your own. Total
+      typing duration is always <code class="code">speed</code>
+      &times; character count no matter the curve—only the pacing within it
+      changes. Pick a curve in the demo below to try it live.
+    </p>
     <InlineNotification
       lowContrast
       hideCloseButton


### PR DESCRIPTION
Typewriter's `easing` prop now drives its reveal pacing (defaulting to
`linear`), with README docs and a live easing picker added to the demo
site.