### PR TITLE
fix(ansi): allow only http, https, and mailto in OSC 8 hyperlinks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1452,7 +1452,7 @@ Use `AnsiOutput` to render terminal output that still contains ANSI [SGR](https:
 <AnsiOutput {text} />
 ```
 
-Malformed or unsupported escape sequences are dropped. Nothing throws.
+Malformed or unsupported escape sequences are dropped. Nothing throws. OSC 8 hyperlinks only render as links for `http:`, `https:`, and `mailto:` URIs; any other scheme renders as plain text.
 
 ### Theming the palette
 

--- a/README.md
+++ b/README.md
@@ -1452,7 +1452,7 @@ Use `AnsiOutput` to render terminal output that still contains ANSI [SGR](https:
 <AnsiOutput {text} />
 ```
 
-Malformed or unsupported escape sequences are dropped. Nothing throws. OSC 8 hyperlinks only render as links for `http:`, `https:`, and `mailto:` URIs; any other scheme renders as plain text.
+Malformed or unsupported escape sequences are dropped. Nothing throws. OSC 8 hyperlinks only render as links for `http:`, `https:`, and `mailto:` URIs; any other scheme renders as plain text. `parseAnsi` is one-shot and drops a trailing unterminated sequence, so for streamed output accumulate the full text and re-parse it rather than calling it once per chunk.
 
 ### Theming the palette
 

--- a/src/ansi.d.ts
+++ b/src/ansi.d.ts
@@ -37,7 +37,12 @@ export type AnsiSegment = {
   conceal?: boolean;
   fg?: AnsiColor;
   bg?: AnsiColor;
-  /** OSC 8 hyperlink target for this run, if any. */
+  /**
+   * OSC 8 hyperlink target for this run, if any. Only `http:`, `https:`,
+   * and `mailto:` schemes are accepted (case-insensitive); any other
+   * scheme (e.g. `javascript:`, `data:`) or a scheme-less uri is dropped
+   * as if no link were present.
+   */
   link?: string;
 };
 

--- a/src/ansi.d.ts
+++ b/src/ansi.d.ts
@@ -46,5 +46,13 @@ export type AnsiSegment = {
   link?: string;
 };
 
-/** Parse ANSI SGR escape codes into styled segments. Malformed input is dropped. */
+/**
+ * Parse ANSI SGR escape codes into styled segments. Malformed input is
+ * dropped.
+ *
+ * This is a one-shot parse: a trailing unterminated escape sequence is
+ * dropped rather than buffered, so calling it once per streamed chunk
+ * loses any sequence that straddles a chunk boundary. Accumulate the full
+ * string and re-parse it on each update instead of parsing per chunk.
+ */
 export declare function parseAnsi(text: string): AnsiSegment[];

--- a/src/ansi.js
+++ b/src/ansi.js
@@ -161,6 +161,22 @@ function toSegment(text, style, link) {
 
 const ESC = "\x1b";
 
+// Schemes allowed as OSC 8 hyperlink targets. Anything else (javascript:,
+// data:, vbscript:, scheme-less strings) is rejected like an empty uri.
+const ALLOWED_LINK_SCHEMES = ["http:", "https:", "mailto:"];
+
+/**
+ * @param {string} uri
+ * @returns {string | undefined}
+ */
+function sanitizeLink(uri) {
+  const trimmed = uri.trim();
+  const lower = trimmed.toLowerCase();
+  return ALLOWED_LINK_SCHEMES.some((scheme) => lower.startsWith(scheme))
+    ? trimmed
+    : undefined;
+}
+
 /**
  * Parse ANSI-escaped terminal output into styled segments.
  *
@@ -276,7 +292,7 @@ export function parseAnsi(text) {
         if (secondSemi !== -1) {
           flush();
           const uri = rest.slice(secondSemi + 1);
-          link = uri || undefined;
+          link = uri ? sanitizeLink(uri) : undefined;
         }
       }
       // Other OSC sequences (title/icon sets, unknown commands) carry no

--- a/src/ansi.js
+++ b/src/ansi.js
@@ -301,6 +301,51 @@ export function parseAnsi(text) {
       continue;
     }
 
+    if (ch === ESC) {
+      const next = text[i + 1];
+
+      if (next === "P" || next === "X" || next === "^" || next === "_") {
+        // DCS/SOS/PM/APC: string-terminated body, like OSC.
+        let j = i + 2;
+        let terminatorLength = 0;
+        while (j < text.length) {
+          if (text[j] === "\x07") {
+            terminatorLength = 1;
+            break;
+          }
+          if (text[j] === ESC && text[j + 1] === "\\") {
+            terminatorLength = 2;
+            break;
+          }
+          j += 1;
+        }
+
+        if (terminatorLength === 0) {
+          // Unterminated: drop the rest.
+          break;
+        }
+
+        i = j + terminatorLength;
+        continue;
+      }
+
+      if (next !== undefined && "()*+-./".includes(next)) {
+        // Charset select: ESC, intermediate byte, designator byte.
+        i = Math.min(i + 3, text.length);
+        continue;
+      }
+
+      if (next === undefined) {
+        // Trailing lone ESC: nothing follows to interpret.
+        i += 1;
+        continue;
+      }
+
+      // Any other ESC <char> (cursor save/restore, reset, etc.): drop both.
+      i += 2;
+      continue;
+    }
+
     if (ch === "\r") {
       if (text[i + 1] === "\n") {
         // Treat \r\n as \n.

--- a/tests/ansi.test.ts
+++ b/tests/ansi.test.ts
@@ -222,4 +222,95 @@ describe("parseAnsi", () => {
       ),
     ).toEqual([{ text: "a", link: "https://example.com" }, { text: "b" }]);
   });
+
+  it("skips a DCS sequence terminated by ST", () => {
+    expect(parseAnsi(`a${ESC}P1$q"p${ESC}\\b`)).toEqual([{ text: "ab" }]);
+  });
+
+  it("skips an SOS sequence terminated by BEL", () => {
+    expect(parseAnsi(`a${ESC}Xjunk\x07b`)).toEqual([{ text: "ab" }]);
+  });
+
+  it("skips a PM sequence terminated by ST", () => {
+    expect(parseAnsi(`a${ESC}^junk${ESC}\\b`)).toEqual([{ text: "ab" }]);
+  });
+
+  it("skips an APC sequence terminated by BEL", () => {
+    expect(parseAnsi(`a${ESC}_junk\x07b`)).toEqual([{ text: "ab" }]);
+  });
+
+  it("drops the rest of the input on an unterminated DCS/SOS/PM/APC sequence", () => {
+    expect(parseAnsi(`a${ESC}Pjunk`)).toEqual([{ text: "a" }]);
+    expect(parseAnsi(`a${ESC}_junk`)).toEqual([{ text: "a" }]);
+  });
+
+  it("skips a charset select sequence", () => {
+    expect(parseAnsi(`a${ESC}(Bb`)).toEqual([{ text: "ab" }]);
+    expect(parseAnsi(`a${ESC}0b`)).toEqual([{ text: "ab" }]);
+  });
+
+  it("drops a single-character escape (reset, cursor save/restore, etc.)", () => {
+    expect(parseAnsi(`a${ESC}cb`)).toEqual([{ text: "ab" }]);
+    expect(parseAnsi(`a${ESC}7b`)).toEqual([{ text: "ab" }]);
+    expect(parseAnsi(`a${ESC}8b`)).toEqual([{ text: "ab" }]);
+    expect(parseAnsi(`a${ESC}=b`)).toEqual([{ text: "ab" }]);
+    expect(parseAnsi(`a${ESC}>b`)).toEqual([{ text: "ab" }]);
+    expect(parseAnsi(`a${ESC}Mb`)).toEqual([{ text: "ab" }]);
+  });
+
+  it("drops a trailing lone ESC without throwing", () => {
+    expect(parseAnsi(`a${ESC}`)).toEqual([{ text: "a" }]);
+  });
+
+  it("never leaks an escape byte into segment text (seeded fuzz)", () => {
+    // Deterministic PRNG (mulberry32) so failures reproduce across runs.
+    let state = 0x5eed1e55;
+    const next = () => {
+      state |= 0;
+      state = (state + 0x6d2b79f5) | 0;
+      let t = Math.imul(state ^ (state >>> 15), 1 | state);
+      t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t;
+      return ((t ^ (t >>> 14)) >>> 0) / 4294967296;
+    };
+
+    const alphabet = [
+      ..."ABCabc019 \t",
+      ESC,
+      "[",
+      "]",
+      ";",
+      "m",
+      "\r",
+      "\n",
+      "\x07",
+      "\\",
+      "P",
+      "X",
+      "^",
+      "_",
+    ];
+
+    for (let trial = 0; trial < 200; trial += 1) {
+      const length = Math.floor(next() * 201);
+      let input = "";
+      for (let k = 0; k < length; k += 1) {
+        input += alphabet[Math.floor(next() * alphabet.length)];
+      }
+
+      let segments: ReturnType<typeof parseAnsi> = [];
+      expect(() => {
+        segments = parseAnsi(input);
+      }).not.toThrow();
+      for (const segment of segments) {
+        expect(segment.text.includes(ESC)).toBe(false);
+      }
+
+      // `\r` has its own pre-existing overwrite semantics (unrelated to
+      // escape handling) that rewrite text even without any ESC byte, so
+      // the identity check only applies when neither is present.
+      if (!input.includes(ESC) && !input.includes("\r")) {
+        expect(segments.map((s) => s.text).join("")).toBe(input);
+      }
+    }
+  });
 });

--- a/tests/ansi.test.ts
+++ b/tests/ansi.test.ts
@@ -188,4 +188,38 @@ describe("parseAnsi", () => {
       { text: "ok" },
     ]);
   });
+
+  it("rejects an OSC 8 hyperlink with a disallowed scheme", () => {
+    expect(
+      parseAnsi(`${ESC}]8;;javascript:alert(1)${ESC}\\click${ESC}]8;;${ESC}\\`),
+    ).toEqual([{ text: "click" }]);
+  });
+
+  it("accepts OSC 8 schemes case-insensitively", () => {
+    expect(
+      parseAnsi(`${ESC}]8;;HTTPS://example.com${ESC}\\x${ESC}]8;;${ESC}\\`),
+    ).toEqual([{ text: "x", link: "HTTPS://example.com" }]);
+  });
+
+  it("accepts a mailto OSC 8 hyperlink", () => {
+    expect(
+      parseAnsi(`${ESC}]8;;mailto:a@b.c${ESC}\\x${ESC}]8;;${ESC}\\`),
+    ).toEqual([{ text: "x", link: "mailto:a@b.c" }]);
+  });
+
+  it("links a valid OSC 8 hyperlink following a rejected one", () => {
+    expect(
+      parseAnsi(
+        `${ESC}]8;;javascript:alert(1)${ESC}\\a${ESC}]8;;https://example.com${ESC}\\b${ESC}]8;;${ESC}\\`,
+      ),
+    ).toEqual([{ text: "a" }, { text: "b", link: "https://example.com" }]);
+  });
+
+  it("closes a previously open link when a rejected OSC 8 uri follows", () => {
+    expect(
+      parseAnsi(
+        `${ESC}]8;;https://example.com${ESC}\\a${ESC}]8;;javascript:alert(1)${ESC}\\b`,
+      ),
+    ).toEqual([{ text: "a", link: "https://example.com" }, { text: "b" }]);
+  });
 });

--- a/tests/e2e/AnsiOutput.link.test.svelte
+++ b/tests/e2e/AnsiOutput.link.test.svelte
@@ -5,6 +5,10 @@
 
   // An OSC 8 hyperlink wrapping "docs".
   const text = `see ${ESC}]8;;https://example.com${ESC}\\docs${ESC}]8;;${ESC}\\ for more`;
+
+  // A javascript: URI, which must render as plain text, not a link.
+  const unsafeText = `click ${ESC}]8;;javascript:alert(1)${ESC}\\here${ESC}]8;;${ESC}\\`;
 </script>
 
 <AnsiOutput {text} data-testid="ansi" />
+<AnsiOutput text={unsafeText} data-testid="ansi-unsafe" />

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -207,6 +207,10 @@ test("AnsiOutput - OSC 8 hyperlink renders as an anchor", async ({
   const link = page.getByTestId("ansi").locator("a");
   await expect(link).toHaveText("docs");
   await expect(link).toHaveAttribute("href", "https://example.com");
+
+  const unsafe = page.getByTestId("ansi-unsafe");
+  await expect(unsafe.locator("a")).toHaveCount(0);
+  await expect(unsafe.locator("span", { hasText: "here" })).toBeVisible();
 });
 
 test("Highlight", async ({ mount, page }) => {

--- a/www/components/AnsiOutput/Examples.svelte
+++ b/www/components/AnsiOutput/Examples.svelte
@@ -74,6 +74,14 @@
 
   const gitMarkup = "<AnsiOutput {text} />";
 
+  /** @param {string} uri */
+  const osc8 = (uri) => `${ESC}]8;;${uri}${ESC}\\`;
+  const links = [
+    `see ${osc8("https://example.com")}docs${osc8("")} for setup,`,
+    `or ${osc8("javascript:alert(1)")}this${osc8("")} which renders as plain text.`,
+  ].join("\n");
+  const linksMarkup = "<AnsiOutput {text} />";
+
   const lightMarkup = [
     "<AnsiOutput",
     "  {text}",
@@ -121,6 +129,7 @@
   );
   const themedSnippet = snippetFor("AnsiOutput", buildLog, themedMarkup);
   const gitSnippet = snippetFor("AnsiOutput", gitDiff, gitMarkup);
+  const linksSnippet = snippetFor("AnsiOutput", links, linksMarkup);
   const lightSnippet = snippetFor("AnsiOutput", vitest, lightMarkup);
 </script>
 
@@ -165,6 +174,18 @@
 </div>
 <div class="mb-5">
   <AnsiOutput text={gitDiff} />
+</div>
+
+<p class="label-01 mb-3">
+  OSC 8 hyperlinks. Only <code class="code">http:</code>,
+  <code class="code">https:</code>, and <code class="code">mailto:</code> render
+  as links; other schemes render as plain text.
+</p>
+<div class="mb-3">
+  <HighlightSvelte code={linksSnippet} class={THEME_MODULE_NAME} />
+</div>
+<div class="mb-5">
+  <AnsiOutput text={links} />
 </div>
 
 <p class="label-01 mb-3">


### PR DESCRIPTION
Closes an XSS-adjacent hole in AnsiOutput's OSC 8 link handling and
plugs a byte-leak where every ESC sequence outside CSI/OSC fell
through into rendered text one character at a time. Also documents
that parseAnsi is a one-shot parser, not safe to call per streamed
chunk.