### PR TITLE
chore(deps-dev): bump ostia to 0.2.0

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "cssnano": "^7.1.9",
         "cssnano-preset-lite": "^4.0.6",
         "highlight.js": "11.12.0",
-        "ostia": "^0.1.7",
+        "ostia": "^0.2.0",
         "postcss": "^8.5.19",
         "postcss-discard-duplicates": "^7.0.4",
         "postcss-inline-css-vars": "^0.1.0",
@@ -702,7 +702,7 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.5", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ=="],
 
-    "ostia": ["ostia@0.1.7", "", { "bin": { "ostia": "cli.js" } }, "sha512-TVrDTh9H/1xzROyNYQONNfIyT9w8Ki/1RDhJ3Awj8KB0tN8Qbnktqwt0cdElQLiP3TFuq6sTJ4XjTZS05PIDhg=="],
+    "ostia": ["ostia@0.2.0", "", { "bin": { "ostia": "cli.js" } }, "sha512-X+kqTYBmK7r0RgLLy5kqXFxrg0drR39ldOW9+i4H2Nnz4xU1dozsrqaz6pxm6wvlcAoSMIGKWFCYMWMkH+4rmA=="],
 
     "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cssnano": "^7.1.9",
     "cssnano-preset-lite": "^4.0.6",
     "highlight.js": "11.12.0",
-    "ostia": "^0.1.7",
+    "ostia": "^0.2.0",
     "postcss": "^8.5.19",
     "postcss-discard-duplicates": "^7.0.4",
     "postcss-inline-css-vars": "^0.1.0",


### PR DESCRIPTION
0.2.0 is a breaking release, but every ostia call site here only
uses group() and task() with no options object, and the only CLI
usage is `ostia bench`, none of which changed shape or name.