### PR TITLE
test: add sourcemap regression coverage for highlightStatic

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -10,6 +10,7 @@
       "devDependencies": {
         "@astrojs/svelte": "^8.1.2",
         "@biomejs/biome": "2.5.10",
+        "@jridgewell/trace-mapping": "^0.3.31",
         "@playwright/experimental-ct-svelte": "1.58.2",
         "@playwright/test": "1.61.1",
         "@sveltejs/vite-plugin-svelte": "^5.1.1",
@@ -210,7 +211,7 @@
 
     "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.5.5", "", {}, "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og=="],
 
-    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
 
     "@oslojs/encoding": ["@oslojs/encoding@1.1.0", "", {}, "sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ=="],
 
@@ -953,6 +954,10 @@
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
     "@astrojs/svelte/@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@6.2.4", "", { "dependencies": { "@sveltejs/vite-plugin-svelte-inspector": "^5.0.0", "deepmerge": "^4.3.1", "magic-string": "^0.30.21", "obug": "^2.1.0", "vitefu": "^1.1.1" }, "peerDependencies": { "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-ou/d51QSdTyN26D7h6dSpusAKaZkAiGM55/AKYi+9AGZw7q85hElbjK3kEyzXHhLSnRISHOYzVge6x0jRZ7DXA=="],
+
+    "@jridgewell/gen-mapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
+
+    "@jridgewell/remapping/@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.25", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-vNk6aEwybGtawWmy/PzwnGDOjCkLWSD2wqvjGGAgOAwCGWySYXfYoxt00IJkTF+8Lb57DwOb3Aa0o9CApepiYQ=="],
 
     "@playwright/experimental-ct-core/playwright": ["playwright@1.58.2", "", { "dependencies": { "playwright-core": "1.58.2" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-vA30H8Nvkq/cPBnNw4Q8TWz1EJyqgpuinBcHET0YVJVFldr8JDNiU9LaWAE1KqSkRYazuaBhTpB5ZzShOezQ6A=="],
 

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
   "devDependencies": {
     "@astrojs/svelte": "^8.1.2",
     "@biomejs/biome": "2.5.10",
+    "@jridgewell/trace-mapping": "^0.3.31",
     "@playwright/experimental-ct-svelte": "1.58.2",
     "@playwright/test": "1.61.1",
     "@sveltejs/vite-plugin-svelte": "^5.1.1",

--- a/tests/static-preprocessor-sourcemap.test.ts
+++ b/tests/static-preprocessor-sourcemap.test.ts
@@ -1,4 +1,4 @@
-import { TraceMap, originalPositionFor } from "@jridgewell/trace-mapping";
+import { originalPositionFor, TraceMap } from "@jridgewell/trace-mapping";
 import { highlightStatic } from "../src/static.js";
 
 const filename = "tests/fixture.svelte";

--- a/tests/static-preprocessor-sourcemap.test.ts
+++ b/tests/static-preprocessor-sourcemap.test.ts
@@ -1,0 +1,140 @@
+import { TraceMap, originalPositionFor } from "@jridgewell/trace-mapping";
+import { highlightStatic } from "../src/static.js";
+
+const filename = "tests/fixture.svelte";
+
+/**
+ * Calls the preprocessor's markup step directly, bypassing svelte/compiler's
+ * `preprocess()`. `preprocess()` re-derives its own combined sourcemap and,
+ * at least for a single markup step with no other preprocessors chained,
+ * that combination collapses to empty `mappings` regardless of what we
+ * return - true both before and after any change to this preprocessor. The
+ * raw, pre-`preprocess()` map is what downstream tools (astro, vite) actually
+ * consume when this preprocessor runs as part of a real chain, so that's
+ * what needs to be correct.
+ */
+async function run(source: string) {
+  const group = highlightStatic();
+  if (!group.markup) throw new Error("expected a markup step");
+  const result = await group.markup({ content: source, filename });
+  if (!result || typeof result === "string" || Array.isArray(result)) {
+    throw new Error("expected a transformed { code, map } result");
+  }
+  return result;
+}
+
+describe("highlightStatic sourcemap", () => {
+  it("splices two sequential static matches without disturbing surrounding markup", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+<p>before</p>
+<Highlight language={javascript} code="const x = 1;" />
+<p>middle</p>
+<Highlight language={javascript} code="const y = 2;" />
+<p>after</p>
+`;
+
+    const { code } = await run(source);
+
+    expect(code.match(/<Highlight/g)).toBeNull();
+    expect(code.match(/data-language="javascript"/g)).toHaveLength(2);
+    expect(code).toContain("<p>before</p>");
+    expect(code).toContain("<p>middle</p>");
+    expect(code).toContain("<p>after</p>");
+    // Order is preserved: "x" is highlighted before "y".
+    expect(code.indexOf('hljs-number">1<')).toBeLessThan(
+      code.indexOf('hljs-number">2<'),
+    );
+  });
+
+  it("replaces a match at the very start of the file", async () => {
+    const source = `<Highlight language={javascript} code="const x = 1;" />
+<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+`;
+    const { code } = await run(source);
+    expect(code.startsWith("<pre")).toBe(true);
+  });
+
+  it("replaces a match with nothing following it", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+<Highlight language={javascript} code="const x = 1;" />`;
+    const { code } = await run(source);
+    expect(code.endsWith("</pre>")).toBe(true);
+  });
+
+  it("produces a well-formed, non-empty sourcemap", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+<Highlight language={javascript} code="const x = 1;" />
+`;
+    const { map } = await run(source);
+    const decoded = map as { sources: unknown; mappings: string };
+
+    expect(map).toMatchObject({ version: 3 });
+    expect(Array.isArray(decoded.sources)).toBe(true);
+    expect(decoded.mappings.length).toBeGreaterThan(0);
+  });
+
+  it("maps unedited lines 1:1 and resyncs original line numbers after multi-line replacements", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+<p>before</p>
+<Highlight language={javascript} code="const x = 1;
+const y = 2;" />
+<p>middle</p>
+<Highlight language={javascript} code="const a = 1;
+const b = 2;
+const c = 3;" />
+<p>after</p>
+`;
+
+    const { code, map } = await run(source);
+    const tracer = new TraceMap(
+      map as ConstructorParameters<typeof TraceMap>[0],
+    );
+    const position = (line: number) =>
+      originalPositionFor(tracer, { line, column: 0 });
+
+    // Sanity: confirm the fixture's line numbers before asserting against them.
+    const srcLines = source.split("\n");
+    expect(srcLines[8]).toBe("<p>middle</p>");
+    expect(srcLines[12]).toBe("<p>after</p>");
+    expect(code.split("\n")[8]).toBe("<p>middle</p>");
+    expect(code.split("\n")[12]).toBe("<p>after</p>");
+
+    // Unedited preamble maps line-for-line to the original. (Line 5 is a
+    // blank line - whether an empty line gets its own mapping segment is an
+    // implementation detail with no observable effect, so it's skipped here.)
+    for (const line of [1, 2, 3, 4, 6]) {
+      expect(position(line)).toMatchObject({ line, column: 0 });
+    }
+
+    // Each replacement's first generated line anchors to its <Highlight> tag's
+    // own start in the original source.
+    expect(position(7)).toMatchObject({ line: 7, column: 0 });
+    expect(position(10)).toMatchObject({ line: 10, column: 0 });
+
+    // The line immediately after each replacement resumes at the correct
+    // original line - the two source-vs-generated line counts here differ
+    // (2 vs 2, then 3 vs 3) only by coincidence of the fixture; this is what
+    // actually catches a line-count drift bug across a multi-line edit.
+    expect(position(9)).toMatchObject({ line: 9, column: 0 });
+    expect(position(13)).toMatchObject({ line: 13, column: 0 });
+  });
+});


### PR DESCRIPTION
Nothing today asserts on the preprocessor's returned sourcemap or covers
two sequential static <Highlight> matches together, both easy to break
silently in any future rewrite of the splicing/mapping logic. Decodes
the map with @jridgewell/trace-mapping to confirm original positions
actually resolve, including across multi-line replacements, plus
start-of-file and end-of-file boundary cases.