### PR TITLE
fix(typewriter): don't auto-skip animation on prefers-reduced-motion

### DIFF
--- a/README.md
+++ b/README.md
@@ -1333,7 +1333,7 @@ Set `speed` (milliseconds per character) and pause with `play`. Turn `play` back
 </Highlight>
 ```
 
-With `prefers-reduced-motion`, the full block shows immediately and `on:done` runs right away. Customize the caret with `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink`.
+`Typewriter` doesn't gate itself on `prefers-reduced-motion` -- if you want to honor it, check `matchMedia("(prefers-reduced-motion: reduce)")` yourself and skip rendering `Typewriter` (or set a very low `speed`). Customize the caret with `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink`.
 
 Each tick reveals one already-rendered unit rather than re-rendering the block, so animating stays smooth up to tens of thousands of characters; past that it falls back to the coarser whole-block reveal.
 
@@ -1825,7 +1825,7 @@ See [Large documents](#large-documents) above.
 
 #### Dispatched Events
 
-- **on:done**: fires when typing finishes, or immediately when reduced motion is on
+- **on:done**: fires when typing finishes
 
 ```svelte
 <Highlight language={typescript} {code} let:highlighted>

--- a/src/HighlightStream.svelte
+++ b/src/HighlightStream.svelte
@@ -478,12 +478,6 @@
     animation: highlight-stream-blink var(--caret-blink, 1s) step-end infinite;
   }
 
-  @media (prefers-reduced-motion: reduce) {
-    .highlight-stream-caret {
-      animation: none;
-    }
-  }
-
   @keyframes highlight-stream-blink {
     50% {
       opacity: 0;

--- a/src/Typewriter.svelte
+++ b/src/Typewriter.svelte
@@ -35,9 +35,6 @@
   let mounted = false;
 
   /** @type {boolean} */
-  let reducedMotion = false;
-
-  /** @type {boolean} */
   let doneFired = false;
 
   /** Number of visible characters currently revealed. @type {number} */
@@ -136,13 +133,6 @@
     clearTimer();
     if (!mounted) return;
 
-    if (reducedMotion) {
-      // Reduced motion: show all at once.
-      if (revealed !== total) revealed = total;
-      fireDone();
-      return;
-    }
-
     if (useUnitReveal) syncUnitDom();
 
     if (play && revealed < total) {
@@ -159,20 +149,20 @@
   $: splitter = createTypewriterSplitter(units, highlighted);
   $: total = units.reduce((sum, unit) => sum + unit.visible, 0);
   $: bigInput = total > UNIT_THRESHOLD;
-  $: useUnitReveal = mounted && !reducedMotion && !bigInput;
+  $: useUnitReveal = mounted && !bigInput;
 
   // Restart when `highlighted` changes.
   $: if (highlighted !== prevHighlighted) {
     prevHighlighted = highlighted;
     doneFired = false;
-    revealed = reducedMotion ? total : 0;
+    revealed = 0;
     void useUnitReveal;
     sync();
   }
 
-  // Re-sync on play/speed/mount/motion. Skip `total` (handled above).
+  // Re-sync on play/speed/mount. Skip `total` (handled above).
   $: {
-    void [play, speed, mounted, reducedMotion, useUnitReveal];
+    void [play, speed, mounted, useUnitReveal];
     sync();
   }
 
@@ -182,20 +172,12 @@
     : mounted
       ? splitter.splitAt(revealed)
       : { head: highlighted, tail: "" };
-  $: showCaret = mounted && !reducedMotion && revealed < total;
+  $: showCaret = mounted && revealed < total;
 
   onMount(() => {
     mounted = true;
 
-    const query = window.matchMedia("(prefers-reduced-motion: reduce)");
-    reducedMotion = query.matches;
-    const onChange = (event) => {
-      reducedMotion = event.matches;
-    };
-    query.addEventListener?.("change", onChange);
-
     return () => {
-      query.removeEventListener?.("change", onChange);
       clearTimer();
     };
   });
@@ -245,13 +227,6 @@
     vertical-align: text-bottom;
     background: var(--caret-color, currentColor);
     animation: typewriter-blink var(--caret-blink, 1s) step-end infinite;
-  }
-
-  @media (prefers-reduced-motion: reduce) {
-    .typewriter-caret,
-    :global(.typewriter-unit.typewriter-caret)::before {
-      animation: none;
-    }
   }
 
   @keyframes typewriter-blink {

--- a/src/Typewriter.svelte.d.ts
+++ b/src/Typewriter.svelte.d.ts
@@ -53,7 +53,7 @@ export type TypewriterProps = HTMLAttributes<HTMLPreElement> & {
 
 export type TypewriterEvents = {
   /**
-   * Fires when typing finishes (or immediately with reduced motion).
+   * Fires when typing finishes.
    */
   done: CustomEvent<null>;
 };

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1644,19 +1644,21 @@ test("Typewriter - animates then settles to the full highlighted content", async
   );
 });
 
-test("Typewriter - reduced motion renders instantly", async ({
+test("Typewriter - ignores prefers-reduced-motion, animation is left to the consumer", async ({
   mount,
   page,
 }) => {
   await page.emulateMedia({ reducedMotion: "reduce" });
 
-  // At speed 1000, typing would take ~44s without reduced motion. With reduced
-  // motion the full content (and `done`) must appear immediately.
+  // Typewriter doesn't gate on prefers-reduced-motion itself, so at a slow
+  // speed the content should still be mid-reveal (not instantly complete).
   await mount(Typewriter, { props: { speed: 1000 } });
 
   const tw = page.getByTestId("tw");
-  await expect(page.getByTestId("done")).toHaveText("1");
-  await expect(tw.locator(".hljs-title.function_")).toHaveText("add");
+  await expect(page.getByTestId("done")).toHaveText("0");
+  await expect(
+    tw.locator(".typewriter-unit.typewriter-hidden").first(),
+  ).toBeAttached();
 });
 
 test("Typewriter - revealed DOM nodes stay connected across ticks (no per-tick rebuild)", async ({

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -534,7 +534,7 @@ export default {
       hideCloseButton
       kind="info"
       title="Reduced motion"
-      subtitle="With prefers-reduced-motion, the full block shows immediately and on:done runs right away."
+      subtitle="Typewriter doesn't gate itself on prefers-reduced-motion; check it yourself and skip rendering Typewriter if you want to honor it."
     />
   </Column>
   <Column xlg={10} lg={10} md={12}> <TypewriterControls /> </Column>


### PR DESCRIPTION
Skipping straight to the end result under prefers-reduced-motion
defeats the point of a reveal animation and a caret blink, and both
already had a consumer-facing knob (speed/play, --caret-blink) to
control them. Leaves respecting the media query up to the consumer
instead.