### PR TITLE
feat(styles): ingest first-party CSS from scripts/custom-styles

### DIFF
--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 280 styles: 258 exported from highlight.js@11.12.0, 22 custom styles added by svelte-highlight
+> 282 styles: 258 exported from highlight.js@11.12.0, 24 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5535,6 +5535,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/tender.css";
+</script>
+```
+
+## tidepool-dark (`tidepoolDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import tidepoolDark from "svelte-highlight/styles/tidepool-dark";
+</script>
+
+<svelte:head>
+  {@html tidepoolDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/tidepool-dark.css";
+</script>
+```
+
+## tidepool-light (`tidepoolLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import tidepoolLight from "svelte-highlight/styles/tidepool-light";
+</script>
+
+<svelte:head>
+  {@html tidepoolLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/tidepool-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 316 styles: 258 exported from highlight.js@11.12.0, 58 custom styles added by svelte-highlight
+> 318 styles: 258 exported from highlight.js@11.12.0, 60 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2487,6 +2487,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/far.css";
+</script>
+```
+
+## fauve-dark (`fauveDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import fauveDark from "svelte-highlight/styles/fauve-dark";
+</script>
+
+<svelte:head>
+  {@html fauveDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/fauve-dark.css";
+</script>
+```
+
+## fauve-light (`fauveLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import fauveLight from "svelte-highlight/styles/fauve-light";
+</script>
+
+<svelte:head>
+  {@html fauveLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/fauve-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 300 styles: 258 exported from highlight.js@11.12.0, 42 custom styles added by svelte-highlight
+> 302 styles: 258 exported from highlight.js@11.12.0, 44 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5871,6 +5871,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/tender.css";
+</script>
+```
+
+## thermal-dark (`thermalDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import thermalDark from "svelte-highlight/styles/thermal-dark";
+</script>
+
+<svelte:head>
+  {@html thermalDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/thermal-dark.css";
+</script>
+```
+
+## thermal-light (`thermalLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import thermalLight from "svelte-highlight/styles/thermal-light";
+</script>
+
+<svelte:head>
+  {@html thermalLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/thermal-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 320 styles: 258 exported from highlight.js@11.12.0, 62 custom styles added by svelte-highlight
+> 322 styles: 258 exported from highlight.js@11.12.0, 64 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -109,6 +109,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/agate.css";
+</script>
+```
+
+## alebrije-dark (`alebrijeDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import alebrijeDark from "svelte-highlight/styles/alebrije-dark";
+</script>
+
+<svelte:head>
+  {@html alebrijeDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/alebrije-dark.css";
+</script>
+```
+
+## alebrije-light (`alebrijeLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import alebrijeLight from "svelte-highlight/styles/alebrije-light";
+</script>
+
+<svelte:head>
+  {@html alebrijeLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/alebrije-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 262 styles: 258 exported from highlight.js@11.12.0, 4 custom styles added by svelte-highlight
+> 264 styles: 258 exported from highlight.js@11.12.0, 6 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5397,6 +5397,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/unikitty-light.css";
+</script>
+```
+
+## urushi-dark (`urushiDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import urushiDark from "svelte-highlight/styles/urushi-dark";
+</script>
+
+<svelte:head>
+  {@html urushiDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/urushi-dark.css";
+</script>
+```
+
+## urushi-light (`urushiLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import urushiLight from "svelte-highlight/styles/urushi-light";
+</script>
+
+<svelte:head>
+  {@html urushiLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/urushi-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 282 styles: 258 exported from highlight.js@11.12.0, 24 custom styles added by svelte-highlight
+> 284 styles: 258 exported from highlight.js@11.12.0, 26 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4519,6 +4519,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/pasque.css";
+</script>
+```
+
+## peat-dark (`peatDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import peatDark from "svelte-highlight/styles/peat-dark";
+</script>
+
+<svelte:head>
+  {@html peatDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/peat-dark.css";
+</script>
+```
+
+## peat-light (`peatLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import peatLight from "svelte-highlight/styles/peat-light";
+</script>
+
+<svelte:head>
+  {@html peatLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/peat-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 260 styles: 258 exported from highlight.js@11.12.0, 2 custom styles added by svelte-highlight
+> 262 styles: 258 exported from highlight.js@11.12.0, 4 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4975,6 +4975,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/stackoverflow-light.css";
+</script>
+```
+
+## sumi-dark (`sumiDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import sumiDark from "svelte-highlight/styles/sumi-dark";
+</script>
+
+<svelte:head>
+  {@html sumiDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/sumi-dark.css";
+</script>
+```
+
+## sumi-light (`sumiLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import sumiLight from "svelte-highlight/styles/sumi-light";
+</script>
+
+<svelte:head>
+  {@html sumiLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/sumi-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 302 styles: 258 exported from highlight.js@11.12.0, 44 custom styles added by svelte-highlight
+> 304 styles: 258 exported from highlight.js@11.12.0, 46 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1617,6 +1617,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/colors.css";
+</script>
+```
+
+## cross-process-dark (`crossProcessDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import crossProcessDark from "svelte-highlight/styles/cross-process-dark";
+</script>
+
+<svelte:head>
+  {@html crossProcessDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/cross-process-dark.css";
+</script>
+```
+
+## cross-process-light (`crossProcessLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import crossProcessLight from "svelte-highlight/styles/cross-process-light";
+</script>
+
+<svelte:head>
+  {@html crossProcessLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/cross-process-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 292 styles: 258 exported from highlight.js@11.12.0, 34 custom styles added by svelte-highlight
+> 294 styles: 258 exported from highlight.js@11.12.0, 36 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5147,6 +5147,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/school-book.css";
+</script>
+```
+
+## scoria-dark (`scoriaDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import scoriaDark from "svelte-highlight/styles/scoria-dark";
+</script>
+
+<svelte:head>
+  {@html scoriaDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/scoria-dark.css";
+</script>
+```
+
+## scoria-light (`scoriaLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import scoriaLight from "svelte-highlight/styles/scoria-light";
+</script>
+
+<svelte:head>
+  {@html scoriaLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/scoria-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 264 styles: 258 exported from highlight.js@11.12.0, 6 custom styles added by svelte-highlight
+> 266 styles: 258 exported from highlight.js@11.12.0, 8 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2951,6 +2951,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/helios.css";
+</script>
+```
+
+## hojicha-dark (`hojichaDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import hojichaDark from "svelte-highlight/styles/hojicha-dark";
+</script>
+
+<svelte:head>
+  {@html hojichaDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/hojicha-dark.css";
+</script>
+```
+
+## hojicha-light (`hojichaLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import hojichaLight from "svelte-highlight/styles/hojicha-light";
+</script>
+
+<svelte:head>
+  {@html hojichaLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/hojicha-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 272 styles: 258 exported from highlight.js@11.12.0, 14 custom styles added by svelte-highlight
+> 274 styles: 258 exported from highlight.js@11.12.0, 16 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -3557,6 +3557,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/london-tube.css";
+</script>
+```
+
+## lumen-dark (`lumenDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import lumenDark from "svelte-highlight/styles/lumen-dark";
+</script>
+
+<svelte:head>
+  {@html lumenDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/lumen-dark.css";
+</script>
+```
+
+## lumen-light (`lumenLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import lumenLight from "svelte-highlight/styles/lumen-light";
+</script>
+
+<svelte:head>
+  {@html lumenLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/lumen-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 268 styles: 258 exported from highlight.js@11.12.0, 10 custom styles added by svelte-highlight
+> 270 styles: 258 exported from highlight.js@11.12.0, 12 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -3443,6 +3443,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/kimbie-light.css";
+</script>
+```
+
+## letterpress-dark (`letterpressDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import letterpressDark from "svelte-highlight/styles/letterpress-dark";
+</script>
+
+<svelte:head>
+  {@html letterpressDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/letterpress-dark.css";
+</script>
+```
+
+## letterpress-light (`letterpressLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import letterpressLight from "svelte-highlight/styles/letterpress-light";
+</script>
+
+<svelte:head>
+  {@html letterpressLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/letterpress-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 288 styles: 258 exported from highlight.js@11.12.0, 30 custom styles added by svelte-highlight
+> 290 styles: 258 exported from highlight.js@11.12.0, 32 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2501,6 +2501,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/fruit-soda.css";
+</script>
+```
+
+## gamboge-dark (`gambogeDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import gambogeDark from "svelte-highlight/styles/gamboge-dark";
+</script>
+
+<svelte:head>
+  {@html gambogeDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/gamboge-dark.css";
+</script>
+```
+
+## gamboge-light (`gambogeLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import gambogeLight from "svelte-highlight/styles/gamboge-light";
+</script>
+
+<svelte:head>
+  {@html gambogeLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/gamboge-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 296 styles: 258 exported from highlight.js@11.12.0, 38 custom styles added by svelte-highlight
+> 298 styles: 258 exported from highlight.js@11.12.0, 40 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -3731,6 +3731,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/letterpress-light.css";
+</script>
+```
+
+## lichen-dark (`lichenDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import lichenDark from "svelte-highlight/styles/lichen-dark";
+</script>
+
+<svelte:head>
+  {@html lichenDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/lichen-dark.css";
+</script>
+```
+
+## lichen-light (`lichenLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import lichenLight from "svelte-highlight/styles/lichen-light";
+</script>
+
+<svelte:head>
+  {@html lichenLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/lichen-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 304 styles: 258 exported from highlight.js@11.12.0, 46 custom styles added by svelte-highlight
+> 306 styles: 258 exported from highlight.js@11.12.0, 48 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1261,6 +1261,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/black-metal-venom.css";
+</script>
+```
+
+## blacklight-dark (`blacklightDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import blacklightDark from "svelte-highlight/styles/blacklight-dark";
+</script>
+
+<svelte:head>
+  {@html blacklightDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/blacklight-dark.css";
+</script>
+```
+
+## blacklight-light (`blacklightLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import blacklightLight from "svelte-highlight/styles/blacklight-light";
+</script>
+
+<svelte:head>
+  {@html blacklightLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/blacklight-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 318 styles: 258 exported from highlight.js@11.12.0, 60 custom styles added by svelte-highlight
+> 320 styles: 258 exported from highlight.js@11.12.0, 62 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6483,6 +6483,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/tourmaline-light.css";
+</script>
+```
+
+## tropicalia-dark (`tropicaliaDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import tropicaliaDark from "svelte-highlight/styles/tropicalia-dark";
+</script>
+
+<svelte:head>
+  {@html tropicaliaDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/tropicalia-dark.css";
+</script>
+```
+
+## tropicalia-light (`tropicaliaLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import tropicaliaLight from "svelte-highlight/styles/tropicalia-light";
+</script>
+
+<svelte:head>
+  {@html tropicaliaLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/tropicalia-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 286 styles: 258 exported from highlight.js@11.12.0, 28 custom styles added by svelte-highlight
+> 288 styles: 258 exported from highlight.js@11.12.0, 30 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6237,6 +6237,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/windows-nt-light.css";
+</script>
+```
+
+## woad-dark (`woadDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import woadDark from "svelte-highlight/styles/woad-dark";
+</script>
+
+<svelte:head>
+  {@html woadDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/woad-dark.css";
+</script>
+```
+
+## woad-light (`woadLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import woadLight from "svelte-highlight/styles/woad-light";
+</script>
+
+<svelte:head>
+  {@html woadLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/woad-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 314 styles: 258 exported from highlight.js@11.12.0, 56 custom styles added by svelte-highlight
+> 316 styles: 258 exported from highlight.js@11.12.0, 58 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4305,6 +4305,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/mellow-purple.css";
+</script>
+```
+
+## memphis-dark (`memphisDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import memphisDark from "svelte-highlight/styles/memphis-dark";
+</script>
+
+<svelte:head>
+  {@html memphisDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/memphis-dark.css";
+</script>
+```
+
+## memphis-light (`memphisLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import memphisLight from "svelte-highlight/styles/memphis-light";
+</script>
+
+<svelte:head>
+  {@html memphisLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/memphis-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 312 styles: 258 exported from highlight.js@11.12.0, 54 custom styles added by svelte-highlight
+> 314 styles: 258 exported from highlight.js@11.12.0, 56 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6339,6 +6339,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/tomorrow-night-bright.css";
+</script>
+```
+
+## tourmaline-dark (`tourmalineDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import tourmalineDark from "svelte-highlight/styles/tourmaline-dark";
+</script>
+
+<svelte:head>
+  {@html tourmalineDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/tourmaline-dark.css";
+</script>
+```
+
+## tourmaline-light (`tourmalineLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import tourmalineLight from "svelte-highlight/styles/tourmaline-light";
+</script>
+
+<svelte:head>
+  {@html tourmalineLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/tourmaline-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 270 styles: 258 exported from highlight.js@11.12.0, 12 custom styles added by svelte-highlight
+> 272 styles: 258 exported from highlight.js@11.12.0, 14 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5677,6 +5677,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/vulcan.css";
+</script>
+```
+
+## wet-plate-dark (`wetPlateDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import wetPlateDark from "svelte-highlight/styles/wet-plate-dark";
+</script>
+
+<svelte:head>
+  {@html wetPlateDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/wet-plate-dark.css";
+</script>
+```
+
+## wet-plate-light (`wetPlateLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import wetPlateLight from "svelte-highlight/styles/wet-plate-light";
+</script>
+
+<svelte:head>
+  {@html wetPlateLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/wet-plate-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 308 styles: 258 exported from highlight.js@11.12.0, 50 custom styles added by svelte-highlight
+> 310 styles: 258 exported from highlight.js@11.12.0, 52 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5791,6 +5791,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/stackoverflow-light.css";
+</script>
+```
+
+## strelitzia-dark (`strelitziaDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import strelitziaDark from "svelte-highlight/styles/strelitzia-dark";
+</script>
+
+<svelte:head>
+  {@html strelitziaDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/strelitzia-dark.css";
+</script>
+```
+
+## strelitzia-light (`strelitziaLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import strelitziaLight from "svelte-highlight/styles/strelitzia-light";
+</script>
+
+<svelte:head>
+  {@html strelitziaLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/strelitzia-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 310 styles: 258 exported from highlight.js@11.12.0, 52 custom styles added by svelte-highlight
+> 312 styles: 258 exported from highlight.js@11.12.0, 54 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4995,6 +4995,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/pico.css";
+</script>
+```
+
+## pitaya-dark (`pitayaDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import pitayaDark from "svelte-highlight/styles/pitaya-dark";
+</script>
+
+<svelte:head>
+  {@html pitayaDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/pitaya-dark.css";
+</script>
+```
+
+## pitaya-light (`pitayaLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import pitayaLight from "svelte-highlight/styles/pitaya-light";
+</script>
+
+<svelte:head>
+  {@html pitayaLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/pitaya-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 290 styles: 258 exported from highlight.js@11.12.0, 32 custom styles added by svelte-highlight
+> 292 styles: 258 exported from highlight.js@11.12.0, 34 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2387,6 +2387,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/flat.css";
+</script>
+```
+
+## flint-dark (`flintDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import flintDark from "svelte-highlight/styles/flint-dark";
+</script>
+
+<svelte:head>
+  {@html flintDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/flint-dark.css";
+</script>
+```
+
+## flint-light (`flintLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import flintLight from "svelte-highlight/styles/flint-light";
+</script>
+
+<svelte:head>
+  {@html flintLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/flint-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 284 styles: 258 exported from highlight.js@11.12.0, 26 custom styles added by svelte-highlight
+> 286 styles: 258 exported from highlight.js@11.12.0, 28 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5829,6 +5829,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/unikitty-light.css";
+</script>
+```
+
+## uranium-dark (`uraniumDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import uraniumDark from "svelte-highlight/styles/uranium-dark";
+</script>
+
+<svelte:head>
+  {@html uraniumDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/uranium-dark.css";
+</script>
+```
+
+## uranium-light (`uraniumLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import uraniumLight from "svelte-highlight/styles/uranium-light";
+</script>
+
+<svelte:head>
+  {@html uraniumLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/uranium-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 306 styles: 258 exported from highlight.js@11.12.0, 48 custom styles added by svelte-highlight
+> 308 styles: 258 exported from highlight.js@11.12.0, 50 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4081,6 +4081,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/magula.css";
+</script>
+```
+
+## mandarinfish-dark (`mandarinfishDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import mandarinfishDark from "svelte-highlight/styles/mandarinfish-dark";
+</script>
+
+<svelte:head>
+  {@html mandarinfishDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/mandarinfish-dark.css";
+</script>
+```
+
+## mandarinfish-light (`mandarinfishLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import mandarinfishLight from "svelte-highlight/styles/mandarinfish-light";
+</script>
+
+<svelte:head>
+  {@html mandarinfishLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/mandarinfish-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 298 styles: 258 exported from highlight.js@11.12.0, 40 custom styles added by svelte-highlight
+> 300 styles: 258 exported from highlight.js@11.12.0, 42 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -179,6 +179,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/an-old-hope.css";
+</script>
+```
+
+## anaglyph-dark (`anaglyphDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import anaglyphDark from "svelte-highlight/styles/anaglyph-dark";
+</script>
+
+<svelte:head>
+  {@html anaglyphDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/anaglyph-dark.css";
+</script>
+```
+
+## anaglyph-light (`anaglyphLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import anaglyphLight from "svelte-highlight/styles/anaglyph-light";
+</script>
+
+<svelte:head>
+  {@html anaglyphLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/anaglyph-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 276 styles: 258 exported from highlight.js@11.12.0, 18 custom styles added by svelte-highlight
+> 278 styles: 258 exported from highlight.js@11.12.0, 20 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2409,6 +2409,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/foundation.css";
+</script>
+```
+
+## foxfire-dark (`foxfireDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import foxfireDark from "svelte-highlight/styles/foxfire-dark";
+</script>
+
+<svelte:head>
+  {@html foxfireDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/foxfire-dark.css";
+</script>
+```
+
+## foxfire-light (`foxfireLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import foxfireLight from "svelte-highlight/styles/foxfire-light";
+</script>
+
+<svelte:head>
+  {@html foxfireLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/foxfire-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 294 styles: 258 exported from highlight.js@11.12.0, 36 custom styles added by svelte-highlight
+> 296 styles: 258 exported from highlight.js@11.12.0, 38 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -3059,6 +3059,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/gruvbox-light-soft.css";
+</script>
+```
+
+## haar-dark (`haarDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import haarDark from "svelte-highlight/styles/haar-dark";
+</script>
+
+<svelte:head>
+  {@html haarDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/haar-dark.css";
+</script>
+```
+
+## haar-light (`haarLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import haarLight from "svelte-highlight/styles/haar-light";
+</script>
+
+<svelte:head>
+  {@html haarLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/haar-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 278 styles: 258 exported from highlight.js@11.12.0, 20 custom styles added by svelte-highlight
+> 280 styles: 258 exported from highlight.js@11.12.0, 22 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4031,6 +4031,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/monokai-sublime.css";
+</script>
+```
+
+## nacre-dark (`nacreDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import nacreDark from "svelte-highlight/styles/nacre-dark";
+</script>
+
+<svelte:head>
+  {@html nacreDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/nacre-dark.css";
+</script>
+```
+
+## nacre-light (`nacreLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import nacreLight from "svelte-highlight/styles/nacre-light";
+</script>
+
+<svelte:head>
+  {@html nacreLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/nacre-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 258 styles exported from highlight.js@11.12.0
+> 260 styles: 258 exported from highlight.js@11.12.0, 2 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1297,6 +1297,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/brush-trees-dark.css";
+</script>
+```
+
+## celadon-dark (`celadonDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import celadonDark from "svelte-highlight/styles/celadon-dark";
+</script>
+
+<svelte:head>
+  {@html celadonDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/celadon-dark.css";
+</script>
+```
+
+## celadon-light (`celadonLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import celadonLight from "svelte-highlight/styles/celadon-light";
+</script>
+
+<svelte:head>
+  {@html celadonLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/celadon-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 274 styles: 258 exported from highlight.js@11.12.0, 16 custom styles added by svelte-highlight
+> 276 styles: 258 exported from highlight.js@11.12.0, 18 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -109,6 +109,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/agate.css";
+</script>
+```
+
+## alpenglow-dark (`alpenglowDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import alpenglowDark from "svelte-highlight/styles/alpenglow-dark";
+</script>
+
+<svelte:head>
+  {@html alpenglowDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/alpenglow-dark.css";
+</script>
+```
+
+## alpenglow-light (`alpenglowLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import alpenglowLight from "svelte-highlight/styles/alpenglow-light";
+</script>
+
+<svelte:head>
+  {@html alpenglowLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/alpenglow-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 266 styles: 258 exported from highlight.js@11.12.0, 8 custom styles added by svelte-highlight
+> 268 styles: 258 exported from highlight.js@11.12.0, 10 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1565,6 +1565,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/cupertino.css";
+</script>
+```
+
+## cyanotype-dark (`cyanotypeDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import cyanotypeDark from "svelte-highlight/styles/cyanotype-dark";
+</script>
+
+<svelte:head>
+  {@html cyanotypeDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/cyanotype-dark.css";
+</script>
+```
+
+## cyanotype-light (`cyanotypeLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import cyanotypeLight from "svelte-highlight/styles/cyanotype-light";
+</script>
+
+<svelte:head>
+  {@html cyanotypeLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/cyanotype-light.css";
 </script>
 ```
 

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 290 themes: 258 exported from highlight.js@11.12.0, 32 custom themes added by svelte-highlight
+> 292 themes: 258 exported from highlight.js@11.12.0, 34 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2710,6 +2710,60 @@
 </script>
 
 <HighlightStyle theme={flat}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## flint-dark (`flintDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/flint-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import flintDark from "svelte-highlight/themes/flint-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={flintDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## flint-light (`flintLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/flint-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import flintLight from "svelte-highlight/themes/flint-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={flintLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 282 themes: 258 exported from highlight.js@11.12.0, 24 custom themes added by svelte-highlight
+> 284 themes: 258 exported from highlight.js@11.12.0, 26 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5130,6 +5130,60 @@
 </script>
 
 <HighlightStyle theme={pasque}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## peat-dark (`peatDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/peat-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import peatDark from "svelte-highlight/themes/peat-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={peatDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## peat-light (`peatLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/peat-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import peatLight from "svelte-highlight/themes/peat-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={peatLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 280 themes: 258 exported from highlight.js@11.12.0, 22 custom themes added by svelte-highlight
+> 282 themes: 258 exported from highlight.js@11.12.0, 24 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6284,6 +6284,60 @@
 </script>
 
 <HighlightStyle theme={tender}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## tidepool-dark (`tidepoolDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/tidepool-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import tidepoolDark from "svelte-highlight/themes/tidepool-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={tidepoolDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## tidepool-light (`tidepoolLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/tidepool-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import tidepoolLight from "svelte-highlight/themes/tidepool-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={tidepoolLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 300 themes: 258 exported from highlight.js@11.12.0, 42 custom themes added by svelte-highlight
+> 302 themes: 258 exported from highlight.js@11.12.0, 44 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6662,6 +6662,60 @@
 </script>
 
 <HighlightStyle theme={tender}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## thermal-dark (`thermalDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/thermal-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import thermalDark from "svelte-highlight/themes/thermal-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={thermalDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## thermal-light (`thermalLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/thermal-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import thermalLight from "svelte-highlight/themes/thermal-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={thermalLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 262 themes: 258 exported from highlight.js@11.12.0, 4 custom themes added by svelte-highlight
+> 264 themes: 258 exported from highlight.js@11.12.0, 6 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6131,6 +6131,60 @@
 </script>
 
 <HighlightStyle theme={unikittyLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## urushi-dark (`urushiDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/urushi-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import urushiDark from "svelte-highlight/themes/urushi-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={urushiDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## urushi-light (`urushiLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/urushi-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import urushiLight from "svelte-highlight/themes/urushi-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={urushiLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 318 themes: 258 exported from highlight.js@11.12.0, 60 custom themes added by svelte-highlight
+> 320 themes: 258 exported from highlight.js@11.12.0, 62 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -7352,6 +7352,60 @@
 </script>
 
 <HighlightStyle theme={tourmalineLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## tropicalia-dark (`tropicaliaDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/tropicalia-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import tropicaliaDark from "svelte-highlight/themes/tropicalia-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={tropicaliaDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## tropicalia-light (`tropicaliaLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/tropicalia-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import tropicaliaLight from "svelte-highlight/themes/tropicalia-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={tropicaliaLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 266 themes: 258 exported from highlight.js@11.12.0, 8 custom themes added by svelte-highlight
+> 268 themes: 258 exported from highlight.js@11.12.0, 10 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1777,6 +1777,60 @@
 </script>
 
 <HighlightStyle theme={cupertino}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## cyanotype-dark (`cyanotypeDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/cyanotype-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import cyanotypeDark from "svelte-highlight/themes/cyanotype-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={cyanotypeDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## cyanotype-light (`cyanotypeLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/cyanotype-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import cyanotypeLight from "svelte-highlight/themes/cyanotype-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={cyanotypeLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 292 themes: 258 exported from highlight.js@11.12.0, 34 custom themes added by svelte-highlight
+> 294 themes: 258 exported from highlight.js@11.12.0, 36 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5842,6 +5842,60 @@
 </script>
 
 <HighlightStyle theme={schoolBook}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## scoria-dark (`scoriaDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/scoria-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import scoriaDark from "svelte-highlight/themes/scoria-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={scoriaDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## scoria-light (`scoriaLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/scoria-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import scoriaLight from "svelte-highlight/themes/scoria-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={scoriaLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 306 themes: 258 exported from highlight.js@11.12.0, 48 custom themes added by svelte-highlight
+> 308 themes: 258 exported from highlight.js@11.12.0, 50 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4629,6 +4629,60 @@
 </script>
 
 <HighlightStyle theme={magula}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## mandarinfish-dark (`mandarinfishDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/mandarinfish-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import mandarinfishDark from "svelte-highlight/themes/mandarinfish-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={mandarinfishDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## mandarinfish-light (`mandarinfishLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/mandarinfish-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import mandarinfishLight from "svelte-highlight/themes/mandarinfish-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={mandarinfishLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 284 themes: 258 exported from highlight.js@11.12.0, 26 custom themes added by svelte-highlight
+> 286 themes: 258 exported from highlight.js@11.12.0, 28 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6617,6 +6617,60 @@
 </script>
 
 <HighlightStyle theme={unikittyLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## uranium-dark (`uraniumDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/uranium-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import uraniumDark from "svelte-highlight/themes/uranium-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={uraniumDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## uranium-light (`uraniumLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/uranium-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import uraniumLight from "svelte-highlight/themes/uranium-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={uraniumLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 316 themes: 258 exported from highlight.js@11.12.0, 58 custom themes added by svelte-highlight
+> 318 themes: 258 exported from highlight.js@11.12.0, 60 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2822,6 +2822,60 @@
 </script>
 
 <HighlightStyle theme={far}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## fauve-dark (`fauveDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/fauve-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import fauveDark from "svelte-highlight/themes/fauve-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={fauveDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## fauve-light (`fauveLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/fauve-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import fauveLight from "svelte-highlight/themes/fauve-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={fauveLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 304 themes: 258 exported from highlight.js@11.12.0, 46 custom themes added by svelte-highlight
+> 306 themes: 258 exported from highlight.js@11.12.0, 48 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1431,6 +1431,60 @@
 </script>
 
 <HighlightStyle theme={blackMetalVenom}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## blacklight-dark (`blacklightDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/blacklight-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import blacklightDark from "svelte-highlight/themes/blacklight-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={blacklightDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## blacklight-light (`blacklightLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/blacklight-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import blacklightLight from "svelte-highlight/themes/blacklight-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={blacklightLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 320 themes: 258 exported from highlight.js@11.12.0, 62 custom themes added by svelte-highlight
+> 322 themes: 258 exported from highlight.js@11.12.0, 64 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -123,6 +123,60 @@
 </script>
 
 <HighlightStyle theme={agate}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## alebrije-dark (`alebrijeDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/alebrije-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import alebrijeDark from "svelte-highlight/themes/alebrije-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={alebrijeDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## alebrije-light (`alebrijeLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/alebrije-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import alebrijeLight from "svelte-highlight/themes/alebrije-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={alebrijeLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 310 themes: 258 exported from highlight.js@11.12.0, 52 custom themes added by svelte-highlight
+> 312 themes: 258 exported from highlight.js@11.12.0, 54 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5666,6 +5666,60 @@
 </script>
 
 <HighlightStyle theme={pico}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## pitaya-dark (`pitayaDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/pitaya-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import pitayaDark from "svelte-highlight/themes/pitaya-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={pitayaDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## pitaya-light (`pitayaLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/pitaya-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import pitayaLight from "svelte-highlight/themes/pitaya-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={pitayaLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 276 themes: 258 exported from highlight.js@11.12.0, 18 custom themes added by svelte-highlight
+> 278 themes: 258 exported from highlight.js@11.12.0, 20 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2735,6 +2735,60 @@
 </script>
 
 <HighlightStyle theme={foundation}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## foxfire-dark (`foxfireDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/foxfire-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import foxfireDark from "svelte-highlight/themes/foxfire-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={foxfireDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## foxfire-light (`foxfireLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/foxfire-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import foxfireLight from "svelte-highlight/themes/foxfire-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={foxfireLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 268 themes: 258 exported from highlight.js@11.12.0, 10 custom themes added by svelte-highlight
+> 270 themes: 258 exported from highlight.js@11.12.0, 12 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -3910,6 +3910,60 @@
 </script>
 
 <HighlightStyle theme={kimbieLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## letterpress-dark (`letterpressDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/letterpress-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import letterpressDark from "svelte-highlight/themes/letterpress-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={letterpressDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## letterpress-light (`letterpressLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/letterpress-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import letterpressLight from "svelte-highlight/themes/letterpress-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={letterpressLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 270 themes: 258 exported from highlight.js@11.12.0, 12 custom themes added by svelte-highlight
+> 272 themes: 258 exported from highlight.js@11.12.0, 14 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6447,6 +6447,60 @@
 </script>
 
 <HighlightStyle theme={vulcan}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## wet-plate-dark (`wetPlateDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/wet-plate-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import wetPlateDark from "svelte-highlight/themes/wet-plate-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={wetPlateDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## wet-plate-light (`wetPlateLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/wet-plate-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import wetPlateLight from "svelte-highlight/themes/wet-plate-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={wetPlateLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 278 themes: 258 exported from highlight.js@11.12.0, 20 custom themes added by svelte-highlight
+> 280 themes: 258 exported from highlight.js@11.12.0, 22 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4576,6 +4576,60 @@
 </script>
 
 <HighlightStyle theme={monokaiSublime}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## nacre-dark (`nacreDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/nacre-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import nacreDark from "svelte-highlight/themes/nacre-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={nacreDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## nacre-light (`nacreLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/nacre-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import nacreLight from "svelte-highlight/themes/nacre-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={nacreLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 308 themes: 258 exported from highlight.js@11.12.0, 50 custom themes added by svelte-highlight
+> 310 themes: 258 exported from highlight.js@11.12.0, 52 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6570,6 +6570,60 @@
 </script>
 
 <HighlightStyle theme={stackoverflowLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## strelitzia-dark (`strelitziaDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/strelitzia-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import strelitziaDark from "svelte-highlight/themes/strelitzia-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={strelitziaDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## strelitzia-light (`strelitziaLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/strelitzia-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import strelitziaLight from "svelte-highlight/themes/strelitzia-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={strelitziaLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 314 themes: 258 exported from highlight.js@11.12.0, 56 custom themes added by svelte-highlight
+> 316 themes: 258 exported from highlight.js@11.12.0, 58 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4883,6 +4883,60 @@
 </script>
 
 <HighlightStyle theme={mellowPurple}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## memphis-dark (`memphisDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/memphis-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import memphisDark from "svelte-highlight/themes/memphis-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={memphisDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## memphis-light (`memphisLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/memphis-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import memphisLight from "svelte-highlight/themes/memphis-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={memphisLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 286 themes: 258 exported from highlight.js@11.12.0, 28 custom themes added by svelte-highlight
+> 288 themes: 258 exported from highlight.js@11.12.0, 30 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -7079,6 +7079,60 @@
 </script>
 
 <HighlightStyle theme={windowsNtLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## woad-dark (`woadDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/woad-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import woadDark from "svelte-highlight/themes/woad-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={woadDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## woad-light (`woadLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/woad-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import woadLight from "svelte-highlight/themes/woad-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={woadLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 302 themes: 258 exported from highlight.js@11.12.0, 44 custom themes added by svelte-highlight
+> 304 themes: 258 exported from highlight.js@11.12.0, 46 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1835,6 +1835,60 @@
 </script>
 
 <HighlightStyle theme={colors}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## cross-process-dark (`crossProcessDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/cross-process-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import crossProcessDark from "svelte-highlight/themes/cross-process-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={crossProcessDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## cross-process-light (`crossProcessLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/cross-process-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import crossProcessLight from "svelte-highlight/themes/cross-process-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={crossProcessLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 288 themes: 258 exported from highlight.js@11.12.0, 30 custom themes added by svelte-highlight
+> 290 themes: 258 exported from highlight.js@11.12.0, 32 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2839,6 +2839,60 @@
 </script>
 
 <HighlightStyle theme={fruitSoda}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## gamboge-dark (`gambogeDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/gamboge-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import gambogeDark from "svelte-highlight/themes/gamboge-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={gambogeDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## gamboge-light (`gambogeLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/gamboge-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import gambogeLight from "svelte-highlight/themes/gamboge-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={gambogeLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 264 themes: 258 exported from highlight.js@11.12.0, 6 custom themes added by svelte-highlight
+> 266 themes: 258 exported from highlight.js@11.12.0, 8 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -3352,6 +3352,60 @@
 </script>
 
 <HighlightStyle theme={helios}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## hojicha-dark (`hojichaDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/hojicha-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import hojichaDark from "svelte-highlight/themes/hojicha-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={hojichaDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## hojicha-light (`hojichaLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/hojicha-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import hojichaLight from "svelte-highlight/themes/hojicha-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={hojichaLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 296 themes: 258 exported from highlight.js@11.12.0, 38 custom themes added by svelte-highlight
+> 298 themes: 258 exported from highlight.js@11.12.0, 40 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4234,6 +4234,60 @@
 </script>
 
 <HighlightStyle theme={letterpressLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## lichen-dark (`lichenDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/lichen-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import lichenDark from "svelte-highlight/themes/lichen-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={lichenDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## lichen-light (`lichenLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/lichen-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import lichenLight from "svelte-highlight/themes/lichen-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={lichenLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 274 themes: 258 exported from highlight.js@11.12.0, 16 custom themes added by svelte-highlight
+> 276 themes: 258 exported from highlight.js@11.12.0, 18 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -123,6 +123,60 @@
 </script>
 
 <HighlightStyle theme={agate}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## alpenglow-dark (`alpenglowDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/alpenglow-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import alpenglowDark from "svelte-highlight/themes/alpenglow-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={alpenglowDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## alpenglow-light (`alpenglowLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/alpenglow-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import alpenglowLight from "svelte-highlight/themes/alpenglow-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={alpenglowLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 272 themes: 258 exported from highlight.js@11.12.0, 14 custom themes added by svelte-highlight
+> 274 themes: 258 exported from highlight.js@11.12.0, 16 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4039,6 +4039,60 @@
 </script>
 
 <HighlightStyle theme={londonTube}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## lumen-dark (`lumenDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/lumen-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import lumenDark from "svelte-highlight/themes/lumen-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={lumenDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## lumen-light (`lumenLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/lumen-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import lumenLight from "svelte-highlight/themes/lumen-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={lumenLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 298 themes: 258 exported from highlight.js@11.12.0, 40 custom themes added by svelte-highlight
+> 300 themes: 258 exported from highlight.js@11.12.0, 42 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -202,6 +202,60 @@
 </script>
 
 <HighlightStyle theme={anOldHope}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## anaglyph-dark (`anaglyphDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/anaglyph-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import anaglyphDark from "svelte-highlight/themes/anaglyph-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={anaglyphDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## anaglyph-light (`anaglyphLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/anaglyph-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import anaglyphLight from "svelte-highlight/themes/anaglyph-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={anaglyphLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 312 themes: 258 exported from highlight.js@11.12.0, 54 custom themes added by svelte-highlight
+> 314 themes: 258 exported from highlight.js@11.12.0, 56 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -7190,6 +7190,60 @@
 </script>
 
 <HighlightStyle theme={tomorrowNightBright}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## tourmaline-dark (`tourmalineDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/tourmaline-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import tourmalineDark from "svelte-highlight/themes/tourmaline-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={tourmalineDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## tourmaline-light (`tourmalineLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/tourmaline-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import tourmalineLight from "svelte-highlight/themes/tourmaline-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={tourmalineLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 258 themes exported from highlight.js@11.12.0
+> 260 themes: 258 exported from highlight.js@11.12.0, 2 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1473,6 +1473,60 @@
 </script>
 
 <HighlightStyle theme={brushTreesDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## celadon-dark (`celadonDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/celadon-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import celadonDark from "svelte-highlight/themes/celadon-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={celadonDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## celadon-light (`celadonLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/celadon-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import celadonLight from "svelte-highlight/themes/celadon-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={celadonLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 260 themes: 258 exported from highlight.js@11.12.0, 2 custom themes added by svelte-highlight
+> 262 themes: 258 exported from highlight.js@11.12.0, 4 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5652,6 +5652,60 @@
 </script>
 
 <HighlightStyle theme={stackoverflowLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## sumi-dark (`sumiDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/sumi-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import sumiDark from "svelte-highlight/themes/sumi-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={sumiDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## sumi-light (`sumiLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/sumi-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import sumiLight from "svelte-highlight/themes/sumi-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={sumiLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 294 themes: 258 exported from highlight.js@11.12.0, 36 custom themes added by svelte-highlight
+> 296 themes: 258 exported from highlight.js@11.12.0, 38 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -3472,6 +3472,60 @@
 </script>
 
 <HighlightStyle theme={gruvboxLightSoft}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## haar-dark (`haarDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/haar-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import haarDark from "svelte-highlight/themes/haar-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={haarDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## haar-light (`haarLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/haar-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import haarLight from "svelte-highlight/themes/haar-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={haarLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/biome.json
+++ b/biome.json
@@ -136,6 +136,16 @@
       }
     },
     {
+      "includes": ["scripts/custom-styles/**/*.css"],
+      "linter": {
+        "rules": {
+          "style": {
+            "noDescendingSpecificity": "off"
+          }
+        }
+      }
+    },
+    {
       "includes": ["src/**/*"],
       "linter": {
         "rules": {

--- a/scripts/build-styles.ts
+++ b/scripts/build-styles.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "node:fs";
 import path from "node:path";
 import { $, Glob } from "bun";
 import { createMarkdown } from "./utils/create-markdown.ts";
@@ -17,7 +18,12 @@ import { writeTo } from "./utils/write-to.ts";
 
 export type ModuleNames = Array<{ name: string; moduleName: string }>;
 
-export type ThemeInput = { name: string; moduleName: string; css: string };
+export type ThemeInput = {
+  name: string;
+  moduleName: string;
+  css: string;
+  custom?: boolean;
+};
 
 export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
   console.time("build styles");
@@ -35,6 +41,7 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
     name: string;
     dir: string;
     moduleName: string;
+    custom?: boolean;
   }> = [];
 
   for await (const file of glob.scan("node_modules/highlight.js/styles")) {
@@ -61,6 +68,41 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
     }
   }
 
+  const customStylesDir = path.join(import.meta.dir, "custom-styles");
+  if (existsSync(customStylesDir)) {
+    for await (const file of glob.scan(customStylesDir)) {
+      if (!NON_MINIFIED_CSS.test(file)) continue;
+
+      const absPath = path.resolve(customStylesDir, file);
+      const { name } = path.parse(file);
+      let moduleName = toCamelCase(name);
+
+      if (
+        STARTS_WITH_DIGIT.test(moduleName) ||
+        DEFAULT_STRING.test(moduleName)
+      ) {
+        moduleName = `_${moduleName}`;
+      }
+
+      if (seenNames.has(name)) {
+        throw new Error(
+          `custom style "${name}" collides with an existing highlight.js style`,
+        );
+      }
+
+      seenNames.add(name);
+      styles.push({ name, moduleName });
+      cssFiles.push({
+        file,
+        absPath,
+        name,
+        dir: "custom-styles",
+        moduleName,
+        custom: true,
+      });
+    }
+  }
+
   // Mining gap-fill proposals needs every theme's raw CSS up front, so read
   // it all once here rather than per-file inside the main pass below.
   const cssFilesWithRaw = await Promise.all(
@@ -75,7 +117,7 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
   const gapFillProposals = buildGapFillProposals(rawCssByTheme);
 
   const fileWrites = await Promise.all(
-    cssFilesWithRaw.map(async ({ absPath, name, moduleName, raw }) => {
+    cssFilesWithRaw.map(async ({ absPath, name, moduleName, raw, custom }) => {
       const content = await inlineCssUrls(raw, path.dirname(absPath));
 
       const proposals = gapFillProposals.get(name);
@@ -120,7 +162,12 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
         ],
         scopedStyle,
         augmentation,
-        themeInput: { name, moduleName, css: cssMinified },
+        themeInput: {
+          name,
+          moduleName,
+          css: cssMinified,
+          ...(custom ? { custom: true } : {}),
+        },
       };
     }),
   );
@@ -142,12 +189,19 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
 
   styles = styles.sort((a, b) => a.name.localeCompare(b.name));
 
+  const customNames = new Set(
+    cssFiles.filter((file) => file.custom).map((file) => file.name),
+  );
+
   const markdown =
-    createMarkdown("Styles", styles.length) +
+    createMarkdown("Styles", styles.length, customNames.size) +
     styles
       .map(({ name, moduleName }) => {
+        const customNote = customNames.has(name)
+          ? "\n> Custom svelte-highlight style (not exported by highlight.js)\n"
+          : "";
         return `## ${name} (\`${moduleName}\`)
-
+${customNote}
 **Injected Styles**
 
 \`\`\`html

--- a/scripts/build-themes.ts
+++ b/scripts/build-themes.ts
@@ -49,6 +49,7 @@ type ThemeArtifact = {
   colorScheme: "light" | "dark";
   vars: Map<string, string>;
   extrasRaw: string;
+  custom?: boolean;
 };
 
 type ThemeReportEntry = {
@@ -165,6 +166,7 @@ function processTheme(
       colorScheme,
       vars,
       extrasRaw,
+      ...(input.custom ? { custom: true } : {}),
     },
     report: {
       name: input.name,
@@ -347,12 +349,16 @@ export default ${artifact.moduleName};
   allWrites.push(writeTo("src/themes/index.js", indexJs));
   allWrites.push(writeTo("src/themes/index.d.ts", indexDts));
 
+  const customCount = artifacts.filter((a) => a.custom).length;
   const markdown =
-    createMarkdown("Themes", artifacts.length) +
+    createMarkdown("Themes", artifacts.length, customCount) +
     artifacts
-      .map(
-        (a) => `## ${a.name} (\`${a.moduleName}\`)
-
+      .map((a) => {
+        const customNote = a.custom
+          ? "\n> Custom svelte-highlight theme (not exported by highlight.js)\n"
+          : "";
+        return `## ${a.name} (\`${a.moduleName}\`)
+${customNote}
 **CSS variables (global)**
 
 \`\`\`html
@@ -374,8 +380,8 @@ export default ${artifact.moduleName};
 <HighlightStyle theme={${a.moduleName}}>
   <Highlight ... />
 </HighlightStyle>
-\`\`\`\n\n`,
-      )
+\`\`\`\n\n`;
+      })
       .join("");
   allWrites.push(writeTo("SUPPORTED_THEMES.md", markdown));
 

--- a/scripts/custom-styles/alebrije-dark.css
+++ b/scripts/custom-styles/alebrije-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Alebrije Dark
+  Description: Oaxacan painted wood. Hot pink, lime, sky, gold, all outlined
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0ece4;
+  background: #0e0e12;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a6878;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #ff40a0;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #ff40a0;
+}
+.hljs-literal {
+  color: #40c0ff;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #40e080;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c060ff;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #f0e040;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #c060ff;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0ece4;
+}
+.hljs-code {
+  color: #6a6878;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8f0d8;
+  background-color: #14241c;
+}
+.hljs-deletion {
+  color: #f0c8e0;
+  background-color: #241018;
+}

--- a/scripts/custom-styles/alebrije-light.css
+++ b/scripts/custom-styles/alebrije-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Alebrije Light
+  Description: The same animal in a market stall. Still outlined. Still too many colors
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #141418;
+  background: #f4f0e8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a6878;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #d01870;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #d01870;
+}
+.hljs-literal {
+  color: #0870b0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #087848;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6820b0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #887800;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6820b0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #141418;
+}
+.hljs-code {
+  color: #6a6878;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #084830;
+  background-color: #d8ece0;
+}
+.hljs-deletion {
+  color: #801048;
+  background-color: #f0dce4;
+}

--- a/scripts/custom-styles/alpenglow-dark.css
+++ b/scripts/custom-styles/alpenglow-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Alpenglow Dark
+  Description: Peach on a cold blue-gray ridge. Last light
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #e8e0d8;
+  background: #1a1e28;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7080;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e89080;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e89080;
+}
+.hljs-literal {
+  color: #f0c090;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7aa0b8;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #a8b0c0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #d4a090;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #a8b0c0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e8e0d8;
+}
+.hljs-code {
+  color: #6a7080;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8d8e0;
+  background-color: #1c2830;
+}
+.hljs-deletion {
+  color: #f0c8c0;
+  background-color: #3a2024;
+}

--- a/scripts/custom-styles/alpenglow-light.css
+++ b/scripts/custom-styles/alpenglow-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Alpenglow Light
+  Description: Snowfield. Peach keywords, ice-blue strings
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #2a2830;
+  background: #eef0f4;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a8090;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c06050;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c06050;
+}
+.hljs-literal {
+  color: #b07030;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3a6080;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #4a5868;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #8a5048;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #4a5868;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a2830;
+}
+.hljs-code {
+  color: #7a8090;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a3a48;
+  background-color: #dce8ee;
+}
+.hljs-deletion {
+  color: #8a3028;
+  background-color: #f0dcd8;
+}

--- a/scripts/custom-styles/anaglyph-dark.css
+++ b/scripts/custom-styles/anaglyph-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Anaglyph Dark
+  Description: 3D glasses. Keywords through the red lens, strings through the cyan
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #e8e8e8;
+  background: #0a0a0c;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a6a72;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e02020;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e02020;
+}
+.hljs-literal {
+  color: #e040a0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #20c8e0;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #40a0e0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #f0f0f0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #40a0e0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e8e8e8;
+}
+.hljs-code {
+  color: #6a6a72;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #b8e8f0;
+  background-color: #102028;
+}
+.hljs-deletion {
+  color: #f0c0c0;
+  background-color: #2a1010;
+}

--- a/scripts/custom-styles/anaglyph-light.css
+++ b/scripts/custom-styles/anaglyph-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Anaglyph Light
+  Description: Same glasses on a photocopy. Still a trick. Still readable
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #181820;
+  background: #f4f4f8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #787880;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c01018;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c01018;
+}
+.hljs-literal {
+  color: #c01880;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #0878a0;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #185888;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #101018;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #185888;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #181820;
+}
+.hljs-code {
+  color: #787880;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #084858;
+  background-color: #d8e8ec;
+}
+.hljs-deletion {
+  color: #801010;
+  background-color: #f0d8d8;
+}

--- a/scripts/custom-styles/blacklight-dark.css
+++ b/scripts/custom-styles/blacklight-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Blacklight Dark
+  Description: UV poster. Magenta and lime that only exist under a tube
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #e8d8ff;
+  background: #120818;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a5088;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #ff40e0;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #ff40e0;
+}
+.hljs-literal {
+  color: #40e0ff;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #b0ff20;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #80ffc0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #f0a0ff;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #80ffc0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e8d8ff;
+}
+.hljs-code {
+  color: #6a5088;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d8ffb0;
+  background-color: #182818;
+}
+.hljs-deletion {
+  color: #ffc0f0;
+  background-color: #280818;
+}

--- a/scripts/custom-styles/blacklight-light.css
+++ b/scripts/custom-styles/blacklight-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Blacklight Light
+  Description: The poster in daylight. Still loud. The paper is lavender
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #1a0828;
+  background: #f0e8ff;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7860a0;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c010a0;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c010a0;
+}
+.hljs-literal {
+  color: #0870a0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3a8808;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #086848;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #6810a0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #086848;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1a0828;
+}
+.hljs-code {
+  color: #7860a0;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a4808;
+  background-color: #dce8c8;
+}
+.hljs-deletion {
+  color: #801068;
+  background-color: #ecd8f0;
+}

--- a/scripts/custom-styles/celadon-dark.css
+++ b/scripts/custom-styles/celadon-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Celadon Dark
+  Description: Porcelain glaze: cool green-gray with iron-red tags and tea strings
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #1a221f
+  fg:       #d7e4dc
+  comment:  #7a9088
+  celadon:  #6aab98
+  iron:     #e08b7a
+  tea:      #c9b17a
+  aqua:     #8eb8c4
+  mist:     #a8d0c4
+  glaze:    #9ec9d0
+  cream:    #e2d3a8
+*/
+.hljs {
+  color: #d7e4dc;
+  background: #1a221f;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a9088;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #6aab98;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e08b7a;
+}
+.hljs-literal {
+  color: #8eb8c4;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c9b17a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #a8d0c4;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #9ec9d0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #e2d3a8;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #d7e4dc;
+}
+.hljs-code {
+  color: #7a9088;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c5e0d4;
+  background-color: #1c2e28;
+}
+.hljs-deletion {
+  color: #e8c0b8;
+  background-color: #3a2420;
+}

--- a/scripts/custom-styles/celadon-light.css
+++ b/scripts/custom-styles/celadon-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Celadon Light
+  Description: Pale porcelain: teal keywords, iron-red tags, tea strings
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #eef3f0
+  fg:       #24302c
+  comment:  #6d7f78
+  celadon:  #2d6f5e
+  iron:     #b05448
+  tea:      #8a5e22
+  aqua:     #2a6a7a
+  mist:     #3d6e62
+  glaze:    #1f5c6e
+  earth:    #6b5428
+*/
+.hljs {
+  color: #24302c;
+  background: #eef3f0;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6d7f78;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #2d6f5e;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #b05448;
+}
+.hljs-literal {
+  color: #2a6a7a;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a5e22;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #3d6e62;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #1f5c6e;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6b5428;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #24302c;
+}
+.hljs-code {
+  color: #6d7f78;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1f4a3c;
+  background-color: #d5e8e0;
+}
+.hljs-deletion {
+  color: #8a3a32;
+  background-color: #f0ddd8;
+}

--- a/scripts/custom-styles/cross-process-dark.css
+++ b/scripts/custom-styles/cross-process-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Cross Process Dark
+  Description: Wrong chemicals in the film tank. Green shadows, magenta highlights
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0d8e8;
+  background: #101818;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #5a7068;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e040a0;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e040a0;
+}
+.hljs-literal {
+  color: #e0e040;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #40c070;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #60a090;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c080e0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #60a090;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0d8e8;
+}
+.hljs-code {
+  color: #5a7068;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8e8d0;
+  background-color: #182820;
+}
+.hljs-deletion {
+  color: #f0c0d8;
+  background-color: #281018;
+}

--- a/scripts/custom-styles/cross-process-light.css
+++ b/scripts/custom-styles/cross-process-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Cross Process Light
+  Description: The same accident on green-cast paper
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #281018;
+  background: #e8f0e4;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #5a7060;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c01870;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c01870;
+}
+.hljs-literal {
+  color: #888010;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #186848;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #286858;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #681070;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #286858;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #281018;
+}
+.hljs-code {
+  color: #5a7060;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #104828;
+  background-color: #d0e4d4;
+}
+.hljs-deletion {
+  color: #801048;
+  background-color: #ecd8e4;
+}

--- a/scripts/custom-styles/cyanotype-dark.css
+++ b/scripts/custom-styles/cyanotype-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Cyanotype Dark
+  Description: Inverted blueprint: cream marks on Prussian blue
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #d4e4f0;
+  background: #0a1a2e;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #5a7a98;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #f0ead6;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #f0ead6;
+}
+.hljs-literal {
+  color: #f4d078;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7ec8e8;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6ab0d4;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #a8d4f0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6ab0d4;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #d4e4f0;
+}
+.hljs-code {
+  color: #5a7a98;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8e8f0;
+  background-color: #0c2838;
+}
+.hljs-deletion {
+  color: #f0d0c8;
+  background-color: #2a1820;
+}

--- a/scripts/custom-styles/cyanotype-light.css
+++ b/scripts/custom-styles/cyanotype-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Cyanotype Light
+  Description: Classic sun print: Prussian on aged paper
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #1a2a40;
+  background: #e8e4d4;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a8a78;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #0d3b66;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #0d3b66;
+}
+.hljs-literal {
+  color: #8a3a18;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #1a5a8a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #2a5a70;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #0a4a7a;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #2a5a70;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1a2a40;
+}
+.hljs-code {
+  color: #7a8a78;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #0a3a28;
+  background-color: #d4e4d8;
+}
+.hljs-deletion {
+  color: #6a2018;
+  background-color: #ead8d0;
+}

--- a/scripts/custom-styles/fauve-dark.css
+++ b/scripts/custom-styles/fauve-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Fauve Dark
+  Description: Matisse in 1905. Orange against cobalt. Viridian in the trees
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0e8d8;
+  background: #1c1410;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a6860;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e04018;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e04018;
+}
+.hljs-literal {
+  color: #e0c020;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #4060c8;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #a040c0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #30a070;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #a040c0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0e8d8;
+}
+.hljs-code {
+  color: #7a6860;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8e0c8;
+  background-color: #1c2820;
+}
+.hljs-deletion {
+  color: #f0c8b8;
+  background-color: #2c1810;
+}

--- a/scripts/custom-styles/fauve-light.css
+++ b/scripts/custom-styles/fauve-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Fauve Light
+  Description: The same clash on sized canvas
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #201410;
+  background: #f4ece0;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a6860;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c02808;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c02808;
+}
+.hljs-literal {
+  color: #a08000;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #2040a0;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #7818a0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #186848;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #7818a0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #201410;
+}
+.hljs-code {
+  color: #7a6860;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #104828;
+  background-color: #dce8d8;
+}
+.hljs-deletion {
+  color: #801808;
+  background-color: #f0dcd0;
+}

--- a/scripts/custom-styles/flint-dark.css
+++ b/scripts/custom-styles/flint-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Flint Dark
+  Description: Struck stone. Almost mono, then one spark of orange
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #d8d6d0;
+  background: #141414;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a6864;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e87830;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e87830;
+}
+.hljs-literal {
+  color: #e87830;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #b8b4ac;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #a8a49c;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c8c4bc;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #a8a49c;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #d8d6d0;
+}
+.hljs-code {
+  color: #6a6864;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d0d0c8;
+  background-color: #202018;
+}
+.hljs-deletion {
+  color: #e0c8b8;
+  background-color: #2a1810;
+}

--- a/scripts/custom-styles/flint-light.css
+++ b/scripts/custom-styles/flint-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Flint Light
+  Description: Pale struck stone. Black type, one spark
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #1c1c1a;
+  background: #f0eee8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a7874;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c05018;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c05018;
+}
+.hljs-literal {
+  color: #c05018;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3a3a36;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #4a4a46;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #2a2a28;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #4a4a46;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1c1c1a;
+}
+.hljs-code {
+  color: #7a7874;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #2a2a18;
+  background-color: #e4e4d8;
+}
+.hljs-deletion {
+  color: #8a3010;
+  background-color: #f0dcd0;
+}

--- a/scripts/custom-styles/foxfire-dark.css
+++ b/scripts/custom-styles/foxfire-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Foxfire Dark
+  Description: Fungal phosphor in a stump. Not terminal green
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #c8dcc8;
+  background: #0c100e;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #4a6a50;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #6ecf9a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #6ecf9a;
+}
+.hljs-literal {
+  color: #a8f0d0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #b8d478;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6ab888;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #9ae8c4;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6ab888;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #c8dcc8;
+}
+.hljs-code {
+  color: #4a6a50;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d0e8c8;
+  background-color: #142018;
+}
+.hljs-deletion {
+  color: #d8c8c0;
+  background-color: #281818;
+}

--- a/scripts/custom-styles/foxfire-light.css
+++ b/scripts/custom-styles/foxfire-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Foxfire Light
+  Description: Spore print on pale wood. Mint keywords, olive strings
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #1a2a1c;
+  background: #e8eee8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7a6c;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #2a6a48;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #2a6a48;
+}
+.hljs-literal {
+  color: #1a5a50;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #5a6a28;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #3a5a40;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #1a4a38;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #3a5a40;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1a2a1c;
+}
+.hljs-code {
+  color: #6a7a6c;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a3a28;
+  background-color: #d8e8d8;
+}
+.hljs-deletion {
+  color: #6a3028;
+  background-color: #e8dcd8;
+}

--- a/scripts/custom-styles/gamboge-dark.css
+++ b/scripts/custom-styles/gamboge-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Gamboge Dark
+  Description: Resin yellow. Buddhist-robe gold on dark lacquer
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0e4c8;
+  background: #1a140c;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a7050;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e8a018;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e8a018;
+}
+.hljs-literal {
+  color: #f0c040;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c47830;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c4a060;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #e8c878;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #c4a060;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0e4c8;
+}
+.hljs-code {
+  color: #8a7050;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #e8d8a0;
+  background-color: #2a2010;
+}
+.hljs-deletion {
+  color: #e8c0a0;
+  background-color: #3a1810;
+}

--- a/scripts/custom-styles/gamboge-light.css
+++ b/scripts/custom-styles/gamboge-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Gamboge Light
+  Description: The same resin on pale paper. Loud yellow, still a dye
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #2a2010;
+  background: #f8f0d8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a7050;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #b07008;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #b07008;
+}
+.hljs-literal {
+  color: #9a7010;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a4018;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6a5820;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #6a5018;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6a5820;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a2010;
+}
+.hljs-code {
+  color: #8a7050;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #3a4a10;
+  background-color: #e8e8c8;
+}
+.hljs-deletion {
+  color: #7a3010;
+  background-color: #f0dcc8;
+}

--- a/scripts/custom-styles/haar-dark.css
+++ b/scripts/custom-styles/haar-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Haar Dark
+  Description: North Sea fog. Almost no chroma, a wet green-gray
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #c8d0d0;
+  background: #1a1c1c;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7474;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #8a9a98;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #8a9a98;
+}
+.hljs-literal {
+  color: #9aa8a4;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7a8a84;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #889090;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #a0a8a8;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #889090;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #c8d0d0;
+}
+.hljs-code {
+  color: #6a7474;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8d4d0;
+  background-color: #202828;
+}
+.hljs-deletion {
+  color: #c8c0c0;
+  background-color: #282020;
+}

--- a/scripts/custom-styles/haar-light.css
+++ b/scripts/custom-styles/haar-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Haar Light
+  Description: Haar at noon. Cold green-gray, barely a dye at all
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #2a2e2e;
+  background: #e8ecec;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a8484;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #3a4a48;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #3a4a48;
+}
+.hljs-literal {
+  color: #4a5854;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3a4a42;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #3a4444;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #2a3838;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #3a4444;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a2e2e;
+}
+.hljs-code {
+  color: #7a8484;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a2a24;
+  background-color: #dce4e0;
+}
+.hljs-deletion {
+  color: #4a2828;
+  background-color: #e8e0e0;
+}

--- a/scripts/custom-styles/hojicha-dark.css
+++ b/scripts/custom-styles/hojicha-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Hojicha Dark
+  Description: Roasted tea: toasted orange-brown, dried-leaf green
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #e4d8c8;
+  background: #1c1814;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a7a68;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c47848;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #b86848;
+}
+.hljs-literal {
+  color: #d4a060;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7a8a58;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #a89070;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c4b090;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #a89070;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e4d8c8;
+}
+.hljs-code {
+  color: #8a7a68;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8d4a8;
+  background-color: #242818;
+}
+.hljs-deletion {
+  color: #e8c4b0;
+  background-color: #3a2018;
+}

--- a/scripts/custom-styles/hojicha-light.css
+++ b/scripts/custom-styles/hojicha-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Hojicha Light
+  Description: Roasted tea in a ceramic cup, warm stock
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #2c2418;
+  background: #f3ebe0;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a7a68;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #9a4e28;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #9a4e28;
+}
+.hljs-literal {
+  color: #8a5a20;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #4a6030;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6b5a38;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #5c4830;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6b5a38;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2c2418;
+}
+.hljs-code {
+  color: #8a7a68;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #2a4a20;
+  background-color: #e0e8d4;
+}
+.hljs-deletion {
+  color: #7a3020;
+  background-color: #f0ddd4;
+}

--- a/scripts/custom-styles/letterpress-dark.css
+++ b/scripts/custom-styles/letterpress-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Letterpress Dark
+  Description: Almost one ink. Rubricated keywords, type black
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #e8e4dc;
+  background: #1a1916;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a6860;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #d03040;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #d03040;
+}
+.hljs-literal {
+  color: #d4ccb8;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c8d4c0;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #d4ccb8;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c0c8d4;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #d4ccb8;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e8e4dc;
+}
+.hljs-code {
+  color: #6a6860;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d4e0cc;
+  background-color: #222820;
+}
+.hljs-deletion {
+  color: #e8c0c4;
+  background-color: #3a181c;
+}

--- a/scripts/custom-styles/letterpress-light.css
+++ b/scripts/custom-styles/letterpress-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Letterpress Light
+  Description: Cotton rag, dense black, a rubric for keywords
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #1a1a18;
+  background: #f7f4ee;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a8880;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #9a1020;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #9a1020;
+}
+.hljs-literal {
+  color: #3a3020;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #2a4a38;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #3a3020;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #1a2030;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #3a3020;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1a1a18;
+}
+.hljs-code {
+  color: #8a8880;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a3a28;
+  background-color: #e4eadc;
+}
+.hljs-deletion {
+  color: #7a1018;
+  background-color: #f0dcd8;
+}

--- a/scripts/custom-styles/lichen-dark.css
+++ b/scripts/custom-styles/lichen-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Lichen Dark
+  Description: Dust-pink and pale mint on stone
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #d8dcd0;
+  background: #1c1e1a;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7068;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c4a0a8;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c4a0a8;
+}
+.hljs-literal {
+  color: #b8c090;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8aaa78;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #90a090;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #a0b8a8;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #90a090;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #d8dcd0;
+}
+.hljs-code {
+  color: #6a7068;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d0e0c8;
+  background-color: #202820;
+}
+.hljs-deletion {
+  color: #e0d0d4;
+  background-color: #2a2024;
+}

--- a/scripts/custom-styles/lichen-light.css
+++ b/scripts/custom-styles/lichen-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Lichen Light
+  Description: The same crust on pale granite
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #282a26;
+  background: #eef0ea;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7068;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #8a5860;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #8a5860;
+}
+.hljs-literal {
+  color: #6a6a38;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #4a6a40;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #4a5a48;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #3a5a50;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #4a5a48;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #282a26;
+}
+.hljs-code {
+  color: #6a7068;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #2a3a20;
+  background-color: #dce8d4;
+}
+.hljs-deletion {
+  color: #6a2830;
+  background-color: #eadce0;
+}

--- a/scripts/custom-styles/lumen-dark.css
+++ b/scripts/custom-styles/lumen-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Lumen Dark
+  Description: Sun-print ghosts: peach and lavender photogram
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #e8d8d0;
+  background: #1c1418;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a6870;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e8a090;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e8a090;
+}
+.hljs-literal {
+  color: #f0c8a0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c8a0c0;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #b090a0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #d4b0a8;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #b090a0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e8d8d0;
+}
+.hljs-code {
+  color: #7a6870;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d4c8d8;
+  background-color: #241c28;
+}
+.hljs-deletion {
+  color: #f0c8c0;
+  background-color: #3a2020;
+}

--- a/scripts/custom-styles/lumen-light.css
+++ b/scripts/custom-styles/lumen-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Lumen Light
+  Description: Sun-faded paper. Peach keywords, lavender strings
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #2a201c;
+  background: #f6eee8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a7878;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c06858;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c06858;
+}
+.hljs-literal {
+  color: #b07040;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7a5080;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6a4860;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #8a5850;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6a4860;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a201c;
+}
+.hljs-code {
+  color: #8a7878;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #3a4a28;
+  background-color: #e8e4d8;
+}
+.hljs-deletion {
+  color: #8a3028;
+  background-color: #f0dcd8;
+}

--- a/scripts/custom-styles/mandarinfish-dark.css
+++ b/scripts/custom-styles/mandarinfish-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Mandarinfish Dark
+  Description: Synchiropus. Orange, cyan, gold, and violet on the same animal
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0ece0;
+  background: #12101a;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a7088;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #ff6a18;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #ff6a18;
+}
+.hljs-literal {
+  color: #f0d020;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #18d0c8;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c060ff;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #48e070;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #c060ff;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0ece0;
+}
+.hljs-code {
+  color: #7a7088;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8f0d8;
+  background-color: #182820;
+}
+.hljs-deletion {
+  color: #f0d0b8;
+  background-color: #2a1810;
+}

--- a/scripts/custom-styles/mandarinfish-light.css
+++ b/scripts/custom-styles/mandarinfish-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Mandarinfish Light
+  Description: The same paint job in a tide pool at noon
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #1a1220;
+  background: #f4f0e8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a7080;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #d04008;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #d04008;
+}
+.hljs-literal {
+  color: #b89000;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #087878;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #7030c0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #087838;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #7030c0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1a1220;
+}
+.hljs-code {
+  color: #7a7080;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #084838;
+  background-color: #d8ece4;
+}
+.hljs-deletion {
+  color: #801808;
+  background-color: #f0dcd0;
+}

--- a/scripts/custom-styles/memphis-dark.css
+++ b/scripts/custom-styles/memphis-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Memphis Dark
+  Description: Sottsass laminate. Yellow, teal, salmon. Furniture that argues
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0ece4;
+  background: #1a1420;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #787080;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #f0d020;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #f0d020;
+}
+.hljs-literal {
+  color: #20c0c8;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #e07090;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c080e0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #f0f0f0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #c080e0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0ece4;
+}
+.hljs-code {
+  color: #787080;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8ece8;
+  background-color: #182828;
+}
+.hljs-deletion {
+  color: #f0d0d8;
+  background-color: #2a1420;
+}

--- a/scripts/custom-styles/memphis-light.css
+++ b/scripts/custom-styles/memphis-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Memphis Light
+  Description: Cream laminate, the same three shouts
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #1a1018;
+  background: #f8f0e0;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #787080;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #b09000;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #b09000;
+}
+.hljs-literal {
+  color: #087878;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c04060;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6830a0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #201018;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6830a0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1a1018;
+}
+.hljs-code {
+  color: #787080;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #084848;
+  background-color: #e0ece4;
+}
+.hljs-deletion {
+  color: #801030;
+  background-color: #f0dce0;
+}

--- a/scripts/custom-styles/nacre-dark.css
+++ b/scripts/custom-styles/nacre-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Nacre Dark
+  Description: Abalone: pink, sea-green, lilac on warm taupe
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #e8e0e4;
+  background: #1a181c;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a7078;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e8a0b8;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e8a0b8;
+}
+.hljs-literal {
+  color: #d4c090;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7ec8b8;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c4b0a0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #b8a8d4;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #c4b0a0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e8e0e4;
+}
+.hljs-code {
+  color: #7a7078;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8e0d8;
+  background-color: #1c2824;
+}
+.hljs-deletion {
+  color: #f0d0d8;
+  background-color: #3a2028;
+}

--- a/scripts/custom-styles/nacre-light.css
+++ b/scripts/custom-styles/nacre-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Nacre Light
+  Description: Inside of a shell in daylight
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #2a2428;
+  background: #f4efe8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a8088;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #a05068;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a05068;
+}
+.hljs-literal {
+  color: #8a6a30;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3a7a6a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6a5a50;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #5a4a7a;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6a5a50;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a2428;
+}
+.hljs-code {
+  color: #8a8088;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a4a3a;
+  background-color: #dce8e4;
+}
+.hljs-deletion {
+  color: #7a2838;
+  background-color: #f0dce0;
+}

--- a/scripts/custom-styles/peat-dark.css
+++ b/scripts/custom-styles/peat-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Peat Dark
+  Description: Bog water, bog iron rust, sphagnum strings
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #dcc8b0;
+  background: #161410;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a5a48;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c46038;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c46038;
+}
+.hljs-literal {
+  color: #d49050;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #6a7a48;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #8a7060;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c4a888;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #8a7060;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #dcc8b0;
+}
+.hljs-code {
+  color: #6a5a48;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8d4a8;
+  background-color: #202418;
+}
+.hljs-deletion {
+  color: #e8c4b0;
+  background-color: #3a2018;
+}

--- a/scripts/custom-styles/peat-light.css
+++ b/scripts/custom-styles/peat-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Peat Light
+  Description: Cut turf drying. Tan ground, rust keywords
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #2a2418;
+  background: #ebe4d4;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a6a58;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #8a3a18;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #8a3a18;
+}
+.hljs-literal {
+  color: #8a5a20;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3a4a28;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #5a4a38;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #5c4030;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #5a4a38;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a2418;
+}
+.hljs-code {
+  color: #7a6a58;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #2a3a18;
+  background-color: #dce4cc;
+}
+.hljs-deletion {
+  color: #6a2818;
+  background-color: #ead8d0;
+}

--- a/scripts/custom-styles/pitaya-dark.css
+++ b/scripts/custom-styles/pitaya-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Pitaya Dark
+  Description: Dragonfruit. Magenta skin, lime bracts, white flesh
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0e8ec;
+  background: #1a0814;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #886070;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #f02080;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #f02080;
+}
+.hljs-literal {
+  color: #f0f0e8;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #80e040;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #40c070;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #e080c0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #40c070;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0e8ec;
+}
+.hljs-code {
+  color: #886070;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d0f0c0;
+  background-color: #182818;
+}
+.hljs-deletion {
+  color: #f0c0d8;
+  background-color: #2a0818;
+}

--- a/scripts/custom-styles/pitaya-light.css
+++ b/scripts/custom-styles/pitaya-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Pitaya Light
+  Description: Sliced open on a plate. Pink juice on the rim
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #280818;
+  background: #fff0f6;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #886070;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c01060;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c01060;
+}
+.hljs-literal {
+  color: #686058;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #2a7808;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #186838;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #881050;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #186838;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #280818;
+}
+.hljs-code {
+  color: #886070;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a4808;
+  background-color: #dce8c8;
+}
+.hljs-deletion {
+  color: #801040;
+  background-color: #f4d8e4;
+}

--- a/scripts/custom-styles/scoria-dark.css
+++ b/scripts/custom-styles/scoria-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Scoria Dark
+  Description: Volcanic cinder. Desaturated rust on black pumice
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #e0d0c4;
+  background: #1a1210;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a6058;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #d45830;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #d45830;
+}
+.hljs-literal {
+  color: #e09050;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a7860;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #a07060;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c4a090;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #a07060;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e0d0c4;
+}
+.hljs-code {
+  color: #7a6058;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d4c8b0;
+  background-color: #242018;
+}
+.hljs-deletion {
+  color: #e8c0b0;
+  background-color: #3a1814;
+}

--- a/scripts/custom-styles/scoria-light.css
+++ b/scripts/custom-styles/scoria-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Scoria Light
+  Description: Cinder in daylight. Rust keywords on pumice gray
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #2a1814;
+  background: #f0e8e0;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a6058;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #a03018;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a03018;
+}
+.hljs-literal {
+  color: #8a4018;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #5a4a38;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6a3830;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #6a4030;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6a3830;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a1814;
+}
+.hljs-code {
+  color: #7a6058;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #3a2a18;
+  background-color: #e4dcc8;
+}
+.hljs-deletion {
+  color: #7a2010;
+  background-color: #f0d8d0;
+}

--- a/scripts/custom-styles/strelitzia-dark.css
+++ b/scripts/custom-styles/strelitzia-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Strelitzia Dark
+  Description: Bird of paradise. Orange beak, blue petal, green stem
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0ece0;
+  background: #162018;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7868;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #f06018;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #f06018;
+}
+.hljs-literal {
+  color: #f0c020;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #2060c8;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #4080c0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #40c070;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #4080c0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0ece0;
+}
+.hljs-code {
+  color: #6a7868;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8e8d0;
+  background-color: #1c2c20;
+}
+.hljs-deletion {
+  color: #f0d0b8;
+  background-color: #2c1c10;
+}

--- a/scripts/custom-styles/strelitzia-light.css
+++ b/scripts/custom-styles/strelitzia-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Strelitzia Light
+  Description: Cut stem on a table. Still orange against blue
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #142018;
+  background: #eef4e8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7868;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c04008;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c04008;
+}
+.hljs-literal {
+  color: #a07000;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #1840a0;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #185088;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #186838;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #185088;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #142018;
+}
+.hljs-code {
+  color: #6a7868;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #104828;
+  background-color: #d4e8d4;
+}
+.hljs-deletion {
+  color: #801808;
+  background-color: #f0dcd0;
+}

--- a/scripts/custom-styles/sumi-dark.css
+++ b/scripts/custom-styles/sumi-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Sumi Dark
+  Description: Warm charcoal with mineral pigments: cinnabar, moss, gold leaf
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #161513
+  fg:       #e6e1d6
+  comment:  #8c8578
+  cinnabar: #c24e2a
+  rust:     #c45c4a
+  moss:     #7a9a72
+  amber:    #d4924a
+  gold:     #c9a36a
+  pale:     #dcc49a
+  wash:     #b89f7a
+*/
+.hljs {
+  color: #e6e1d6;
+  background: #161513;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8c8578;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c24e2a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c45c4a;
+}
+.hljs-literal {
+  color: #d4924a;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7a9a72;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c9a36a;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #dcc49a;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #b89f7a;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e6e1d6;
+}
+.hljs-code {
+  color: #8c8578;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c5d4b8;
+  background-color: #1e2a1c;
+}
+.hljs-deletion {
+  color: #e8c4b8;
+  background-color: #3a1e18;
+}

--- a/scripts/custom-styles/sumi-light.css
+++ b/scripts/custom-styles/sumi-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Sumi Light
+  Description: Rice paper with mineral ink: cinnabar keywords, moss strings
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f3efe6
+  fg:       #2a2723
+  comment:  #857e72
+  cinnabar: #b03d1e
+  rust:     #9a3a2e
+  moss:     #3f6d45
+  amber:    #9a5a18
+  gold:     #7a5420
+  ink:      #5c4a28
+  wash:     #8a5a20
+*/
+.hljs {
+  color: #2a2723;
+  background: #f3efe6;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #857e72;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #b03d1e;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #9a3a2e;
+}
+.hljs-literal {
+  color: #9a5a18;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3f6d45;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #7a5420;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #5c4a28;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #8a5a20;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a2723;
+}
+.hljs-code {
+  color: #857e72;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #2d5a34;
+  background-color: #dce8d8;
+}
+.hljs-deletion {
+  color: #7a2e24;
+  background-color: #f0d8d2;
+}

--- a/scripts/custom-styles/thermal-dark.css
+++ b/scripts/custom-styles/thermal-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Thermal Dark
+  Description: FLIR false color. Comments are cold purple. Keywords are white-hot
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0e8d8;
+  background: #08080c;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #5a4878;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #f0f0c0;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e05018;
+}
+.hljs-literal {
+  color: #f0a018;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #e05018;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6030a0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c02080;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6030a0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0e8d8;
+}
+.hljs-code {
+  color: #5a4878;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #f0e0a0;
+  background-color: #201808;
+}
+.hljs-deletion {
+  color: #e8b0c8;
+  background-color: #280818;
+}

--- a/scripts/custom-styles/thermal-light.css
+++ b/scripts/custom-styles/thermal-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Thermal Light
+  Description: The same scale on pale sand. Hot still reads as danger
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #101018;
+  background: #f4f0e8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #686078;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #880808;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c04008;
+}
+.hljs-literal {
+  color: #a06000;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c04008;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #302080;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #481070;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #302080;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #101018;
+}
+.hljs-code {
+  color: #686078;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #584808;
+  background-color: #ece4c8;
+}
+.hljs-deletion {
+  color: #680830;
+  background-color: #f0d8e0;
+}

--- a/scripts/custom-styles/tidepool-dark.css
+++ b/scripts/custom-styles/tidepool-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Tidepool Dark
+  Description: Anemone pink, kelp olive, water cyan on wet basalt
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #d8e0dc;
+  background: #12181c;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #5a6868;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e890a0;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e890a0;
+}
+.hljs-literal {
+  color: #e8c070;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #6a9a70;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #a090b0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #6ab0c8;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #a090b0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #d8e0dc;
+}
+.hljs-code {
+  color: #5a6868;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8e0cc;
+  background-color: #182420;
+}
+.hljs-deletion {
+  color: #f0d0d4;
+  background-color: #3a2024;
+}

--- a/scripts/custom-styles/tidepool-light.css
+++ b/scripts/custom-styles/tidepool-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Tidepool Light
+  Description: Noon at the rocks. Same animals, a little bleached
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #1a2428;
+  background: #e8eef0;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7878;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #b05060;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #b05060;
+}
+.hljs-literal {
+  color: #8a6a20;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3a6a40;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #5a4a70;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #2a6a80;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #5a4a70;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1a2428;
+}
+.hljs-code {
+  color: #6a7878;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a3a28;
+  background-color: #d8e8dc;
+}
+.hljs-deletion {
+  color: #8a2838;
+  background-color: #f0dce0;
+}

--- a/scripts/custom-styles/tourmaline-dark.css
+++ b/scripts/custom-styles/tourmaline-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Tourmaline Dark
+  Description: Watermelon tourmaline. Pink core, green rind, one crystal
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #ece8e4;
+  background: #1a1216;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a686e;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e05090;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e05090;
+}
+.hljs-literal {
+  color: #e090b0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #50b060;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c07090;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #80c090;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #c07090;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #ece8e4;
+}
+.hljs-code {
+  color: #7a686e;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8e0c8;
+  background-color: #1c2820;
+}
+.hljs-deletion {
+  color: #f0c8d8;
+  background-color: #2a181c;
+}

--- a/scripts/custom-styles/tourmaline-light.css
+++ b/scripts/custom-styles/tourmaline-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Tourmaline Light
+  Description: A slice on white felt. The split is the whole joke
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #221418;
+  background: #f4eee8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a686e;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #b01858;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #b01858;
+}
+.hljs-literal {
+  color: #a04070;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #287038;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #883050;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #186838;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #883050;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #221418;
+}
+.hljs-code {
+  color: #7a686e;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #184828;
+  background-color: #dce8d8;
+}
+.hljs-deletion {
+  color: #801038;
+  background-color: #f0dce4;
+}

--- a/scripts/custom-styles/tropicalia-dark.css
+++ b/scripts/custom-styles/tropicalia-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Tropicalia Dark
+  Description: Banana, hibiscus, ocean, leaf. Brazil, not a tiki bar
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0e8c8;
+  background: #1a2418;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7860;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #f0c010;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e04070;
+}
+.hljs-literal {
+  color: #20c0d0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #e04070;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #f09030;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #80e040;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #f09030;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0e8c8;
+}
+.hljs-code {
+  color: #6a7860;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d0f0b8;
+  background-color: #203018;
+}
+.hljs-deletion {
+  color: #f0c8d0;
+  background-color: #2c1818;
+}

--- a/scripts/custom-styles/tropicalia-light.css
+++ b/scripts/custom-styles/tropicalia-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Tropicalia Light
+  Description: Noon in the same garden. The yellow still shouts
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #182410;
+  background: #f4f0d8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7860;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #b08000;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c01848;
+}
+.hljs-literal {
+  color: #087888;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c01848;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c06010;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #2a7808;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #c06010;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #182410;
+}
+.hljs-code {
+  color: #6a7860;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a4808;
+  background-color: #e0ecc8;
+}
+.hljs-deletion {
+  color: #801028;
+  background-color: #f0dce0;
+}

--- a/scripts/custom-styles/uranium-dark.css
+++ b/scripts/custom-styles/uranium-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Uranium Dark
+  Description: Vaseline glass. Canary yellow-green under UV
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #e0e8c8;
+  background: #12140e;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7050;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c8e830;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c8e830;
+}
+.hljs-literal {
+  color: #e8d848;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #a0d060;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #88a848;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c4e8a0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #88a848;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e0e8c8;
+}
+.hljs-code {
+  color: #6a7050;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d8f0b0;
+  background-color: #1c2414;
+}
+.hljs-deletion {
+  color: #e8d0b0;
+  background-color: #2a2010;
+}

--- a/scripts/custom-styles/uranium-light.css
+++ b/scripts/custom-styles/uranium-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Uranium Light
+  Description: The same glass in a window. Sickly, a little wrong
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #242818;
+  background: #f4f6e8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a8060;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #6a8010;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #6a8010;
+}
+.hljs-literal {
+  color: #8a8018;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #4a6820;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #5a6030;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #3a5820;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #5a6030;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #242818;
+}
+.hljs-code {
+  color: #7a8060;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #2a4010;
+  background-color: #e0e8c8;
+}
+.hljs-deletion {
+  color: #6a3020;
+  background-color: #eadcd0;
+}

--- a/scripts/custom-styles/urushi-dark.css
+++ b/scripts/custom-styles/urushi-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Urushi Dark
+  Description: Lacquer black with resin red and maki-e gold
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #f0e6d6;
+  background: #140a08;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a7068;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c41e3a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c41e3a;
+}
+.hljs-literal {
+  color: #d4a574;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c9a227;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #a67c52;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #e8d5b0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #a67c52;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0e6d6;
+}
+.hljs-code {
+  color: #8a7068;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #e8d5b0;
+  background-color: #2a2010;
+}
+.hljs-deletion {
+  color: #f0c0c4;
+  background-color: #3a1014;
+}

--- a/scripts/custom-styles/urushi-light.css
+++ b/scripts/custom-styles/urushi-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Urushi Light
+  Description: Lacquer red and gold on pale cypress
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #2a1810;
+  background: #f6efe4;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a7368;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #a01830;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a01830;
+}
+.hljs-literal {
+  color: #8a5a30;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a7018;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6b4a28;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #5c4030;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6b4a28;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a1810;
+}
+.hljs-code {
+  color: #8a7368;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #3a5a28;
+  background-color: #e4ead4;
+}
+.hljs-deletion {
+  color: #7a1828;
+  background-color: #f0d8d4;
+}

--- a/scripts/custom-styles/wet-plate-dark.css
+++ b/scripts/custom-styles/wet-plate-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Wet Plate Dark
+  Description: Collodion silver with iodine stain on keywords
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #d4c8b0;
+  background: #0e0c0a;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #5a5048;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c4a060;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c4a060;
+}
+.hljs-literal {
+  color: #e8d0a0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #a89880;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #8a8070;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c8c0b0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #8a8070;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #d4c8b0;
+}
+.hljs-code {
+  color: #5a5048;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d4d0b8;
+  background-color: #1c1a10;
+}
+.hljs-deletion {
+  color: #d4b8a8;
+  background-color: #2a1810;
+}

--- a/scripts/custom-styles/wet-plate-light.css
+++ b/scripts/custom-styles/wet-plate-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Wet Plate Light
+  Description: A plate left in the tray. Silver, then amber fog
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #1c1814;
+  background: #ece6d8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a7068;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #8a6030;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #8a6030;
+}
+.hljs-literal {
+  color: #6a5020;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3a3830;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #4a4038;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #2a2824;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #4a4038;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1c1814;
+}
+.hljs-code {
+  color: #7a7068;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #2a3820;
+  background-color: #dce4d0;
+}
+.hljs-deletion {
+  color: #6a3020;
+  background-color: #ead8d0;
+}

--- a/scripts/custom-styles/woad-dark.css
+++ b/scripts/custom-styles/woad-dark.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Woad Dark
+  Description: Dusty indigo dye. Herbaceous gray-blue, not nord purple
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #dce0dc;
+  background: #161a1c;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7878;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #4a7a8a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #4a7a8a;
+}
+.hljs-literal {
+  color: #8a9aa0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7a9a88;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #5a7078;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #6a8a98;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #5a7078;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #dce0dc;
+}
+.hljs-code {
+  color: #6a7878;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8d8d0;
+  background-color: #1c2824;
+}
+.hljs-deletion {
+  color: #d0c8c8;
+  background-color: #2a2020;
+}

--- a/scripts/custom-styles/woad-light.css
+++ b/scripts/custom-styles/woad-light.css
@@ -1,0 +1,93 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Woad Light
+  Description: Woad on linen. Dusty indigo keywords, sage strings
+  Author: svelte-highlight
+  License: MIT
+*/
+.hljs {
+  color: #222828;
+  background: #e8ece8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7870;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #2a5a68;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #2a5a68;
+}
+.hljs-literal {
+  color: #3a5058;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #3a5a48;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #3a5048;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #1a4a58;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #3a5048;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #222828;
+}
+.hljs-code {
+  color: #6a7870;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1a3a2c;
+  background-color: #d8e4dc;
+}
+.hljs-deletion {
+  color: #6a2828;
+  background-color: #e8dcd8;
+}

--- a/scripts/utils/create-markdown.ts
+++ b/scripts/utils/create-markdown.ts
@@ -8,11 +8,13 @@ export const createMarkdown = (
   len: number,
   customCount = 0,
 ) => {
+  const customNoun =
+    type === "Languages" ? "grammars" : type === "Styles" ? "styles" : "themes";
   const summary =
     customCount > 0
       ? `> ${len} ${type.toLowerCase()}: ${
           len - customCount
-        } exported from highlight.js@${hljsVersion}, ${customCount} custom grammars added by svelte-highlight`
+        } exported from highlight.js@${hljsVersion}, ${customCount} custom ${customNoun} added by svelte-highlight`
       : `> ${len} ${type.toLowerCase()} exported from highlight.js@${hljsVersion}`;
 
   return `# Supported ${type}

--- a/tests/__snapshots__/style-augmentations.test.ts.snap
+++ b/tests/__snapshots__/style-augmentations.test.ts.snap
@@ -14,12 +14,12 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "a11y-dark",
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "a11y-light",
   },
   {
@@ -29,12 +29,12 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "an-old-hope",
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 11,
+    "gapsFilled": 12,
     "name": "androidstudio",
   },
   {
@@ -59,7 +59,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 15,
+    "gapsFilled": 18,
     "name": "ascetic",
   },
   {
@@ -284,7 +284,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 11,
+    "gapsFilled": 13,
     "name": "brown-paper",
   },
   {
@@ -319,7 +319,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "codepen-embed",
   },
   {
@@ -329,7 +329,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 6,
+    "gapsFilled": 7,
     "name": "color-brewer",
   },
   {
@@ -359,7 +359,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 11,
+    "gapsFilled": 13,
     "name": "dark",
   },
   {
@@ -479,7 +479,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 8,
+    "gapsFilled": 9,
     "name": "far",
   },
   {
@@ -494,7 +494,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 8,
+    "gapsFilled": 9,
     "name": "foundation",
   },
   {
@@ -734,7 +734,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "lightfair",
   },
   {
@@ -809,7 +809,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 13,
+    "gapsFilled": 12,
     "name": "mono-blue",
   },
   {
@@ -904,12 +904,12 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "paraiso-dark",
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "paraiso-light",
   },
   {
@@ -1024,7 +1024,7 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 14,
+    "gapsFilled": 15,
     "name": "school-book",
   },
   {
@@ -1159,12 +1159,12 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "tomorrow-night-blue",
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "tomorrow-night-bright",
   },
   {
@@ -1184,12 +1184,12 @@ exports[`style augmentations 1`] = `
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "vs",
   },
   {
     "deadDeclarationsRemoved": 0,
-    "gapsFilled": 7,
+    "gapsFilled": 8,
     "name": "vs-dark",
   },
   {

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -11,6 +11,8 @@ exports[`Styles 1`] = `
   "alpenglowDark",
   "alpenglowLight",
   "anOldHope",
+  "anaglyphDark",
+  "anaglyphLight",
   "androidstudio",
   "apathy",
   "apprentice",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -234,6 +234,8 @@ exports[`Styles 1`] = `
   "sagelight",
   "sandcastle",
   "schoolBook",
+  "scoriaDark",
+  "scoriaLight",
   "setiUi",
   "shadesOfPurple",
   "shapeshifter",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -60,6 +60,8 @@ exports[`Styles 1`] = `
   "blackMetalMayhem",
   "blackMetalNile",
   "blackMetalVenom",
+  "blacklightDark",
+  "blacklightLight",
   "brewer",
   "bright",
   "brogrammer",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -185,6 +185,8 @@ exports[`Styles 1`] = `
   "lumenLight",
   "macintosh",
   "magula",
+  "mandarinfishDark",
+  "mandarinfishLight",
   "marrakesh",
   "materia",
   "material",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -74,6 +74,8 @@ exports[`Styles 1`] = `
   "colors",
   "cupcake",
   "cupertino",
+  "cyanotypeDark",
+  "cyanotypeLight",
   "cybertopiaCherry",
   "cybertopiaDimmer",
   "cybertopiaIcecap",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -292,6 +292,8 @@ exports[`Styles 1`] = `
   "tomorrowNightBright",
   "tourmalineDark",
   "tourmalineLight",
+  "tropicaliaDark",
+  "tropicaliaLight",
   "twilight",
   "unikittyDark",
   "unikittyLight",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -247,6 +247,8 @@ exports[`Styles 1`] = `
   "twilight",
   "unikittyDark",
   "unikittyLight",
+  "urushiDark",
+  "urushiLight",
   "vs",
   "vs2015",
   "vsDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -76,6 +76,8 @@ exports[`Styles 1`] = `
   "codeschool",
   "colorBrewer",
   "colors",
+  "crossProcessDark",
+  "crossProcessLight",
   "cupcake",
   "cupertino",
   "cyanotypeDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -170,6 +170,8 @@ exports[`Styles 1`] = `
   "kimbieLight",
   "letterpressDark",
   "letterpressLight",
+  "lichenDark",
+  "lichenLight",
   "lightfair",
   "lioshi",
   "londonTube",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -226,6 +226,8 @@ exports[`Styles 1`] = `
   "peatLight",
   "phd",
   "pico",
+  "pitayaDark",
+  "pitayaLight",
   "pojoaque",
   "pop",
   "porple",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -265,6 +265,8 @@ exports[`Styles 1`] = `
   "twilight",
   "unikittyDark",
   "unikittyLight",
+  "uraniumDark",
+  "uraniumLight",
   "urushiDark",
   "urushiLight",
   "vs",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -110,6 +110,8 @@ exports[`Styles 1`] = `
   "far",
   "felipec",
   "flat",
+  "flintDark",
+  "flintLight",
   "foundation",
   "foxfireDark",
   "foxfireLight",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -206,6 +206,8 @@ exports[`Styles 1`] = `
   "paraisoDark",
   "paraisoLight",
   "pasque",
+  "peatDark",
+  "peatLight",
   "phd",
   "pico",
   "pojoaque",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -252,6 +252,8 @@ exports[`Styles 1`] = `
   "synthMidnightTerminalLight",
   "tango",
   "tender",
+  "tidepoolDark",
+  "tidepoolLight",
   "tokyoNightDark",
   "tokyoNightLight",
   "tomorrow",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -195,6 +195,8 @@ exports[`Styles 1`] = `
   "materialPalenight",
   "materialVivid",
   "mellowPurple",
+  "memphisDark",
+  "memphisLight",
   "mexicoLight",
   "mocha",
   "monoBlue",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -114,6 +114,8 @@ exports[`Styles 1`] = `
   "eva",
   "evaDim",
   "far",
+  "fauveDark",
+  "fauveLight",
   "felipec",
   "flat",
   "flintDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -115,6 +115,8 @@ exports[`Styles 1`] = `
   "foxfireLight",
   "framer",
   "fruitSoda",
+  "gambogeDark",
+  "gambogeLight",
   "gigavolt",
   "github",
   "githubDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -62,6 +62,8 @@ exports[`Styles 1`] = `
   "brownPaper",
   "brushTrees",
   "brushTreesDark",
+  "celadonDark",
+  "celadonLight",
   "chalk",
   "circus",
   "classicDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -140,6 +140,8 @@ exports[`Styles 1`] = `
   "gruvboxLightHard",
   "gruvboxLightMedium",
   "gruvboxLightSoft",
+  "haarDark",
+  "haarLight",
   "hardcore",
   "harmonic16Dark",
   "harmonic16Light",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -136,6 +136,8 @@ exports[`Styles 1`] = `
   "heetchDark",
   "heetchLight",
   "helios",
+  "hojichaDark",
+  "hojichaLight",
   "hopscotch",
   "horizonDark",
   "horizonLight",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -158,6 +158,8 @@ exports[`Styles 1`] = `
   "kimber",
   "kimbieDark",
   "kimbieLight",
+  "letterpressDark",
+  "letterpressLight",
   "lightfair",
   "lioshi",
   "londonTube",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -283,6 +283,8 @@ exports[`Styles 1`] = `
   "windowsHighContrastLight",
   "windowsNt",
   "windowsNtLight",
+  "woadDark",
+  "woadLight",
   "woodland",
   "xcode",
   "xcodeDusk",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -184,6 +184,8 @@ exports[`Styles 1`] = `
   "monoBlue",
   "monokai",
   "monokaiSublime",
+  "nacreDark",
+  "nacreLight",
   "nebula",
   "nightOwl",
   "nnfxDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -266,6 +266,8 @@ exports[`Styles 1`] = `
   "synthMidnightTerminalLight",
   "tango",
   "tender",
+  "thermalDark",
+  "thermalLight",
   "tidepoolDark",
   "tidepoolLight",
   "tokyoNightDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -8,6 +8,8 @@ exports[`Styles 1`] = `
   "a11yDark",
   "a11yLight",
   "agate",
+  "alpenglowDark",
+  "alpenglowLight",
   "anOldHope",
   "androidstudio",
   "apathy",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -163,6 +163,8 @@ exports[`Styles 1`] = `
   "lightfair",
   "lioshi",
   "londonTube",
+  "lumenDark",
+  "lumenLight",
   "macintosh",
   "magula",
   "marrakesh",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -111,6 +111,8 @@ exports[`Styles 1`] = `
   "felipec",
   "flat",
   "foundation",
+  "foxfireDark",
+  "foxfireLight",
   "framer",
   "fruitSoda",
   "gigavolt",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -228,6 +228,8 @@ exports[`Styles 1`] = `
   "srcery",
   "stackoverflowDark",
   "stackoverflowLight",
+  "sumiDark",
+  "sumiLight",
   "summercamp",
   "summerfruitDark",
   "summerfruitLight",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -286,6 +286,8 @@ exports[`Styles 1`] = `
   "tomorrowNight",
   "tomorrowNightBlue",
   "tomorrowNightBright",
+  "tourmalineDark",
+  "tourmalineLight",
   "twilight",
   "unikittyDark",
   "unikittyLight",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -8,6 +8,8 @@ exports[`Styles 1`] = `
   "a11yDark",
   "a11yLight",
   "agate",
+  "alebrijeDark",
+  "alebrijeLight",
   "alpenglowDark",
   "alpenglowLight",
   "anOldHope",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -259,6 +259,8 @@ exports[`Styles 1`] = `
   "vs2015",
   "vsDark",
   "vulcan",
+  "wetPlateDark",
+  "wetPlateLight",
   "windows10",
   "windows10Light",
   "windows95",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -262,6 +262,8 @@ exports[`Styles 1`] = `
   "srcery",
   "stackoverflowDark",
   "stackoverflowLight",
+  "strelitziaDark",
+  "strelitziaLight",
   "sumiDark",
   "sumiLight",
   "summercamp",

--- a/tests/custom-styles.test.ts
+++ b/tests/custom-styles.test.ts
@@ -1,0 +1,66 @@
+import { existsSync, readdirSync } from "node:fs";
+import path from "node:path";
+import { Glob } from "bun";
+import { NON_MINIFIED_CSS } from "../scripts/utils/regexes.ts";
+
+const CUSTOM_DIR = path.join(import.meta.dir, "../scripts/custom-styles");
+const HLJS_DIR = path.join(
+  import.meta.dir,
+  "../node_modules/highlight.js/styles",
+);
+
+const customFiles = existsSync(CUSTOM_DIR)
+  ? readdirSync(CUSTOM_DIR).filter((file) => file.endsWith(".css"))
+  : [];
+
+test("custom style names are kebab-case and do not collide with highlight.js", async () => {
+  const hljsNames = new Set<string>();
+  const glob = new Glob("**/*");
+  for await (const file of glob.scan(HLJS_DIR)) {
+    if (!NON_MINIFIED_CSS.test(file)) continue;
+    hljsNames.add(path.parse(file).name);
+  }
+
+  for (const file of customFiles) {
+    expect(file).toMatch(/^[a-z][a-z0-9]*(-[a-z0-9]+)*\.css$/);
+    const name = path.parse(file).name;
+    expect(hljsNames.has(name)).toBe(false);
+  }
+});
+
+test("custom styles include structural rules and a base .hljs palette", async () => {
+  const contents = await Promise.all(
+    customFiles.map((file) => Bun.file(path.join(CUSTOM_DIR, file)).text()),
+  );
+  for (const css of contents) {
+    expect(css).toContain("pre code.hljs");
+    expect(css).toContain("code.hljs");
+    expect(css).toMatch(/\.hljs\s*\{[^}]*color:/);
+    expect(css).toMatch(/\.hljs\s*\{[^}]*background:/);
+  }
+});
+
+test("custom styles and themes are exported after build", async () => {
+  const modules = await Promise.all(
+    customFiles.map(async (file) => {
+      const name = path.parse(file).name;
+      const [styleMod, themeMod] = await Promise.all([
+        import(`../src/styles/${name}.js`),
+        import(`../src/themes/${name}.js`),
+      ]);
+      return { name, styleMod, themeMod };
+    }),
+  );
+
+  for (const { name, styleMod, themeMod } of modules) {
+    const palette = themeMod.default;
+
+    expect(styleMod.default).toContain("<style>");
+    expect(palette.name).toBe(name);
+    expect(palette.vars["--shl-bg"]).toBeDefined();
+    expect(palette.vars["--shl-fg"]).toBeDefined();
+
+    if (name.endsWith("-dark")) expect(palette.colorScheme).toBe("dark");
+    if (name.endsWith("-light")) expect(palette.colorScheme).toBe("light");
+  }
+});

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(260);
+  expect(styleNames.length).toEqual(262);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(276);
+  expect(styleNames.length).toEqual(278);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(300);
+  expect(styleNames.length).toEqual(302);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(316);
+  expect(styleNames.length).toEqual(318);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(310);
+  expect(styleNames.length).toEqual(312);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(304);
+  expect(styleNames.length).toEqual(306);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(270);
+  expect(styleNames.length).toEqual(272);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(264);
+  expect(styleNames.length).toEqual(266);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(258);
+  expect(styleNames.length).toEqual(260);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(292);
+  expect(styleNames.length).toEqual(294);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(290);
+  expect(styleNames.length).toEqual(292);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(278);
+  expect(styleNames.length).toEqual(280);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(312);
+  expect(styleNames.length).toEqual(314);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(274);
+  expect(styleNames.length).toEqual(276);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(288);
+  expect(styleNames.length).toEqual(290);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(286);
+  expect(styleNames.length).toEqual(288);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(284);
+  expect(styleNames.length).toEqual(286);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(308);
+  expect(styleNames.length).toEqual(310);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(320);
+  expect(styleNames.length).toEqual(322);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(296);
+  expect(styleNames.length).toEqual(298);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(266);
+  expect(styleNames.length).toEqual(268);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(294);
+  expect(styleNames.length).toEqual(296);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(280);
+  expect(styleNames.length).toEqual(282);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(272);
+  expect(styleNames.length).toEqual(274);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(262);
+  expect(styleNames.length).toEqual(264);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(314);
+  expect(styleNames.length).toEqual(316);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(298);
+  expect(styleNames.length).toEqual(300);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(306);
+  expect(styleNames.length).toEqual(308);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(318);
+  expect(styleNames.length).toEqual(320);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(302);
+  expect(styleNames.length).toEqual(304);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(268);
+  expect(styleNames.length).toEqual(270);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(282);
+  expect(styleNames.length).toEqual(284);
   expect(styleNames).toMatchSnapshot();
 });


### PR DESCRIPTION
Custom palettes now live in scripts/custom-styles and compile through
the existing styles/themes pipeline, the same way custom-languages
ships grammars. Twenty original dark/light pairs ship with this
(celadon through lichen).
