### PR TITLE
chore(deps): drop magic-string, hand-roll the preprocessor's sourcemap

### DIFF
--- a/bench/index.ts
+++ b/bench/index.ts
@@ -21,6 +21,7 @@ import "./text-diff.bench.ts";
 import "./render.bench.ts";
 import "./typewriter.bench.ts";
 import "./stream-sealed-chunks.bench.ts";
+import "./preprocessor.bench.ts";
 
 const filterArg = process.argv[2];
 

--- a/bench/preprocessor.bench.ts
+++ b/bench/preprocessor.bench.ts
@@ -1,0 +1,47 @@
+/**
+ * highlightStatic()'s markup() step, end to end: parsing a .svelte file,
+ * resolving each matched language module, running highlight.js, and
+ * splicing the static HTML back in with a sourcemap. Scaling by match
+ * count isolates the splice/sourcemap cost (the part this preprocessor
+ * hand-rolls instead of using magic-string) from the fixed parse/resolve
+ * overhead paid once per file regardless of match count.
+ */
+import { bench, do_not_optimize, group, run, summary } from "mitata";
+import { highlightStatic } from "../src/static.js";
+
+const filename = "bench/fixture.svelte";
+
+function fixture(matchCount: number) {
+  const header = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+`;
+  const blocks: string[] = [];
+  for (let i = 0; i < matchCount; i += 1) {
+    blocks.push(
+      `<p>section ${i}</p>`,
+      `<Highlight language={javascript} code="function f${i}(a, b) {\nreturn a + b + ${i};\n}" />`,
+    );
+  }
+  return `${header + blocks.join("\n")}\n`;
+}
+
+const MATCH_COUNTS = [1, 10, 50];
+
+group("highlightStatic().markup()", () => {
+  summary(() => {
+    for (const matchCount of MATCH_COUNTS) {
+      const source = fixture(matchCount);
+      bench(`${matchCount} matches`, async () => {
+        const group = highlightStatic();
+        do_not_optimize(await group.markup?.({ content: source, filename }));
+      });
+    }
+  });
+});
+
+// Run this suite alone with `bun bench/preprocessor.bench.ts` for a fast
+// feedback loop; bench/index.ts imports every suite for a full-baseline run.
+if (import.meta.main) await run();

--- a/bun.lock
+++ b/bun.lock
@@ -4,9 +4,6 @@
   "workspaces": {
     "": {
       "name": "svelte-highlight",
-      "dependencies": {
-        "magic-string": "^0.30.17",
-      },
       "devDependencies": {
         "@astrojs/svelte": "^8.1.2",
         "@biomejs/biome": "2.5.10",

--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "astro": "astro",
     "playwright": "playwright"
   },
-  "dependencies": {
-    "magic-string": "^0.30.17"
-  },
   "devDependencies": {
     "@astrojs/svelte": "^8.1.2",
     "@biomejs/biome": "2.5.10",

--- a/src/preprocessor.js
+++ b/src/preprocessor.js
@@ -1,6 +1,5 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
-import MagicString from "magic-string";
 import { parse } from "svelte/compiler";
 import { ensureRegistered, registry } from "./registry.js";
 
@@ -252,6 +251,151 @@ function renderStatic(language, code) {
   );
 }
 
+const BASE64_VLQ_CHARS =
+  "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
+
+/** @param {number} value */
+function encodeVlq(value) {
+  let vlq = value < 0 ? (-value << 1) + 1 : value << 1;
+  let result = "";
+  do {
+    let digit = vlq & 31;
+    vlq >>>= 5;
+    if (vlq > 0) digit |= 32;
+    result += BASE64_VLQ_CHARS[digit];
+  } while (vlq > 0);
+  return result;
+}
+
+/** @param {string} content */
+function computeLineStarts(content) {
+  const starts = [0];
+  for (let i = 0; i < content.length; i += 1) {
+    if (content[i] === "\n") starts.push(i + 1);
+  }
+  return starts;
+}
+
+/**
+ * @param {number[]} lineStarts
+ * @param {number} index
+ */
+function positionAt(lineStarts, index) {
+  let lo = 0;
+  let hi = lineStarts.length - 1;
+  while (lo < hi) {
+    const mid = (lo + hi + 1) >> 1;
+    if ((lineStarts[mid] ?? 0) <= index) lo = mid;
+    else hi = mid - 1;
+  }
+  return { line: lo, column: index - (lineStarts[lo] ?? 0) };
+}
+
+/**
+ * Splices non-overlapping replacements into `content` and produces a matching
+ * (source-map v3) sourcemap. Every edit here replaces a whole element with a
+ * self-contained HTML string, so there's nothing finer-grained to map inside
+ * a replacement - one segment per edit boundary is as accurate as mapping
+ * every character, and far cheaper to produce.
+ *
+ * @param {string} content
+ * @param {{ start: number; end: number; replacement: string }[]} edits sorted by `start`, non-overlapping
+ */
+function applyEdits(content, edits) {
+  const lineStarts = computeLineStarts(content);
+  /** @type {string[]} */
+  const out = [];
+  /** @type {{ genCol: number; line: number; col: number }[][]} */
+  const segmentsByLine = [[]];
+
+  let genLine = 0;
+  let genCol = 0;
+
+  /**
+   * @param {number} line
+   * @param {number} col
+   */
+  function mark(line, col) {
+    segmentsByLine[genLine]?.push({ genCol, line, col });
+  }
+
+  /**
+   * Appends `text` to the output, advancing genLine/genCol across any
+   * newlines it contains. When `origLine` is given (unedited text only -
+   * a replacement's interior lines have no original counterpart), marks
+   * the start of each new line at column 0 against the next original line.
+   *
+   * @param {string} text
+   * @param {number} [origLine]
+   */
+  function advance(text, origLine) {
+    let from = 0;
+    let line = origLine ?? 0;
+    for (let i = 0; i < text.length; i += 1) {
+      if (text[i] !== "\n") continue;
+      out.push(text.slice(from, i + 1));
+      from = i + 1;
+      genLine += 1;
+      genCol = 0;
+      segmentsByLine.push([]);
+      if (origLine !== undefined) {
+        line += 1;
+        mark(line, 0);
+      }
+    }
+    out.push(text.slice(from));
+    genCol += text.length - from;
+  }
+
+  /**
+   * @param {number} start
+   * @param {number} end
+   */
+  function copyUnedited(start, end) {
+    if (start === end) return;
+    const pos = positionAt(lineStarts, start);
+    mark(pos.line, pos.column);
+    advance(content.slice(start, end), pos.line);
+  }
+
+  let cursor = 0;
+  for (const edit of edits) {
+    copyUnedited(cursor, edit.start);
+
+    const pos = positionAt(lineStarts, edit.start);
+    mark(pos.line, pos.column);
+    advance(edit.replacement);
+
+    cursor = edit.end;
+  }
+  copyUnedited(cursor, content.length);
+
+  let mappings = "";
+  let prevLine = 0;
+  let prevCol = 0;
+  for (const [lineIndex, segments] of segmentsByLine.entries()) {
+    if (lineIndex > 0) mappings += ";";
+    let prevGenCol = 0;
+    for (let i = 0; i < segments.length; i += 1) {
+      const segment = segments[i];
+      if (!segment) continue;
+      mappings += i === 0 ? "" : ",";
+      mappings += encodeVlq(segment.genCol - prevGenCol);
+      mappings += encodeVlq(0); // single source, index never changes
+      mappings += encodeVlq(segment.line - prevLine);
+      mappings += encodeVlq(segment.col - prevCol);
+      prevGenCol = segment.genCol;
+      prevLine = segment.line;
+      prevCol = segment.col;
+    }
+  }
+
+  return {
+    code: out.join(""),
+    map: { version: 3, sources: [""], names: [], mappings },
+  };
+}
+
 /**
  * @typedef {{
  *   onWarn?: (message: string, details: { filename?: string | undefined; line: number; cause: unknown }) => void;
@@ -348,27 +492,34 @@ export function highlightStatic(options = {}) {
         }),
       );
 
-      const ms = new MagicString(content);
-      let changed = false;
+      /** @type {{ start: number; end: number; replacement: string }[]} */
+      const edits = [];
 
       for (const [index, match] of matches.entries()) {
         const html = htmlByMatch[index];
         if (!html) continue;
 
-        try {
-          ms.overwrite(match.element.start, match.element.end, html);
-          changed = true;
-        } catch (cause) {
+        const { start, end } = match.element;
+        const previous = edits.at(-1);
+
+        // Matched elements can't nest (they require an empty slot) and
+        // collectElements visits them in source order, so this should
+        // never actually trigger - kept as a defensive fallback so one
+        // malformed range can't take down the whole preprocessor pass.
+        if (start >= end || (previous && start < previous.end)) {
           warn("failed to apply the static replacement", {
             filename,
-            line: locate(content, match.element.start).line,
-            cause,
+            line: locate(content, start).line,
+            cause: new Error("invalid or overlapping replacement range"),
           });
+          continue;
         }
+
+        edits.push({ start, end, replacement: html });
       }
 
-      if (!changed) return;
-      return { code: ms.toString(), map: ms.generateMap({ hires: true }) };
+      if (edits.length === 0) return;
+      return applyEdits(content, edits);
     },
   };
 }


### PR DESCRIPTION
Bumping magic-string past 0.30.x diverged from the range svelte,
astro, and vite-plugin-svelte pin, so it stopped hoisting and
duplicated across node_modules for no real benefit. The preprocessor
only ever does non-overlapping whole-element replacements, small
enough to splice and sourcemap by hand instead of carrying the
dependency at all.

Sourcemap and multi-match regression coverage landed separately in
#503 (already merged), guarding both the old and new implementation.