### PR TITLE
feat(styles): add custom `kintsugi` dark and light styles

### DIFF
--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 340 styles: 258 exported from highlight.js@11.12.0, 82 custom styles added by svelte-highlight
+> 342 styles: 258 exported from highlight.js@11.12.0, 84 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -205,6 +205,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/alpenglow-light.css";
+</script>
+```
+
+## amaranth-dark (`amaranthDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import amaranthDark from "svelte-highlight/styles/amaranth-dark";
+</script>
+
+<svelte:head>
+  {@html amaranthDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/amaranth-dark.css";
+</script>
+```
+
+## amaranth-light (`amaranthLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import amaranthLight from "svelte-highlight/styles/amaranth-light";
+</script>
+
+<svelte:head>
+  {@html amaranthLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/amaranth-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 332 styles: 258 exported from highlight.js@11.12.0, 74 custom styles added by svelte-highlight
+> 334 styles: 258 exported from highlight.js@11.12.0, 76 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2653,6 +2653,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/felipec.css";
+</script>
+```
+
+## ferrofluid-dark (`ferrofluidDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import ferrofluidDark from "svelte-highlight/styles/ferrofluid-dark";
+</script>
+
+<svelte:head>
+  {@html ferrofluidDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/ferrofluid-dark.css";
+</script>
+```
+
+## ferrofluid-light (`ferrofluidLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import ferrofluidLight from "svelte-highlight/styles/ferrofluid-light";
+</script>
+
+<svelte:head>
+  {@html ferrofluidLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/ferrofluid-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 334 styles: 258 exported from highlight.js@11.12.0, 76 custom styles added by svelte-highlight
+> 336 styles: 258 exported from highlight.js@11.12.0, 78 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6271,6 +6271,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/sumi-light.css";
+</script>
+```
+
+## suminagashi-dark (`suminagashiDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import suminagashiDark from "svelte-highlight/styles/suminagashi-dark";
+</script>
+
+<svelte:head>
+  {@html suminagashiDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/suminagashi-dark.css";
+</script>
+```
+
+## suminagashi-light (`suminagashiLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import suminagashiLight from "svelte-highlight/styles/suminagashi-light";
+</script>
+
+<svelte:head>
+  {@html suminagashiLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/suminagashi-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 342 styles: 258 exported from highlight.js@11.12.0, 84 custom styles added by svelte-highlight
+> 344 styles: 258 exported from highlight.js@11.12.0, 86 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1721,6 +1721,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/classic-light.css";
+</script>
+```
+
+## cobalt-dark (`cobaltDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import cobaltDark from "svelte-highlight/styles/cobalt-dark";
+</script>
+
+<svelte:head>
+  {@html cobaltDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/cobalt-dark.css";
+</script>
+```
+
+## cobalt-light (`cobaltLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import cobaltLight from "svelte-highlight/styles/cobalt-light";
+</script>
+
+<svelte:head>
+  {@html cobaltLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/cobalt-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 338 styles: 258 exported from highlight.js@11.12.0, 80 custom styles added by svelte-highlight
+> 340 styles: 258 exported from highlight.js@11.12.0, 82 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5915,6 +5915,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/scoria-light.css";
+</script>
+```
+
+## selenite-dark (`seleniteDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import seleniteDark from "svelte-highlight/styles/selenite-dark";
+</script>
+
+<svelte:head>
+  {@html seleniteDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/selenite-dark.css";
+</script>
+```
+
+## selenite-light (`seleniteLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import seleniteLight from "svelte-highlight/styles/selenite-light";
+</script>
+
+<svelte:head>
+  {@html seleniteLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/selenite-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 326 styles: 258 exported from highlight.js@11.12.0, 68 custom styles added by svelte-highlight
+> 328 styles: 258 exported from highlight.js@11.12.0, 70 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1625,6 +1625,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/classic-light.css";
+</script>
+```
+
+## cochineal-dark (`cochinealDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import cochinealDark from "svelte-highlight/styles/cochineal-dark";
+</script>
+
+<svelte:head>
+  {@html cochinealDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/cochineal-dark.css";
+</script>
+```
+
+## cochineal-light (`cochinealLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import cochinealLight from "svelte-highlight/styles/cochineal-light";
+</script>
+
+<svelte:head>
+  {@html cochinealLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/cochineal-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 328 styles: 258 exported from highlight.js@11.12.0, 70 custom styles added by svelte-highlight
+> 330 styles: 258 exported from highlight.js@11.12.0, 72 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4655,6 +4655,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/monokai-sublime.css";
+</script>
+```
+
+## motherboard-dark (`motherboardDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import motherboardDark from "svelte-highlight/styles/motherboard-dark";
+</script>
+
+<svelte:head>
+  {@html motherboardDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/motherboard-dark.css";
+</script>
+```
+
+## motherboard-light (`motherboardLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import motherboardLight from "svelte-highlight/styles/motherboard-light";
+</script>
+
+<svelte:head>
+  {@html motherboardLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/motherboard-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 322 styles: 258 exported from highlight.js@11.12.0, 64 custom styles added by svelte-highlight
+> 324 styles: 258 exported from highlight.js@11.12.0, 66 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -3923,6 +3923,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/kimbie-light.css";
+</script>
+```
+
+## kintsugi-dark (`kintsugiDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import kintsugiDark from "svelte-highlight/styles/kintsugi-dark";
+</script>
+
+<svelte:head>
+  {@html kintsugiDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/kintsugi-dark.css";
+</script>
+```
+
+## kintsugi-light (`kintsugiLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import kintsugiLight from "svelte-highlight/styles/kintsugi-light";
+</script>
+
+<svelte:head>
+  {@html kintsugiLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/kintsugi-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 324 styles: 258 exported from highlight.js@11.12.0, 66 custom styles added by svelte-highlight
+> 326 styles: 258 exported from highlight.js@11.12.0, 68 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6789,6 +6789,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/urushi-light.css";
+</script>
+```
+
+## verdigris-dark (`verdigrisDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import verdigrisDark from "svelte-highlight/styles/verdigris-dark";
+</script>
+
+<svelte:head>
+  {@html verdigrisDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/verdigris-dark.css";
+</script>
+```
+
+## verdigris-light (`verdigrisLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import verdigrisLight from "svelte-highlight/styles/verdigris-light";
+</script>
+
+<svelte:head>
+  {@html verdigrisLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/verdigris-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 346 styles: 258 exported from highlight.js@11.12.0, 88 custom styles added by svelte-highlight
+> 348 styles: 258 exported from highlight.js@11.12.0, 90 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2441,6 +2441,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/dracula.css";
+</script>
+```
+
+## dusk-dark (`duskDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import duskDark from "svelte-highlight/styles/dusk-dark";
+</script>
+
+<svelte:head>
+  {@html duskDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/dusk-dark.css";
+</script>
+```
+
+## dusk-light (`duskLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import duskLight from "svelte-highlight/styles/dusk-light";
+</script>
+
+<svelte:head>
+  {@html duskLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/dusk-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 344 styles: 258 exported from highlight.js@11.12.0, 86 custom styles added by svelte-highlight
+> 346 styles: 258 exported from highlight.js@11.12.0, 88 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -7269,6 +7269,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/verdigris-light.css";
+</script>
+```
+
+## vitriol-dark (`vitriolDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import vitriolDark from "svelte-highlight/styles/vitriol-dark";
+</script>
+
+<svelte:head>
+  {@html vitriolDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/vitriol-dark.css";
+</script>
+```
+
+## vitriol-light (`vitriolLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import vitriolLight from "svelte-highlight/styles/vitriol-light";
+</script>
+
+<svelte:head>
+  {@html vitriolLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/vitriol-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 336 styles: 258 exported from highlight.js@11.12.0, 78 custom styles added by svelte-highlight
+> 338 styles: 258 exported from highlight.js@11.12.0, 80 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -957,6 +957,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/atom-one-light.css";
+</script>
+```
+
+## bakelite-dark (`bakeliteDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import bakeliteDark from "svelte-highlight/styles/bakelite-dark";
+</script>
+
+<svelte:head>
+  {@html bakeliteDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/bakelite-dark.css";
+</script>
+```
+
+## bakelite-light (`bakeliteLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import bakeliteLight from "svelte-highlight/styles/bakelite-light";
+</script>
+
+<svelte:head>
+  {@html bakeliteLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/bakelite-light.css";
 </script>
 ```
 

--- a/SUPPORTED_STYLES.md
+++ b/SUPPORTED_STYLES.md
@@ -1,6 +1,6 @@
 # Supported Styles
 
-> 330 styles: 258 exported from highlight.js@11.12.0, 72 custom styles added by svelte-highlight
+> 332 styles: 258 exported from highlight.js@11.12.0, 74 custom styles added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6399,6 +6399,54 @@
 ```html
 <script>
   import "svelte-highlight/styles/tender.css";
+</script>
+```
+
+## terrazzo-dark (`terrazzoDark`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import terrazzoDark from "svelte-highlight/styles/terrazzo-dark";
+</script>
+
+<svelte:head>
+  {@html terrazzoDark}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/terrazzo-dark.css";
+</script>
+```
+
+## terrazzo-light (`terrazzoLight`)
+
+> Custom svelte-highlight style (not exported by highlight.js)
+
+**Injected Styles**
+
+```html
+<script>
+  import terrazzoLight from "svelte-highlight/styles/terrazzo-light";
+</script>
+
+<svelte:head>
+  {@html terrazzoLight}
+</svelte:head>
+```
+
+**CSS StyleSheet**
+
+```html
+<script>
+  import "svelte-highlight/styles/terrazzo-light.css";
 </script>
 ```
 

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 342 themes: 258 exported from highlight.js@11.12.0, 84 custom themes added by svelte-highlight
+> 344 themes: 258 exported from highlight.js@11.12.0, 86 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1951,6 +1951,60 @@
 </script>
 
 <HighlightStyle theme={classicLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## cobalt-dark (`cobaltDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/cobalt-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import cobaltDark from "svelte-highlight/themes/cobalt-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={cobaltDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## cobalt-light (`cobaltLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/cobalt-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import cobaltLight from "svelte-highlight/themes/cobalt-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={cobaltLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 340 themes: 258 exported from highlight.js@11.12.0, 82 custom themes added by svelte-highlight
+> 342 themes: 258 exported from highlight.js@11.12.0, 84 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -231,6 +231,60 @@
 </script>
 
 <HighlightStyle theme={alpenglowLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## amaranth-dark (`amaranthDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/amaranth-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import amaranthDark from "svelte-highlight/themes/amaranth-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={amaranthDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## amaranth-light (`amaranthLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/amaranth-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import amaranthLight from "svelte-highlight/themes/amaranth-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={amaranthLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 332 themes: 258 exported from highlight.js@11.12.0, 74 custom themes added by svelte-highlight
+> 334 themes: 258 exported from highlight.js@11.12.0, 76 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -3009,6 +3009,60 @@
 </script>
 
 <HighlightStyle theme={felipec}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## ferrofluid-dark (`ferrofluidDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/ferrofluid-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import ferrofluidDark from "svelte-highlight/themes/ferrofluid-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={ferrofluidDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## ferrofluid-light (`ferrofluidLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/ferrofluid-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import ferrofluidLight from "svelte-highlight/themes/ferrofluid-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={ferrofluidLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 336 themes: 258 exported from highlight.js@11.12.0, 78 custom themes added by svelte-highlight
+> 338 themes: 258 exported from highlight.js@11.12.0, 80 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1085,6 +1085,60 @@
 </script>
 
 <HighlightStyle theme={atomOneLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## bakelite-dark (`bakeliteDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/bakelite-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import bakeliteDark from "svelte-highlight/themes/bakelite-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={bakeliteDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## bakelite-light (`bakeliteLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/bakelite-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import bakeliteLight from "svelte-highlight/themes/bakelite-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={bakeliteLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 334 themes: 258 exported from highlight.js@11.12.0, 76 custom themes added by svelte-highlight
+> 336 themes: 258 exported from highlight.js@11.12.0, 78 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -7110,6 +7110,60 @@
 </script>
 
 <HighlightStyle theme={sumiLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## suminagashi-dark (`suminagashiDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/suminagashi-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import suminagashiDark from "svelte-highlight/themes/suminagashi-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={suminagashiDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## suminagashi-light (`suminagashiLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/suminagashi-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import suminagashiLight from "svelte-highlight/themes/suminagashi-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={suminagashiLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 330 themes: 258 exported from highlight.js@11.12.0, 72 custom themes added by svelte-highlight
+> 332 themes: 258 exported from highlight.js@11.12.0, 74 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -7256,6 +7256,60 @@
 </script>
 
 <HighlightStyle theme={tender}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## terrazzo-dark (`terrazzoDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/terrazzo-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import terrazzoDark from "svelte-highlight/themes/terrazzo-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={terrazzoDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## terrazzo-light (`terrazzoLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/terrazzo-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import terrazzoLight from "svelte-highlight/themes/terrazzo-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={terrazzoLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 326 themes: 258 exported from highlight.js@11.12.0, 68 custom themes added by svelte-highlight
+> 328 themes: 258 exported from highlight.js@11.12.0, 70 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -1843,6 +1843,60 @@
 </script>
 
 <HighlightStyle theme={classicLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## cochineal-dark (`cochinealDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/cochineal-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import cochinealDark from "svelte-highlight/themes/cochineal-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={cochinealDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## cochineal-light (`cochinealLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/cochineal-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import cochinealLight from "svelte-highlight/themes/cochineal-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={cochinealLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 324 themes: 258 exported from highlight.js@11.12.0, 66 custom themes added by svelte-highlight
+> 326 themes: 258 exported from highlight.js@11.12.0, 68 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -7697,6 +7697,60 @@
 </script>
 
 <HighlightStyle theme={urushiLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## verdigris-dark (`verdigrisDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/verdigris-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import verdigrisDark from "svelte-highlight/themes/verdigris-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={verdigrisDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## verdigris-light (`verdigrisLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/verdigris-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import verdigrisLight from "svelte-highlight/themes/verdigris-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={verdigrisLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 322 themes: 258 exported from highlight.js@11.12.0, 64 custom themes added by svelte-highlight
+> 324 themes: 258 exported from highlight.js@11.12.0, 66 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -4450,6 +4450,60 @@
 </script>
 
 <HighlightStyle theme={kimbieLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## kintsugi-dark (`kintsugiDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/kintsugi-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import kintsugiDark from "svelte-highlight/themes/kintsugi-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={kintsugiDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## kintsugi-light (`kintsugiLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/kintsugi-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import kintsugiLight from "svelte-highlight/themes/kintsugi-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={kintsugiLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 328 themes: 258 exported from highlight.js@11.12.0, 70 custom themes added by svelte-highlight
+> 330 themes: 258 exported from highlight.js@11.12.0, 72 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -5278,6 +5278,60 @@
 </script>
 
 <HighlightStyle theme={monokaiSublime}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## motherboard-dark (`motherboardDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/motherboard-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import motherboardDark from "svelte-highlight/themes/motherboard-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={motherboardDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## motherboard-light (`motherboardLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/motherboard-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import motherboardLight from "svelte-highlight/themes/motherboard-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={motherboardLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 338 themes: 258 exported from highlight.js@11.12.0, 80 custom themes added by svelte-highlight
+> 340 themes: 258 exported from highlight.js@11.12.0, 82 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -6706,6 +6706,60 @@
 </script>
 
 <HighlightStyle theme={scoriaLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## selenite-dark (`seleniteDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/selenite-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import seleniteDark from "svelte-highlight/themes/selenite-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={seleniteDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## selenite-light (`seleniteLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/selenite-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import seleniteLight from "svelte-highlight/themes/selenite-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={seleniteLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 344 themes: 258 exported from highlight.js@11.12.0, 86 custom themes added by svelte-highlight
+> 346 themes: 258 exported from highlight.js@11.12.0, 88 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -8237,6 +8237,60 @@
 </script>
 
 <HighlightStyle theme={verdigrisLight}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## vitriol-dark (`vitriolDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/vitriol-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import vitriolDark from "svelte-highlight/themes/vitriol-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={vitriolDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## vitriol-light (`vitriolLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/vitriol-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import vitriolLight from "svelte-highlight/themes/vitriol-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={vitriolLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/SUPPORTED_THEMES.md
+++ b/SUPPORTED_THEMES.md
@@ -1,6 +1,6 @@
 # Supported Themes
 
-> 346 themes: 258 exported from highlight.js@11.12.0, 88 custom themes added by svelte-highlight
+> 348 themes: 258 exported from highlight.js@11.12.0, 90 custom themes added by svelte-highlight
 
 ## 1c-light (`_1cLight`)
 
@@ -2767,6 +2767,60 @@
 </script>
 
 <HighlightStyle theme={dracula}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## dusk-dark (`duskDark`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/dusk-dark.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import duskDark from "svelte-highlight/themes/dusk-dark";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={duskDark}>
+  <Highlight ... />
+</HighlightStyle>
+```
+
+## dusk-light (`duskLight`)
+
+> Custom svelte-highlight theme (not exported by highlight.js)
+
+**CSS variables (global)**
+
+```html
+<script>
+  import "svelte-highlight/themes/base.css";
+  import "svelte-highlight/themes/dusk-light.css";
+</script>
+```
+
+**Palette object**
+
+```svelte
+<script>
+  import { HighlightStyle } from "svelte-highlight";
+  import duskLight from "svelte-highlight/themes/dusk-light";
+  import "svelte-highlight/themes/base.css";
+</script>
+
+<HighlightStyle theme={duskLight}>
   <Highlight ... />
 </HighlightStyle>
 ```

--- a/scripts/custom-styles/amaranth-dark.css
+++ b/scripts/custom-styles/amaranth-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Amaranth Dark
+  Description: Amaranth pigment: deep magenta-violet on near-black with a warm gold accent
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #150c14
+  fg:       #ecd8e8
+  comment:  #8a6a84
+  magenta:  #d43f8a
+  gold:     #d4a02e
+  violet:   #b06fd4
+  amber:    #e0854a
+  rose:     #c85a9e
+  brightmagenta: #e85fa4
+  tan:      #cfa66e
+*/
+.hljs {
+  color: #ecd8e8;
+  background: #150c14;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a6a84;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #d43f8a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #d4a02e;
+}
+.hljs-literal {
+  color: #b06fd4;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #e0854a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c85a9e;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #e85fa4;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #cfa66e;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #ecd8e8;
+}
+.hljs-code {
+  color: #8a6a84;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #cde0b8;
+  background-color: #1c2814;
+}
+.hljs-deletion {
+  color: #f0a8a8;
+  background-color: #301418;
+}

--- a/scripts/custom-styles/amaranth-light.css
+++ b/scripts/custom-styles/amaranth-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Amaranth Light
+  Description: Amaranth pigment on parchment: deep magenta-violet with warm gold
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f5ecf3
+  fg:       #2c1428
+  comment:  #8a6e86
+  magenta:  #a01f5e
+  gold:     #8a5a0e
+  violet:   #6a2f8a
+  amber:    #8a4a1a
+  rose:     #942f6e
+  darkmagenta: #7a1a52
+  bronze:   #6b4a24
+*/
+.hljs {
+  color: #2c1428;
+  background: #f5ecf3;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a6e86;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #a01f5e;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #8a5a0e;
+}
+.hljs-literal {
+  color: #6a2f8a;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a4a1a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #942f6e;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #7a1a52;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6b4a24;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2c1428;
+}
+.hljs-code {
+  color: #8a6e86;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #244010;
+  background-color: #dce8cc;
+}
+.hljs-deletion {
+  color: #7a1414;
+  background-color: #f2d4d0;
+}

--- a/scripts/custom-styles/bakelite-dark.css
+++ b/scripts/custom-styles/bakelite-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Bakelite Dark
+  Description: Vintage maroon radio plastic: deep brown-red with butterscotch controls
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #1c110d
+  fg:       #ecd8b8
+  comment:  #8a6a58
+  amber:    #d68a2e
+  maroon:   #b8442e
+  caramel:  #d4b06a
+  burnt:    #c46a3a
+  bronze:   #a86e3e
+  brightamber: #e0a24a
+  tan:      #cfa66e
+*/
+.hljs {
+  color: #ecd8b8;
+  background: #1c110d;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a6a58;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #d68a2e;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #b8442e;
+}
+.hljs-literal {
+  color: #d4b06a;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c46a3a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #a86e3e;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #e0a24a;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #cfa66e;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #ecd8b8;
+}
+.hljs-code {
+  color: #8a6a58;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d8cf9a;
+  background-color: #241c10;
+}
+.hljs-deletion {
+  color: #e0a08c;
+  background-color: #341612;
+}

--- a/scripts/custom-styles/bakelite-light.css
+++ b/scripts/custom-styles/bakelite-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Bakelite Light
+  Description: Cream butterscotch plastic: warm amber tones on vintage cream
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f2e6cc
+  fg:       #2e1c10
+  comment:  #8a6f4e
+  amber:    #8a4a10
+  maroon:   #7a281a
+  caramel:  #6b4a1e
+  burnt:    #8a3e1a
+  bronze:   #6b4424
+  darkamber: #7a4e12
+  ochre:    #5c3f1e
+*/
+.hljs {
+  color: #2e1c10;
+  background: #f2e6cc;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a6f4e;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #8a4a10;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #7a281a;
+}
+.hljs-literal {
+  color: #6b4a1e;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a3e1a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6b4424;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #7a4e12;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #5c3f1e;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2e1c10;
+}
+.hljs-code {
+  color: #8a6f4e;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #2f4014;
+  background-color: #e0e0c0;
+}
+.hljs-deletion {
+  color: #6e2010;
+  background-color: #f0d4c4;
+}

--- a/scripts/custom-styles/cobalt-dark.css
+++ b/scripts/custom-styles/cobalt-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Cobalt Dark
+  Description: Saturated ultramarine glass: deep blue base with warm gold accents
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #16294f
+  fg:       #dce8f5
+  comment:  #6a84a8
+  gold:     #eab04a
+  copper:   #e0855a
+  cyan:     #8fd0e0
+  cream:    #e8cf8a
+  sky:      #7ab4dc
+  paleblue: #a8c8ec
+  palegold: #f0d9a0
+*/
+.hljs {
+  color: #dce8f5;
+  background: #16294f;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a84a8;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #eab04a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e0855a;
+}
+.hljs-literal {
+  color: #8fd0e0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #e8cf8a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #7ab4dc;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #a8c8ec;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #f0d9a0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #dce8f5;
+}
+.hljs-code {
+  color: #6a84a8;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #b8e8cc;
+  background-color: #163a2c;
+}
+.hljs-deletion {
+  color: #f0a8a0;
+  background-color: #4a2018;
+}

--- a/scripts/custom-styles/cobalt-light.css
+++ b/scripts/custom-styles/cobalt-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Cobalt Light
+  Description: Pale cobalt glass: cool blue-tinted white with deep ultramarine ink
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #eaf0fa
+  fg:       #16223a
+  comment:  #6a7f9e
+  gold:     #8a5a12
+  copper:   #a8481e
+  cyan:     #1a6e8a
+  brass:    #8a6e1e
+  cobalt:   #1f5e8a
+  indigo:   #143a6e
+  bronze:   #6b5424
+*/
+.hljs {
+  color: #16223a;
+  background: #eaf0fa;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a7f9e;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #8a5a12;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a8481e;
+}
+.hljs-literal {
+  color: #1a6e8a;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a6e1e;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #1f5e8a;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #143a6e;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6b5424;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #16223a;
+}
+.hljs-code {
+  color: #6a7f9e;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #14401f;
+  background-color: #d4e8da;
+}
+.hljs-deletion {
+  color: #7a2414;
+  background-color: #f0d6cc;
+}

--- a/scripts/custom-styles/cochineal-dark.css
+++ b/scripts/custom-styles/cochineal-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Cochineal Dark
+  Description: Dyer's crimson: deep wine black with scarlet and mauve pigment tones
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #180d0e
+  fg:       #ecd8d4
+  comment:  #8a6a68
+  crimson:  #d43f5a
+  saffron:  #e0834a
+  mauve:    #b06fae
+  gold:     #d99a56
+  rose:     #c85a6e
+  scarlet:  #e85f74
+  tan:      #caa06e
+*/
+.hljs {
+  color: #ecd8d4;
+  background: #180d0e;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a6a68;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #d43f5a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e0834a;
+}
+.hljs-literal {
+  color: #b06fae;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #d99a56;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c85a6e;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #e85f74;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #caa06e;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #ecd8d4;
+}
+.hljs-code {
+  color: #8a6a68;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #cde0b8;
+  background-color: #1c2814;
+}
+.hljs-deletion {
+  color: #f0a8a8;
+  background-color: #3a1418;
+}

--- a/scripts/custom-styles/cochineal-light.css
+++ b/scripts/custom-styles/cochineal-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Cochineal Light
+  Description: Dyer's crimson on parchment: deep scarlet and plum on warm cream
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f5eceb
+  fg:       #2c1214
+  comment:  #8a6e6c
+  crimson:  #a8203c
+  burnt:    #a85a1e
+  plum:     #7a3f78
+  gold:     #8a5a1a
+  rose:     #942f48
+  darkred:  #7a1a2e
+  bronze:   #6b4a24
+*/
+.hljs {
+  color: #2c1214;
+  background: #f5eceb;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a6e6c;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #a8203c;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a85a1e;
+}
+.hljs-literal {
+  color: #7a3f78;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a5a1a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #942f48;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #7a1a2e;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6b4a24;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2c1214;
+}
+.hljs-code {
+  color: #8a6e6c;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #244010;
+  background-color: #dce8cc;
+}
+.hljs-deletion {
+  color: #7a1414;
+  background-color: #f2d4d0;
+}

--- a/scripts/custom-styles/dusk-dark.css
+++ b/scripts/custom-styles/dusk-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Dusk Dark
+  Description: Twilight slate: a midtone violet-blue base, not near-black, with amber accents
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #524c6e
+  fg:       #f0e8dc
+  comment:  #9488ac
+  amber:    #f0b45a
+  coral:    #e8845a
+  cyan:     #8fd4e0
+  gold:     #f0d090
+  violet:   #c49cd4
+  brightamber: #f5c87a
+  tan:      #e8c8a0
+*/
+.hljs {
+  color: #f0e8dc;
+  background: #524c6e;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #9488ac;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #f0b45a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e8845a;
+}
+.hljs-literal {
+  color: #8fd4e0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #f0d090;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #c49cd4;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #f5c87a;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #e8c8a0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #f0e8dc;
+}
+.hljs-code {
+  color: #9488ac;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8e8b0;
+  background-color: #2c3c24;
+}
+.hljs-deletion {
+  color: #f0a8a0;
+  background-color: #3c2438;
+}

--- a/scripts/custom-styles/dusk-light.css
+++ b/scripts/custom-styles/dusk-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Dusk Light
+  Description: Overcast lavender-gray, not stark white, with deep amber and coral ink
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #c2bcd8
+  fg:       #241c34
+  comment:  #6a5e84
+  amber:    #7a3e0e
+  coral:    #8a3418
+  teal:     #155a6e
+  brass:    #7a5a10
+  violet:   #5a3a6e
+  darkamber: #6a4008
+  bronze:   #5a4428
+*/
+.hljs {
+  color: #241c34;
+  background: #c2bcd8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a5e84;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #7a3e0e;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #8a3418;
+}
+.hljs-literal {
+  color: #155a6e;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7a5a10;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #5a3a6e;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #6a4008;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #5a4428;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #241c34;
+}
+.hljs-code {
+  color: #6a5e84;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1f4014;
+  background-color: #d4e0c0;
+}
+.hljs-deletion {
+  color: #6e1c14;
+  background-color: #ecd0d8;
+}

--- a/scripts/custom-styles/ferrofluid-dark.css
+++ b/scripts/custom-styles/ferrofluid-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Ferrofluid Dark
+  Description: Magnetic black liquid: gunmetal spikes with a sharp magenta/cyan glow
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #0d0d10
+  fg:       #d4d6dc
+  comment:  #6a6d78
+  gunmetal: #8f97a8
+  magenta:  #ff3fa0
+  cyan:     #4fd8e0
+  steel:    #a8adba
+  slate:    #6b7488
+  brightmagenta: #ff6fc0
+  palesteel: #b8bccc
+*/
+.hljs {
+  color: #d4d6dc;
+  background: #0d0d10;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6a6d78;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #8f97a8;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #ff3fa0;
+}
+.hljs-literal {
+  color: #4fd8e0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #a8adba;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6b7488;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #ff6fc0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #b8bccc;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #d4d6dc;
+}
+.hljs-code {
+  color: #6a6d78;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #a8e8d8;
+  background-color: #10201c;
+}
+.hljs-deletion {
+  color: #ff8fae;
+  background-color: #2c1420;
+}

--- a/scripts/custom-styles/ferrofluid-light.css
+++ b/scripts/custom-styles/ferrofluid-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Ferrofluid Light
+  Description: Magnetic ink on white paper: steel-blue spikes with a deep magenta/cyan accent
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f0f0f2
+  fg:       #1a1a1e
+  comment:  #757a86
+  steelblue: #4a5468
+  magenta:  #b8135f
+  cyan:     #146e78
+  steel:    #565c6c
+  slate:    #3a4256
+  darkmagenta: #94104a
+  charcoal: #363a46
+*/
+.hljs {
+  color: #1a1a1e;
+  background: #f0f0f2;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #757a86;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #4a5468;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #b8135f;
+}
+.hljs-literal {
+  color: #146e78;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #565c6c;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #3a4256;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #94104a;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #363a46;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1a1a1e;
+}
+.hljs-code {
+  color: #757a86;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #146048;
+  background-color: #d4ece0;
+}
+.hljs-deletion {
+  color: #94143a;
+  background-color: #f4d6e0;
+}

--- a/scripts/custom-styles/haar-dark.css
+++ b/scripts/custom-styles/haar-dark.css
@@ -8,40 +8,40 @@ code.hljs {
 }
 /*
   Theme: Haar Dark
-  Description: North Sea fog. Almost no chroma, a wet green-gray
+  Description: North Sea fog at dusk. Almost no chroma, a cold violet-gray
   Author: svelte-highlight
   License: MIT
 */
 .hljs {
-  color: #c8d0d0;
-  background: #1a1c1c;
+  color: #d0ccda;
+  background: #191820;
 }
 .hljs-comment,
 .hljs-quote {
-  color: #6a7474;
+  color: #726e82;
   font-style: italic;
 }
 .hljs-doctag,
 .hljs-keyword,
 .hljs-formula,
 .hljs-template-tag {
-  color: #8a9a98;
+  color: #8c86a2;
 }
 .hljs-section,
 .hljs-name,
 .hljs-selector-tag,
 .hljs-tag,
 .hljs-subst {
-  color: #8a9a98;
+  color: #a4948e;
 }
 .hljs-literal {
-  color: #9aa8a4;
+  color: #9a92ac;
 }
 .hljs-string,
 .hljs-regexp,
 .hljs-attribute,
 .hljs-meta .hljs-string {
-  color: #7a8a84;
+  color: #a49484;
 }
 .hljs-attr,
 .hljs-variable,
@@ -52,7 +52,7 @@ code.hljs {
 .hljs-selector-attr,
 .hljs-selector-pseudo,
 .hljs-number {
-  color: #889090;
+  color: #847ea0;
 }
 .hljs-symbol,
 .hljs-bullet,
@@ -60,19 +60,19 @@ code.hljs {
 .hljs-meta,
 .hljs-selector-id,
 .hljs-title {
-  color: #a0a8a8;
+  color: #ada4c0;
 }
 .hljs-built_in,
 .hljs-title.class_,
 .hljs-class .hljs-title {
-  color: #889090;
+  color: #ac9c8a;
 }
 .hljs-punctuation,
 .hljs-operator {
-  color: #c8d0d0;
+  color: #d0ccda;
 }
 .hljs-code {
-  color: #6a7474;
+  color: #726e82;
 }
 .hljs-emphasis {
   font-style: italic;

--- a/scripts/custom-styles/haar-light.css
+++ b/scripts/custom-styles/haar-light.css
@@ -8,40 +8,40 @@ code.hljs {
 }
 /*
   Theme: Haar Light
-  Description: Haar at noon. Cold green-gray, barely a dye at all
+  Description: Haar at noon. Cold violet-gray, barely a dye at all
   Author: svelte-highlight
   License: MIT
 */
 .hljs {
-  color: #2a2e2e;
-  background: #e8ecec;
+  color: #28242f;
+  background: #ecebf1;
 }
 .hljs-comment,
 .hljs-quote {
-  color: #7a8484;
+  color: #7c7890;
   font-style: italic;
 }
 .hljs-doctag,
 .hljs-keyword,
 .hljs-formula,
 .hljs-template-tag {
-  color: #3a4a48;
+  color: #423c56;
 }
 .hljs-section,
 .hljs-name,
 .hljs-selector-tag,
 .hljs-tag,
 .hljs-subst {
-  color: #3a4a48;
+  color: #584c40;
 }
 .hljs-literal {
-  color: #4a5854;
+  color: #4c4460;
 }
 .hljs-string,
 .hljs-regexp,
 .hljs-attribute,
 .hljs-meta .hljs-string {
-  color: #3a4a42;
+  color: #5a4c3c;
 }
 .hljs-attr,
 .hljs-variable,
@@ -52,7 +52,7 @@ code.hljs {
 .hljs-selector-attr,
 .hljs-selector-pseudo,
 .hljs-number {
-  color: #3a4444;
+  color: #383050;
 }
 .hljs-symbol,
 .hljs-bullet,
@@ -60,19 +60,19 @@ code.hljs {
 .hljs-meta,
 .hljs-selector-id,
 .hljs-title {
-  color: #2a3838;
+  color: #201c30;
 }
 .hljs-built_in,
 .hljs-title.class_,
 .hljs-class .hljs-title {
-  color: #3a4444;
+  color: #48402f;
 }
 .hljs-punctuation,
 .hljs-operator {
-  color: #2a2e2e;
+  color: #28242f;
 }
 .hljs-code {
-  color: #7a8484;
+  color: #7c7890;
 }
 .hljs-emphasis {
   font-style: italic;

--- a/scripts/custom-styles/kintsugi-dark.css
+++ b/scripts/custom-styles/kintsugi-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Kintsugi Dark
+  Description: Gold-mended lacquer: black ceramic base with gilded seams
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #17140f
+  fg:       #e8dcc8
+  comment:  #7a6f5c
+  gold:     #c9a44e
+  seam:     #c96f4a
+  glaze:    #8fa7ad
+  amber:    #e0b25c
+  bronze:   #b98a4e
+  brightgold: #f0c869
+  ivory:    #ead9a8
+*/
+.hljs {
+  color: #e8dcc8;
+  background: #17140f;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a6f5c;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c9a44e;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #c96f4a;
+}
+.hljs-literal {
+  color: #8fa7ad;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #e0b25c;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #b98a4e;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #f0c869;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #ead9a8;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e8dcc8;
+}
+.hljs-code {
+  color: #7a6f5c;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #d9c98a;
+  background-color: #2a2415;
+}
+.hljs-deletion {
+  color: #e0a08c;
+  background-color: #3a1f18;
+}

--- a/scripts/custom-styles/kintsugi-light.css
+++ b/scripts/custom-styles/kintsugi-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Kintsugi Light
+  Description: Porcelain repaired in gold: ivory glaze with gilded crack lines
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f2ece0
+  fg:       #2b2418
+  comment:  #8a7d68
+  gold:     #9c7a1f
+  seam:     #a8492c
+  glaze:    #3d6670
+  amber:    #8a5a1a
+  bronze:   #6b4f24
+  darkgold: #7a5c14
+  ochre:    #5c4a1e
+*/
+.hljs {
+  color: #2b2418;
+  background: #f2ece0;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a7d68;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #9c7a1f;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a8492c;
+}
+.hljs-literal {
+  color: #3d6670;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a5a1a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6b4f24;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #7a5c14;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #5c4a1e;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2b2418;
+}
+.hljs-code {
+  color: #8a7d68;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #2f4a1f;
+  background-color: #dce8d0;
+}
+.hljs-deletion {
+  color: #7a2418;
+  background-color: #f0d8d0;
+}

--- a/scripts/custom-styles/motherboard-dark.css
+++ b/scripts/custom-styles/motherboard-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Motherboard Dark
+  Description: PCB substrate: matte green-black with gold traces and silver solder
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #0c1712
+  fg:       #cbe0c4
+  comment:  #5f7a5c
+  gold:     #d1a934
+  copper:   #d97f4a
+  silver:   #a8b8bc
+  palegold: #e6cd7a
+  pcbgreen: #7fbf87
+  icblue:   #8fd0d4
+  silkscreen: #d8dcc0
+*/
+.hljs {
+  color: #cbe0c4;
+  background: #0c1712;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #5f7a5c;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #d1a934;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #d97f4a;
+}
+.hljs-literal {
+  color: #a8b8bc;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #e6cd7a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #7fbf87;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #8fd0d4;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #d8dcc0;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #cbe0c4;
+}
+.hljs-code {
+  color: #5f7a5c;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #b8e8b0;
+  background-color: #14251a;
+}
+.hljs-deletion {
+  color: #e8a89c;
+  background-color: #2c1815;
+}

--- a/scripts/custom-styles/motherboard-light.css
+++ b/scripts/custom-styles/motherboard-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Motherboard Light
+  Description: White soldermask PCB: pale board with copper and dark PCB-green ink
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #eef2ea
+  fg:       #1a241a
+  comment:  #66795f
+  gold:     #8a6a14
+  copper:   #a8501e
+  silver:   #4a5a5e
+  darkgold: #8a6e1e
+  pcbgreen: #2f6e3a
+  icblue:   #1e6a70
+  silkscreen: #4a5230
+*/
+.hljs {
+  color: #1a241a;
+  background: #eef2ea;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #66795f;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #8a6a14;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a8501e;
+}
+.hljs-literal {
+  color: #4a5a5e;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a6e1e;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #2f6e3a;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #1e6a70;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #4a5230;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1a241a;
+}
+.hljs-code {
+  color: #66795f;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1f4014;
+  background-color: #d8e8cc;
+}
+.hljs-deletion {
+  color: #7a2414;
+  background-color: #f0d6cc;
+}

--- a/scripts/custom-styles/selenite-dark.css
+++ b/scripts/custom-styles/selenite-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Selenite Dark
+  Description: Moonlit crystal cave: deep indigo-black with pale violet crystal glow
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #14131a
+  fg:       #e4e0ec
+  comment:  #7d7690
+  violet:   #a894dc
+  mauve:    #d494bc
+  blue:     #86b4dc
+  lilac:    #c4a8dc
+  periwinkle: #94a8dc
+  indigo:   #b4c0ec
+  dustymauve: #b8a8bc
+*/
+.hljs {
+  color: #e4e0ec;
+  background: #14131a;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7d7690;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #a894dc;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #d494bc;
+}
+.hljs-literal {
+  color: #86b4dc;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c4a8dc;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #94a8dc;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #b4c0ec;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #b8a8bc;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e4e0ec;
+}
+.hljs-code {
+  color: #7d7690;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #b8e8b0;
+  background-color: #182418;
+}
+.hljs-deletion {
+  color: #f0a8c8;
+  background-color: #301622;
+}

--- a/scripts/custom-styles/selenite-light.css
+++ b/scripts/custom-styles/selenite-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Selenite Light
+  Description: Translucent crystal: pale lavender-white with soft ethereal violets
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f4f1f8
+  fg:       #2c2a34
+  comment:  #837e94
+  violet:   #6a5aa0
+  mauve:    #a05a8a
+  blue:     #4a7aa0
+  lilac:    #8a6ea0
+  periwinkle: #5a6ea0
+  indigo:   #4a5a94
+  dustymauve: #6b5a74
+*/
+.hljs {
+  color: #2c2a34;
+  background: #f4f1f8;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #837e94;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #6a5aa0;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a05a8a;
+}
+.hljs-literal {
+  color: #4a7aa0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a6ea0;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #5a6ea0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #4a5a94;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6b5a74;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2c2a34;
+}
+.hljs-code {
+  color: #837e94;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #244a20;
+  background-color: #d8ecd0;
+}
+.hljs-deletion {
+  color: #7a2040;
+  background-color: #f2d8e4;
+}

--- a/scripts/custom-styles/suminagashi-dark.css
+++ b/scripts/custom-styles/suminagashi-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Suminagashi Dark
+  Description: Ink pool at night: swirls of teal, crimson, and violet glow on black water
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #15130f
+  fg:       #ece4d0
+  comment:  #8f8570
+  teal:     #4fc4d4
+  crimson:  #e0576e
+  violet:   #a68adf
+  gold:     #e0a94a
+  green:    #6ecb8e
+  brightteal: #7ad4e0
+  sepia:    #cbb888
+*/
+.hljs {
+  color: #ece4d0;
+  background: #15130f;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8f8570;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #4fc4d4;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #e0576e;
+}
+.hljs-literal {
+  color: #a68adf;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #e0a94a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6ecb8e;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #7ad4e0;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #cbb888;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #ece4d0;
+}
+.hljs-code {
+  color: #8f8570;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #b8e8b0;
+  background-color: #182418;
+}
+.hljs-deletion {
+  color: #f0a8a8;
+  background-color: #301616;
+}

--- a/scripts/custom-styles/suminagashi-light.css
+++ b/scripts/custom-styles/suminagashi-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Suminagashi Light
+  Description: Marbled washi paper: swirled jewel-tone ink on warm cream
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f2ebd9
+  fg:       #2a241a
+  comment:  #8a8068
+  teal:     #1e6e7a
+  crimson:  #a8283c
+  violet:   #6b4fa0
+  gold:     #a8701e
+  green:    #2f6e50
+  darkteal: #174a5e
+  sepia:    #5c4a24
+*/
+.hljs {
+  color: #2a241a;
+  background: #f2ebd9;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a8068;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #1e6e7a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a8283c;
+}
+.hljs-literal {
+  color: #6b4fa0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #a8701e;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #2f6e50;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #174a5e;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #5c4a24;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a241a;
+}
+.hljs-code {
+  color: #8a8068;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1f4014;
+  background-color: #dce8cc;
+}
+.hljs-deletion {
+  color: #7a1414;
+  background-color: #f2d4d0;
+}

--- a/scripts/custom-styles/terrazzo-dark.css
+++ b/scripts/custom-styles/terrazzo-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Terrazzo Dark
+  Description: Polished dark terrazzo floor: black matrix flecked with bright chips
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #1a1816
+  fg:       #e8e4dc
+  comment:  #8f887c
+  coral:    #e8607e
+  teal:     #4fc4b0
+  mustard:  #e0ac4a
+  violet:   #a68adf
+  green:    #6ecb7a
+  terracotta: #e07a4a
+  stone:    #cfc9ba
+*/
+.hljs {
+  color: #e8e4dc;
+  background: #1a1816;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8f887c;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #e8607e;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #4fc4b0;
+}
+.hljs-literal {
+  color: #e0ac4a;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #a68adf;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #6ecb7a;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #e07a4a;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #cfc9ba;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e8e4dc;
+}
+.hljs-code {
+  color: #8f887c;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #b8e8b0;
+  background-color: #182818;
+}
+.hljs-deletion {
+  color: #f0a8a8;
+  background-color: #301616;
+}

--- a/scripts/custom-styles/terrazzo-light.css
+++ b/scripts/custom-styles/terrazzo-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Terrazzo Light
+  Description: Poured concrete floor: white matrix flecked with coral, teal, and gold chips
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f4f1ec
+  fg:       #2a2622
+  comment:  #8a8378
+  coral:    #c23b5a
+  teal:     #1f7a6c
+  mustard:  #b8862a
+  violet:   #6b4fa0
+  green:    #2f6e3a
+  terracotta: #a8481f
+  charcoal: #4a4740
+*/
+.hljs {
+  color: #2a2622;
+  background: #f4f1ec;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a8378;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #c23b5a;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #1f7a6c;
+}
+.hljs-literal {
+  color: #b8862a;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #6b4fa0;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #2f6e3a;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #a8481f;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #4a4740;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #2a2622;
+}
+.hljs-code {
+  color: #8a8378;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1f4014;
+  background-color: #dce8cc;
+}
+.hljs-deletion {
+  color: #7a1414;
+  background-color: #f2d4d0;
+}

--- a/scripts/custom-styles/verdigris-dark.css
+++ b/scripts/custom-styles/verdigris-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Verdigris Dark
+  Description: Oxidized copper: patina blue-green with exposed copper accents
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #101c1a
+  fg:       #cfe8de
+  comment:  #6f8f86
+  patina:   #4fae8e
+  copper:   #d9895a
+  aqua:     #7bc4c4
+  brass:    #c9a15a
+  teal:     #5fae9e
+  mint:     #8fd4b8
+  tan:      #e0b98a
+*/
+.hljs {
+  color: #cfe8de;
+  background: #101c1a;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6f8f86;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #4fae8e;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #d9895a;
+}
+.hljs-literal {
+  color: #7bc4c4;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #c9a15a;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #5fae9e;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #8fd4b8;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #e0b98a;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #cfe8de;
+}
+.hljs-code {
+  color: #6f8f86;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #b8e8cc;
+  background-color: #14281f;
+}
+.hljs-deletion {
+  color: #e8b8a0;
+  background-color: #3a2016;
+}

--- a/scripts/custom-styles/verdigris-dark.css
+++ b/scripts/custom-styles/verdigris-dark.css
@@ -8,51 +8,51 @@ code.hljs {
 }
 /*
   Theme: Verdigris Dark
-  Description: Oxidized copper: patina blue-green with exposed copper accents
+  Description: Oxidized copper: cerulean-blue patina with exposed copper accents
   Author: svelte-highlight
   License: MIT
 
-  bg:       #101c1a
-  fg:       #cfe8de
-  comment:  #6f8f86
-  patina:   #4fae8e
-  copper:   #d9895a
-  aqua:     #7bc4c4
-  brass:    #c9a15a
-  teal:     #5fae9e
-  mint:     #8fd4b8
-  tan:      #e0b98a
+  bg:       #0c1a1e
+  fg:       #cfe6ec
+  comment:  #6a8992
+  patina:   #3f9aae
+  copper:   #d97a48
+  cerulean: #6fb8d4
+  brass:    #c99450
+  teal:     #4a96a8
+  brightcerulean: #7fc8d8
+  tan:      #dcb478
 */
 .hljs {
-  color: #cfe8de;
-  background: #101c1a;
+  color: #cfe6ec;
+  background: #0c1a1e;
 }
 .hljs-comment,
 .hljs-quote {
-  color: #6f8f86;
+  color: #6a8992;
   font-style: italic;
 }
 .hljs-doctag,
 .hljs-keyword,
 .hljs-formula,
 .hljs-template-tag {
-  color: #4fae8e;
+  color: #3f9aae;
 }
 .hljs-section,
 .hljs-name,
 .hljs-selector-tag,
 .hljs-tag,
 .hljs-subst {
-  color: #d9895a;
+  color: #d97a48;
 }
 .hljs-literal {
-  color: #7bc4c4;
+  color: #6fb8d4;
 }
 .hljs-string,
 .hljs-regexp,
 .hljs-attribute,
 .hljs-meta .hljs-string {
-  color: #c9a15a;
+  color: #c99450;
 }
 .hljs-attr,
 .hljs-variable,
@@ -63,7 +63,7 @@ code.hljs {
 .hljs-selector-attr,
 .hljs-selector-pseudo,
 .hljs-number {
-  color: #5fae9e;
+  color: #4a96a8;
 }
 .hljs-symbol,
 .hljs-bullet,
@@ -71,19 +71,19 @@ code.hljs {
 .hljs-meta,
 .hljs-selector-id,
 .hljs-title {
-  color: #8fd4b8;
+  color: #7fc8d8;
 }
 .hljs-built_in,
 .hljs-title.class_,
 .hljs-class .hljs-title {
-  color: #e0b98a;
+  color: #dcb478;
 }
 .hljs-punctuation,
 .hljs-operator {
-  color: #cfe8de;
+  color: #cfe6ec;
 }
 .hljs-code {
-  color: #6f8f86;
+  color: #6a8992;
 }
 .hljs-emphasis {
   font-style: italic;

--- a/scripts/custom-styles/verdigris-light.css
+++ b/scripts/custom-styles/verdigris-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Verdigris Light
+  Description: Weathered copper roofing: pale patina with burnt copper accents
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #eef4f1
+  fg:       #1c2c28
+  comment:  #6c7f79
+  patina:   #1f6e56
+  copper:   #a85526
+  teal:     #21707a
+  brass:    #7a5a1e
+  darkteal: #2a6e60
+  deeppatina: #175c48
+  bronze:   #6b4a20
+*/
+.hljs {
+  color: #1c2c28;
+  background: #eef4f1;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #6c7f79;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #1f6e56;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #a85526;
+}
+.hljs-literal {
+  color: #21707a;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #7a5a1e;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #2a6e60;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #175c48;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #6b4a20;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #1c2c28;
+}
+.hljs-code {
+  color: #6c7f79;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #14401f;
+  background-color: #d4e8da;
+}
+.hljs-deletion {
+  color: #6e2c14;
+  background-color: #ecd6c8;
+}

--- a/scripts/custom-styles/verdigris-light.css
+++ b/scripts/custom-styles/verdigris-light.css
@@ -8,51 +8,51 @@ code.hljs {
 }
 /*
   Theme: Verdigris Light
-  Description: Weathered copper roofing: pale patina with burnt copper accents
+  Description: Weathered copper roofing: pale cerulean patina with burnt copper accents
   Author: svelte-highlight
   License: MIT
 
-  bg:       #eef4f1
-  fg:       #1c2c28
-  comment:  #6c7f79
-  patina:   #1f6e56
-  copper:   #a85526
-  teal:     #21707a
-  brass:    #7a5a1e
-  darkteal: #2a6e60
-  deeppatina: #175c48
-  bronze:   #6b4a20
+  bg:       #e8f2f4
+  fg:       #14282c
+  comment:  #5e7a80
+  cerulean: #146478
+  copper:   #a8481e
+  skyteal:  #1a5a70
+  brass:    #7a5218
+  teal:     #1f5c68
+  deepcerulean: #0f4a58
+  bronze:   #6b4818
 */
 .hljs {
-  color: #1c2c28;
-  background: #eef4f1;
+  color: #14282c;
+  background: #e8f2f4;
 }
 .hljs-comment,
 .hljs-quote {
-  color: #6c7f79;
+  color: #5e7a80;
   font-style: italic;
 }
 .hljs-doctag,
 .hljs-keyword,
 .hljs-formula,
 .hljs-template-tag {
-  color: #1f6e56;
+  color: #146478;
 }
 .hljs-section,
 .hljs-name,
 .hljs-selector-tag,
 .hljs-tag,
 .hljs-subst {
-  color: #a85526;
+  color: #a8481e;
 }
 .hljs-literal {
-  color: #21707a;
+  color: #1a5a70;
 }
 .hljs-string,
 .hljs-regexp,
 .hljs-attribute,
 .hljs-meta .hljs-string {
-  color: #7a5a1e;
+  color: #7a5218;
 }
 .hljs-attr,
 .hljs-variable,
@@ -63,7 +63,7 @@ code.hljs {
 .hljs-selector-attr,
 .hljs-selector-pseudo,
 .hljs-number {
-  color: #2a6e60;
+  color: #1f5c68;
 }
 .hljs-symbol,
 .hljs-bullet,
@@ -71,19 +71,19 @@ code.hljs {
 .hljs-meta,
 .hljs-selector-id,
 .hljs-title {
-  color: #175c48;
+  color: #0f4a58;
 }
 .hljs-built_in,
 .hljs-title.class_,
 .hljs-class .hljs-title {
-  color: #6b4a20;
+  color: #6b4818;
 }
 .hljs-punctuation,
 .hljs-operator {
-  color: #1c2c28;
+  color: #14282c;
 }
 .hljs-code {
-  color: #6c7f79;
+  color: #5e7a80;
 }
 .hljs-emphasis {
   font-style: italic;

--- a/scripts/custom-styles/vitriol-dark.css
+++ b/scripts/custom-styles/vitriol-dark.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Vitriol Dark
+  Description: Chemical glow: saturated indigo-violet base with an acid-green reagent
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #1c1440
+  fg:       #e4dcf5
+  comment:  #8a7ab0
+  violet:   #b088f0
+  acid:     #8ee06a
+  electric: #6ab4f0
+  orchid:   #e0a8f0
+  softviolet: #9a7ce0
+  lavender: #c8a0f5
+  paleacid: #a8dc8a
+*/
+.hljs {
+  color: #e4dcf5;
+  background: #1c1440;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #8a7ab0;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #b088f0;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #8ee06a;
+}
+.hljs-literal {
+  color: #6ab4f0;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #e0a8f0;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #9a7ce0;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #c8a0f5;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #a8dc8a;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #e4dcf5;
+}
+.hljs-code {
+  color: #8a7ab0;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #c8f0a8;
+  background-color: #203818;
+}
+.hljs-deletion {
+  color: #f0a8c0;
+  background-color: #3a1830;
+}

--- a/scripts/custom-styles/vitriol-light.css
+++ b/scripts/custom-styles/vitriol-light.css
@@ -1,0 +1,104 @@
+pre code.hljs {
+  display: block;
+  overflow-x: auto;
+  padding: 1em;
+}
+code.hljs {
+  padding: 3px 5px;
+}
+/*
+  Theme: Vitriol Light
+  Description: Chemical glow on paper: violet-tinted white with a deep acid-green reagent
+  Author: svelte-highlight
+  License: MIT
+
+  bg:       #f0ecfa
+  fg:       #241c3a
+  comment:  #7a6e94
+  violet:   #6a3ea0
+  acid:     #2f7a1e
+  electric: #1a5e8a
+  orchid:   #8a2e94
+  softviolet: #5a4a94
+  darkviolet: #4a2a7a
+  darkacid: #3a6e24
+*/
+.hljs {
+  color: #241c3a;
+  background: #f0ecfa;
+}
+.hljs-comment,
+.hljs-quote {
+  color: #7a6e94;
+  font-style: italic;
+}
+.hljs-doctag,
+.hljs-keyword,
+.hljs-formula,
+.hljs-template-tag {
+  color: #6a3ea0;
+}
+.hljs-section,
+.hljs-name,
+.hljs-selector-tag,
+.hljs-tag,
+.hljs-subst {
+  color: #2f7a1e;
+}
+.hljs-literal {
+  color: #1a5e8a;
+}
+.hljs-string,
+.hljs-regexp,
+.hljs-attribute,
+.hljs-meta .hljs-string {
+  color: #8a2e94;
+}
+.hljs-attr,
+.hljs-variable,
+.hljs-template-variable,
+.hljs-params,
+.hljs-type,
+.hljs-selector-class,
+.hljs-selector-attr,
+.hljs-selector-pseudo,
+.hljs-number {
+  color: #5a4a94;
+}
+.hljs-symbol,
+.hljs-bullet,
+.hljs-link,
+.hljs-meta,
+.hljs-selector-id,
+.hljs-title {
+  color: #4a2a7a;
+}
+.hljs-built_in,
+.hljs-title.class_,
+.hljs-class .hljs-title {
+  color: #3a6e24;
+}
+.hljs-punctuation,
+.hljs-operator {
+  color: #241c3a;
+}
+.hljs-code {
+  color: #7a6e94;
+}
+.hljs-emphasis {
+  font-style: italic;
+}
+.hljs-strong {
+  font-weight: bold;
+}
+.hljs-link {
+  text-decoration: underline;
+}
+.hljs-addition {
+  color: #1f4014;
+  background-color: #dce8cc;
+}
+.hljs-deletion {
+  color: #7a1440;
+  background-color: #f2d4e4;
+}

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -210,6 +210,8 @@ exports[`Styles 1`] = `
   "monoBlue",
   "monokai",
   "monokaiSublime",
+  "motherboardDark",
+  "motherboardLight",
   "nacreDark",
   "nacreLight",
   "nebula",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -178,6 +178,8 @@ exports[`Styles 1`] = `
   "kimber",
   "kimbieDark",
   "kimbieLight",
+  "kintsugiDark",
+  "kintsugiLight",
   "letterpressDark",
   "letterpressLight",
   "lichenDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -111,6 +111,8 @@ exports[`Styles 1`] = `
   "dirtysea",
   "docco",
   "dracula",
+  "duskDark",
+  "duskLight",
   "edgeDark",
   "edgeLight",
   "eighties",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -80,6 +80,8 @@ exports[`Styles 1`] = `
   "circus",
   "classicDark",
   "classicLight",
+  "cobaltDark",
+  "cobaltLight",
   "cochinealDark",
   "cochinealLight",
   "codepenEmbed",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -266,6 +266,8 @@ exports[`Styles 1`] = `
   "schoolBook",
   "scoriaDark",
   "scoriaLight",
+  "seleniteDark",
+  "seleniteLight",
   "setiUi",
   "shadesOfPurple",
   "shapeshifter",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -12,6 +12,8 @@ exports[`Styles 1`] = `
   "alebrijeLight",
   "alpenglowDark",
   "alpenglowLight",
+  "amaranthDark",
+  "amaranthLight",
   "anOldHope",
   "anaglyphDark",
   "anaglyphLight",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -46,6 +46,8 @@ exports[`Styles 1`] = `
   "atomOneDark",
   "atomOneDarkReasonable",
   "atomOneLight",
+  "bakeliteDark",
+  "bakeliteLight",
   "base16Github",
   "base16IrBlack",
   "base16Monokai",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -121,6 +121,8 @@ exports[`Styles 1`] = `
   "fauveDark",
   "fauveLight",
   "felipec",
+  "ferrofluidDark",
+  "ferrofluidLight",
   "flat",
   "flintDark",
   "flintLight",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -288,6 +288,8 @@ exports[`Styles 1`] = `
   "synthMidnightTerminalLight",
   "tango",
   "tender",
+  "terrazzoDark",
+  "terrazzoLight",
   "thermalDark",
   "thermalLight",
   "tidepoolDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -282,6 +282,8 @@ exports[`Styles 1`] = `
   "strelitziaLight",
   "sumiDark",
   "sumiLight",
+  "suminagashiDark",
+  "suminagashiLight",
   "summercamp",
   "summerfruitDark",
   "summerfruitLight",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -305,6 +305,8 @@ exports[`Styles 1`] = `
   "uraniumLight",
   "urushiDark",
   "urushiLight",
+  "verdigrisDark",
+  "verdigrisLight",
   "vs",
   "vs2015",
   "vsDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -325,6 +325,8 @@ exports[`Styles 1`] = `
   "urushiLight",
   "verdigrisDark",
   "verdigrisLight",
+  "vitriolDark",
+  "vitriolLight",
   "vs",
   "vs2015",
   "vsDark",

--- a/tests/__snapshots__/styles.test.ts.snap
+++ b/tests/__snapshots__/styles.test.ts.snap
@@ -76,6 +76,8 @@ exports[`Styles 1`] = `
   "circus",
   "classicDark",
   "classicLight",
+  "cochinealDark",
+  "cochinealLight",
   "codepenEmbed",
   "codeschool",
   "colorBrewer",

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(322);
+  expect(styleNames.length).toEqual(324);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(326);
+  expect(styleNames.length).toEqual(328);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(324);
+  expect(styleNames.length).toEqual(326);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(328);
+  expect(styleNames.length).toEqual(330);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(344);
+  expect(styleNames.length).toEqual(346);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(346);
+  expect(styleNames.length).toEqual(348);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(330);
+  expect(styleNames.length).toEqual(332);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(332);
+  expect(styleNames.length).toEqual(334);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(342);
+  expect(styleNames.length).toEqual(344);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(338);
+  expect(styleNames.length).toEqual(340);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(336);
+  expect(styleNames.length).toEqual(338);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(340);
+  expect(styleNames.length).toEqual(342);
   expect(styleNames).toMatchSnapshot();
 });

--- a/tests/styles.test.ts
+++ b/tests/styles.test.ts
@@ -5,6 +5,6 @@ test("Styles", () => {
 
   // @ts-expect-error
   expect(styles.default).toBeUndefined();
-  expect(styleNames.length).toEqual(334);
+  expect(styleNames.length).toEqual(336);
   expect(styleNames).toMatchSnapshot();
 });


### PR DESCRIPTION
Ten new original palettes, each dark/light pair: kintsugi (gold-mended
lacquer), verdigris (oxidized copper), cochineal (dyer's crimson),
motherboard (PCB traces), terrazzo (flecked stone), ferrofluid
(gunmetal with a magenta/cyan spike), suminagashi (ink marbling),
bakelite (vintage plastic), selenite (translucent crystal), and
amaranth (magenta-violet pigment).