### PR TITLE
fix(components): keep FileTabs active in sync with files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1540,6 +1540,8 @@ Arrow keys move between tabs; `Home` and `End` jump to the first and last. The m
 </FileTabs>
 ```
 
+`active` is reconciled whenever `files` changes: an unknown or stale value (including a `bind:active` set before `files` loads) falls back to `files[0]`; removing the active file selects its former neighbor (same index, clamped to the new length), like closing a tab in an editor; an empty `files` array sets `active` to `undefined` and the tab panel omits `aria-labelledby`. `on:change` fires once whenever this reconciliation actually changes `active`.
+
 ## Component API
 
 ### `Highlight`
@@ -1814,7 +1816,7 @@ See [Large documents](#large-documents) above.
 | files  | `string[]` | N/A (required) |
 | active | `string`   | `files[0]`     |
 
-`$$restProps` are forwarded to the top-level `div` element. `active` supports `bind:active`.
+`$$restProps` are forwarded to the top-level `div` element. `active` supports `bind:active` and is reconciled against `files`: an unknown value falls back to `files[0]`, removing the active file selects its former neighbor, and an empty `files` array sets `active` to `undefined`.
 
 #### Dispatched Events
 

--- a/README.md
+++ b/README.md
@@ -1559,6 +1559,8 @@ Arrow keys move between tabs; `Home` and `End` jump to the first and last. The m
 
 When the tab strip overflows, its overflowing edge fades to signal there's more to scroll to; changing `active` (by click, keyboard, or `bind:active`) scrolls that tab into view.
 
+The active tab's `--tab-active-color` and `--tab-active-background` are resolved from the highlighted code's computed style after mount, so they render as `inherit`/`transparent` on first paint; for an SSR-critical, above-the-fold tab strip, set `--tab-active-background` and `--tab-active-color` yourself to avoid a flash before hydration.
+
 ## Component API
 
 ### `Highlight`

--- a/README.md
+++ b/README.md
@@ -469,6 +469,21 @@ These apply when `langtag` is set to `true`.
 | --prompt-font-weight  | Font weight of the terminal prompt       | `700`                               |
 | --prompt-color        | Color of the terminal prompt             | `inherit`                           |
 
+### `FileTabs` variables
+
+| Variable               | Description                                                     | Default value                                |
+| :---------------------- | :--------------------------------------------------------------- | :-------------------------------------------- |
+| --file-tabs-gap         | Gap between tabs                                                  | `0`                                            |
+| --file-tabs-background  | Tab strip background                                              | `inherit`                                      |
+| --tab-overflow-fade     | Width of the scroll shadow shown on the overflowing edge          | `1.5rem`                                       |
+| --tab-padding           | Padding of each tab                                               | `0.5em 1em`                                    |
+| --tab-color             | Text color of inactive tabs                                      | `inherit`                                      |
+| --tab-background        | Background color of inactive tabs                                | `transparent`                                  |
+| --tab-inactive-opacity  | Opacity of inactive tabs (active and hovered tabs stay opaque)    | `0.55`                                         |
+| --tab-active-color      | Text color of the active tab                                     | the highlighted code's text color              |
+| --tab-active-background | Background color of the active tab                               | the highlighted code's background              |
+| --tab-focus-outline     | Keyboard focus outline of a tab                                   | `2px solid currentColor`                       |
+
 ## Svelte Syntax Highlighting
 
 Use the `HighlightSvelte` component for Svelte syntax highlighting.
@@ -1541,6 +1556,8 @@ Arrow keys move between tabs; `Home` and `End` jump to the first and last. The m
 ```
 
 `active` is reconciled whenever `files` changes: an unknown or stale value (including a `bind:active` set before `files` loads) falls back to `files[0]`; removing the active file selects its former neighbor (same index, clamped to the new length), like closing a tab in an editor; an empty `files` array sets `active` to `undefined` and the tab panel omits `aria-labelledby`. `on:change` fires once whenever this reconciliation actually changes `active`.
+
+When the tab strip overflows, its overflowing edge fades to signal there's more to scroll to; changing `active` (by click, keyboard, or `bind:active`) scrolls that tab into view.
 
 ## Component API
 

--- a/src/FileTabs.svelte
+++ b/src/FileTabs.svelte
@@ -16,7 +16,7 @@
    */
   export let active = files[0];
 
-  import { afterUpdate, createEventDispatcher } from "svelte";
+  import { afterUpdate, createEventDispatcher, tick } from "svelte";
 
   const dispatch = createEventDispatcher();
 
@@ -60,6 +60,21 @@
   }
 
   $: activeIndex = files.indexOf(active);
+
+  // Keep the active tab in view whenever it changes, e.g. `bind:active`
+  // set from outside the visible tab strip. Guarded so it never runs
+  // during SSR, where there is no scrollable DOM to act on.
+  let previousActive;
+
+  $: if (typeof document !== "undefined" && active !== previousActive) {
+    previousActive = active;
+    scrollActiveIntoView();
+  }
+
+  async function scrollActiveIntoView() {
+    await tick();
+    tabs[activeIndex]?.scrollIntoView({ block: "nearest", inline: "nearest" });
+  }
 
   /** @param {string} file */
   function selectTab(file) {
@@ -159,8 +174,27 @@
   .tablist {
     display: flex;
     gap: var(--file-tabs-gap, 0);
-    background: var(--file-tabs-background, inherit);
     overflow-x: auto;
+    background-color: var(--file-tabs-background, inherit);
+    background-repeat: no-repeat;
+    background-size: var(--tab-overflow-fade, 1.5rem) 100%;
+    background-position: left, right, left, right;
+    /* `local` covers scroll with the content, hiding the `scroll` shadows
+       beneath them until the corresponding edge is scrolled out of view. */
+    background-attachment: local, local, scroll, scroll;
+    background-image:
+      linear-gradient(
+        to right,
+        var(--file-tabs-background, inherit),
+        var(--file-tabs-background, inherit)
+      ),
+      linear-gradient(
+        to left,
+        var(--file-tabs-background, inherit),
+        var(--file-tabs-background, inherit)
+      ),
+      linear-gradient(to right, rgba(0, 0, 0, 0.18), rgba(0, 0, 0, 0)),
+      linear-gradient(to left, rgba(0, 0, 0, 0.18), rgba(0, 0, 0, 0));
   }
 
   .tab {

--- a/src/FileTabs.svelte
+++ b/src/FileTabs.svelte
@@ -6,7 +6,14 @@
   /** @type {string[]} */
   export let files;
 
-  /** @type {string} */
+  /**
+   * Active file (`bind:active`).
+   * Reconciled whenever `files` changes: an unknown or stale value
+   * selects `files[0]`; if the previously active file is removed, its
+   * neighbor (same index, clamped to the new length) is selected
+   * instead; an empty `files` list sets this to `undefined`.
+   * @type {string | undefined}
+   */
   export let active = files[0];
 
   import { afterUpdate, createEventDispatcher } from "svelte";
@@ -21,6 +28,36 @@
 
   /** @type {HTMLButtonElement[]} */
   let tabs = [];
+
+  // Index `active` last resolved to; used to pick a neighbor when the
+  // active file disappears from `files`.
+  let lastValidIndex = -1;
+
+  $: {
+    const index = files.indexOf(active);
+
+    if (index === -1) {
+      if (files.length === 0) {
+        if (active !== undefined) active = undefined;
+        lastValidIndex = -1;
+      } else {
+        const nextIndex =
+          lastValidIndex === -1
+            ? 0
+            : Math.min(lastValidIndex, files.length - 1);
+        const next = files[nextIndex];
+
+        lastValidIndex = nextIndex;
+
+        if (next !== active) {
+          active = next;
+          dispatch("change", { active });
+        }
+      }
+    } else {
+      lastValidIndex = index;
+    }
+  }
 
   $: activeIndex = files.indexOf(active);
 
@@ -107,7 +144,7 @@
     role="tabpanel"
     id="{baseId}-panel"
     class="tabpanel"
-    aria-labelledby="{baseId}-tab-{activeIndex}"
+    aria-labelledby={activeIndex === -1 ? undefined : `${baseId}-tab-${activeIndex}`}
   >
     <slot {active} />
   </div>

--- a/src/FileTabs.svelte.d.ts
+++ b/src/FileTabs.svelte.d.ts
@@ -31,6 +31,13 @@ export type FileTabsProps = HTMLAttributes<HTMLDivElement> & {
   "--file-tabs-background"?: string;
 
   /**
+   * Width of the scroll shadow shown on the overflowing edge of the
+   * tab strip.
+   * @default "1.5rem"
+   */
+  "--tab-overflow-fade"?: string;
+
+  /**
    * Tab padding.
    * @default "0.5em 1em"
    */

--- a/src/FileTabs.svelte.d.ts
+++ b/src/FileTabs.svelte.d.ts
@@ -10,6 +10,10 @@ export type FileTabsProps = HTMLAttributes<HTMLDivElement> & {
 
   /**
    * Active file (`bind:active`).
+   * Reconciled whenever `files` changes: an unknown or stale value
+   * selects `files[0]`; if the previously active file is removed, its
+   * neighbor (same index, clamped to the new length) is selected
+   * instead; an empty `files` list sets this to `undefined`.
    * @default files[0]
    */
   active?: string;

--- a/tests/e2e/FileTabs.test.svelte
+++ b/tests/e2e/FileTabs.test.svelte
@@ -12,12 +12,23 @@
     };
 
   export let initialActive: string | undefined = undefined;
+  export let manyFiles = false;
+  export let width: string | undefined = undefined;
 
-  let files = Object.keys(sources);
+  const manyFileNames = Array.from(
+    { length: 20 },
+    (_, i) => `some-very-long-file-name-number-${i}.ts`,
+  );
+
+  let files = manyFiles ? manyFileNames : Object.keys(sources);
 
   let active = initialActive ?? files[0];
   let lastChange = "";
   let changeCount = 0;
+
+  // Re-applies `initialActive` when the test updates it post-mount, to
+  // simulate a `bind:active` value set programmatically from outside.
+  $: if (initialActive !== undefined) active = initialActive;
 
   function removeActiveFile() {
     files = files.filter((file) => file !== active);
@@ -30,22 +41,24 @@
 
 <svelte:head> {@html atomOneDark} </svelte:head>
 
-<FileTabs
-  {files}
-  bind:active
-  on:change={(event) => {
-    lastChange = event.detail.active;
-    changeCount += 1;
-  }}
-  let:active
->
-  {#if active}
-    <Highlight
-      language={sources[active].language}
-      code={sources[active].code}
-    />
-  {/if}
-</FileTabs>
+<div style={width ? `width: ${width}` : undefined}>
+  <FileTabs
+    {files}
+    bind:active
+    on:change={(event) => {
+      lastChange = event.detail.active;
+      changeCount += 1;
+    }}
+    let:active
+  >
+    {#if active && sources[active]}
+      <Highlight
+        language={sources[active].language}
+        code={sources[active].code}
+      />
+    {/if}
+  </FileTabs>
+</div>
 
 <p data-testid="active">{active}</p>
 <p data-testid="last-change">{lastChange}</p>

--- a/tests/e2e/FileTabs.test.svelte
+++ b/tests/e2e/FileTabs.test.svelte
@@ -11,10 +11,21 @@
       "vite.config.js": { language: javascript, code: "export default {};" },
     };
 
-  const files = Object.keys(sources);
+  export let initialActive: string | undefined = undefined;
 
-  let active = files[0];
+  let files = Object.keys(sources);
+
+  let active = initialActive ?? files[0];
   let lastChange = "";
+  let changeCount = 0;
+
+  function removeActiveFile() {
+    files = files.filter((file) => file !== active);
+  }
+
+  function clearFiles() {
+    files = [];
+  }
 </script>
 
 <svelte:head> {@html atomOneDark} </svelte:head>
@@ -22,11 +33,26 @@
 <FileTabs
   {files}
   bind:active
-  on:change={(event) => (lastChange = event.detail.active)}
+  on:change={(event) => {
+    lastChange = event.detail.active;
+    changeCount += 1;
+  }}
   let:active
 >
-  <Highlight language={sources[active].language} code={sources[active].code} />
+  {#if active}
+    <Highlight
+      language={sources[active].language}
+      code={sources[active].code}
+    />
+  {/if}
 </FileTabs>
 
 <p data-testid="active">{active}</p>
 <p data-testid="last-change">{lastChange}</p>
+<p data-testid="change-count">{changeCount}</p>
+<button type="button" data-testid="remove-active" on:click={removeActiveFile}>
+  Remove active file
+</button>
+<button type="button" data-testid="clear-files" on:click={clearFiles}>
+  Clear files
+</button>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1899,3 +1899,32 @@ test("FileTabs - an empty files list omits aria-labelledby", async ({
   );
   expect(messages).toEqual([]);
 });
+
+test("FileTabs - the active tab scrolls into view when set programmatically", async ({
+  mount,
+  page,
+}) => {
+  const component = await mount(FileTabs, {
+    props: { manyFiles: true, width: "300px" },
+  });
+
+  const lastTabName = "some-very-long-file-name-number-19.ts";
+
+  await component.update({
+    props: { manyFiles: true, width: "300px", initialActive: lastTabName },
+  });
+
+  const tablistBox = await page.locator(".tablist").boundingBox();
+  const tabBox = await page
+    .getByRole("tab", { name: lastTabName })
+    .boundingBox();
+
+  if (!tablistBox || !tabBox) {
+    throw new Error("expected .tablist and the active tab to have layout");
+  }
+
+  expect(tabBox.x).toBeGreaterThanOrEqual(tablistBox.x - 1);
+  expect(tabBox.x + tabBox.width).toBeLessThanOrEqual(
+    tablistBox.x + tablistBox.width + 1,
+  );
+});

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1844,3 +1844,58 @@ test("FileTabs - active tab background matches the highlighted code theme", asyn
     codeBackground,
   );
 });
+
+test("FileTabs - a stale initial active falls back to the first file", async ({
+  mount,
+  page,
+}) => {
+  await mount(FileTabs, { props: { initialActive: "nope.ts" } });
+
+  await expect(page.getByRole("tab", { name: "App.svelte" })).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+
+  const panel = page.getByRole("tabpanel");
+  const labelledby = await panel.getAttribute("aria-labelledby");
+  expect(labelledby).not.toBeNull();
+  await expect(page.locator(`#${labelledby}`)).toHaveAttribute(
+    "aria-selected",
+    "true",
+  );
+});
+
+test("FileTabs - removing the active file selects its neighbor", async ({
+  mount,
+  page,
+}) => {
+  await mount(FileTabs, { props: { initialActive: "index.js" } });
+
+  await page.getByTestId("remove-active").click();
+
+  await expect(page.getByTestId("active")).toHaveText("vite.config.js");
+  await expect(
+    page.getByRole("tab", { name: "vite.config.js" }),
+  ).toHaveAttribute("aria-selected", "true");
+  await expect(page.getByTestId("last-change")).toHaveText("vite.config.js");
+  await expect(page.getByTestId("change-count")).toHaveText("1");
+});
+
+test("FileTabs - an empty files list omits aria-labelledby", async ({
+  mount,
+  page,
+}) => {
+  const messages: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") messages.push(message.text());
+  });
+
+  await mount(FileTabs);
+  await page.getByTestId("clear-files").click();
+
+  await expect(page.getByRole("tab")).toHaveCount(0);
+  await expect(page.getByRole("tabpanel")).not.toHaveAttribute(
+    "aria-labelledby",
+  );
+  expect(messages).toEqual([]);
+});

--- a/www/components/FileTabs.svelte
+++ b/www/components/FileTabs.svelte
@@ -1,5 +1,6 @@
 <script>
   import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
   import Highlight, { FileTabs, HighlightSvelte } from "svelte-highlight";
   import css from "svelte-highlight/languages/css";
   import javascript from "svelte-highlight/languages/javascript";
@@ -11,7 +12,12 @@
     "styles.css": { language: css, code: ".hljs {\n  color: inherit;\n}" },
   };
 
-  const files = Object.keys(sources);
+  let files = Object.keys(sources);
+  let active = files[0];
+
+  function removeActiveFile() {
+    files = files.filter((file) => file !== active);
+  }
 
   const snippet = `<script>
   import Highlight, { FileTabs } from "svelte-highlight";
@@ -42,10 +48,26 @@
 
 <p class="mb-5">Pick a tab, or use the arrow keys:</p>
 
-<FileTabs {files} let:active>
-  <Highlight
-    language={sources[active].language}
-    code={sources[active].code}
-    class={THEME_MODULE_NAME}
-  />
+<FileTabs {files} bind:active let:active>
+  {#if active}
+    <Highlight
+      language={sources[active].language}
+      code={sources[active].code}
+      class={THEME_MODULE_NAME}
+    />
+  {/if}
 </FileTabs>
+
+<p class="label-01 mb-3" style="margin-top: 1.5rem">
+  Removing the active file selects its neighbor instead of leaving no tab
+  selected:
+</p>
+
+<Button
+  size="small"
+  kind="tertiary"
+  disabled={files.length === 0}
+  on:click={removeActiveFile}
+>
+  Remove "{active}"
+</Button>

--- a/www/components/FileTabs.svelte
+++ b/www/components/FileTabs.svelte
@@ -19,6 +19,12 @@
     files = files.filter((file) => file !== active);
   }
 
+  const manyFiles = Array.from(
+    { length: 12 },
+    (_, i) => `component-${i}.svelte`,
+  );
+  let manyFilesActive = manyFiles[0];
+
   const snippet = `<script>
   import Highlight, { FileTabs } from "svelte-highlight";
   import javascript from "svelte-highlight/languages/javascript";
@@ -70,4 +76,23 @@
   on:click={removeActiveFile}
 >
   Remove "{active}"
+</Button>
+
+<p class="label-01 mb-3" style="margin-top: 1.5rem">
+  A tab strip narrower than its tabs fades the overflowing edge, and jumping to
+  a tab scrolls it into view:
+</p>
+
+<div style="max-width: 320px" class="mb-3">
+  <FileTabs files={manyFiles} bind:active={manyFilesActive}>
+    <p class="label-01" style="padding: 1em">{manyFilesActive}</p>
+  </FileTabs>
+</div>
+
+<Button
+  size="small"
+  kind="tertiary"
+  on:click={() => (manyFilesActive = manyFiles[manyFiles.length - 1])}
+>
+  Jump to last tab
 </Button>


### PR DESCRIPTION
Fixes FileTabs losing tab selection when active drifts out of sync
with files (stale bind:active, an emptied list, or the active file
being removed at runtime), and adds a scroll-shadow affordance plus
active-tab auto-scroll for tab strips that overflow their container.