### PR TITLE
feat(ansi): add createAnsiSession for incremental ANSI parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -1494,6 +1494,14 @@ With `autoContrast` on (the default), spans that set a background get a readable
 <AnsiOutput {text} autoContrast={false} />
 ```
 
+### Wrapping long lines
+
+`AnsiOutput` never wraps by default -- long lines scroll horizontally. Set `wrap` to wrap them instead:
+
+```svelte
+<AnsiOutput {text} wrap />
+```
+
 ### Pairing with `CodeWindow`
 
 Put `AnsiOutput` inside `CodeWindow variant="terminal"` for the prompt and title bar:
@@ -1665,6 +1673,7 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 | :----------- | :-------- | :------------- |
 | text         | `string`  | N/A (required) |
 | autoContrast | `boolean` | `true`         |
+| wrap         | `boolean` | `false`        |
 
 `$$restProps` are forwarded to the top-level `pre` element.
 

--- a/bench/ansi.bench.ts
+++ b/bench/ansi.bench.ts
@@ -6,7 +6,7 @@
  * `<script>`, which isn't reachable from bench/ or tests/ at all.
  */
 import { group, task } from "ostia";
-import { parseAnsi } from "../src/ansi.js";
+import { createAnsiSession, parseAnsi } from "../src/ansi.js";
 import { classNames, inlineStyle } from "../src/ansi-color.js";
 
 const FG_CODES = [
@@ -56,6 +56,45 @@ group("classNames() + inlineStyle() over parsed segments", () => {
         },
       );
     }
+  }
+});
+
+// Fixed chunk size for the repeated-append case below: small enough to
+// straddle SGR/OSC 8 sequences many times over a long corpus.
+const CHUNK_BYTES = 200;
+
+/** Split `source` into fixed-size chunks (the last one may be shorter). */
+function chunk(source: string, size: number) {
+  const chunks: string[] = [];
+  for (let i = 0; i < source.length; i += size) {
+    chunks.push(source.slice(i, i + size));
+  }
+  return chunks;
+}
+
+group("repeated append: createAnsiSession vs re-parsing on every chunk", () => {
+  for (const count of SEGMENT_COUNTS) {
+    const chunks = chunk(ansiSource(count), CHUNK_BYTES);
+
+    task(`${count.toLocaleString()} segments, createAnsiSession`, () => {
+      const session = createAnsiSession();
+      let latest: unknown;
+      for (const piece of chunks) {
+        session.append(piece);
+        latest = session.segments();
+      }
+      return latest;
+    });
+
+    task(`${count.toLocaleString()} segments, parseAnsi on every chunk`, () => {
+      let accumulated = "";
+      let latest: unknown;
+      for (const piece of chunks) {
+        accumulated += piece;
+        latest = parseAnsi(accumulated);
+      }
+      return latest;
+    });
   }
 });
 

--- a/src/AnsiOutput.svelte
+++ b/src/AnsiOutput.svelte
@@ -8,6 +8,12 @@
    */
   export let autoContrast = true;
 
+  /**
+   * Wrap long lines instead of horizontally scrolling.
+   * @type {boolean}
+   */
+  export let wrap = false;
+
   import { createAnsiSession } from "./ansi.js";
   import { classNames, inlineStyle } from "./ansi-color.js";
 
@@ -41,7 +47,7 @@
   }));
 </script>
 
-<pre class="ansi" {...$$restProps}><code
+<pre class="ansi" class:wrap {...$$restProps}><code
     >{#each segments as segment}{#if segment.link}<a href={segment.link} rel="noopener noreferrer" class={segment.class} style={segment.style}
         >{segment.text}</a
       >{:else}<span class={segment.class} style={segment.style}
@@ -66,6 +72,11 @@
     font-size: var(--ansi-font-size, 0.875em);
     line-height: var(--ansi-line-height, 1.5);
     tab-size: var(--ansi-tab-size, 4);
+  }
+
+  .ansi.wrap {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
   }
 
   .bold {

--- a/src/AnsiOutput.svelte
+++ b/src/AnsiOutput.svelte
@@ -8,11 +8,31 @@
    */
   export let autoContrast = true;
 
-  import { parseAnsi } from "./ansi.js";
+  import { createAnsiSession } from "./ansi.js";
   import { classNames, inlineStyle } from "./ansi-color.js";
 
-  // Precompute class/style per segment. Parse only when `text` changes.
-  $: parsed = parseAnsi(text);
+  let session = createAnsiSession();
+  // Prefix of `text` already fed to `session`. If `text` stops starting
+  // with this, treat it as a restart (not an append) and re-parse fresh.
+  let fedText = "";
+  let parsed = [];
+
+  // Re-parsing the whole string on every change is O(n^2) over a growing
+  // (live-tailed or streamed) `text`, so only feed the new suffix when
+  // `text` grows by a pure append; anything else gets a fresh session.
+  $: {
+    if (text.startsWith(fedText)) {
+      if (text.length > fedText.length) {
+        session.append(text.slice(fedText.length));
+        fedText = text;
+      }
+    } else {
+      session = createAnsiSession();
+      session.append(text);
+      fedText = text;
+    }
+    parsed = session.segments();
+  }
   $: segments = parsed.map((segment) => ({
     text: segment.text,
     class: classNames(segment),

--- a/src/AnsiOutput.svelte.d.ts
+++ b/src/AnsiOutput.svelte.d.ts
@@ -14,6 +14,13 @@ export type AnsiOutputProps = HTMLAttributes<HTMLPreElement> & {
   autoContrast?: boolean;
 
   /**
+   * Wrap long lines (`white-space: pre-wrap; overflow-wrap: anywhere`)
+   * instead of horizontally scrolling.
+   * @default false
+   */
+  wrap?: boolean;
+
+  /**
    * Output block padding.
    * @default "1em"
    */

--- a/src/ansi.d.ts
+++ b/src/ansi.d.ts
@@ -56,3 +56,30 @@ export type AnsiSegment = {
  * string and re-parse it on each update instead of parsing per chunk.
  */
 export declare function parseAnsi(text: string): AnsiSegment[];
+
+/** An incremental ANSI parser session; see {@link createAnsiSession}. */
+export interface AnsiSession {
+  /** Feed the next chunk of text into the session. */
+  append(chunk: string): void;
+  /**
+   * Completed segments so far, plus a live trailing segment for any
+   * buffered-but-not-yet-flushed text. Does not mutate session state.
+   */
+  segments(): AnsiSegment[];
+  /**
+   * Flush remaining buffered text and drop any still-pending incomplete
+   * sequence, then return the final segments. Calling `append()` after
+   * `finish()` is unsupported.
+   */
+  finish(): AnsiSegment[];
+}
+
+/**
+ * Create an incremental counterpart to {@link parseAnsi} for text that
+ * arrives in chunks. Carries style, the open OSC 8 link, and a
+ * partial-escape buffer across `append()` calls, so a chunk boundary that
+ * splits a sequence doesn't get parsed wrong or dropped. `finish()`'s
+ * output is identical to calling `parseAnsi` once on the full
+ * concatenation of every appended chunk.
+ */
+export declare function createAnsiSession(): AnsiSession;

--- a/src/ansi.js
+++ b/src/ansi.js
@@ -365,3 +365,227 @@ export function parseAnsi(text) {
   flush();
   return segments;
 }
+
+/** @typedef {import("./ansi").AnsiSession} AnsiSession */
+
+/**
+ * Create an incremental ANSI parser session for text arriving in chunks
+ * (a live-tailed log, a streamed response). `finish()`'s output is
+ * identical to calling `parseAnsi` once on the full concatenation of every
+ * appended chunk.
+ *
+ * @returns {AnsiSession}
+ */
+export function createAnsiSession() {
+  /** @type {AnsiSegment[]} */
+  const segments = [];
+  /** @type {AnsiStyle} */
+  const style = {};
+  let buffer = "";
+  /** @type {string | undefined} */
+  let link;
+  // Unconsumed tail from the previous append(): an incomplete sequence
+  // (split SGR/OSC 8, a lone trailing ESC or \r) that only made sense to
+  // resolve once more input arrived.
+  let pending = "";
+  let finished = false;
+
+  const flush = () => {
+    if (buffer) {
+      segments.push(toSegment(buffer, style, link));
+      buffer = "";
+    }
+  };
+
+  const resetLine = () => {
+    const bufferBreak = buffer.lastIndexOf("\n");
+    if (bufferBreak !== -1) {
+      buffer = buffer.slice(0, bufferBreak + 1);
+      return;
+    }
+    buffer = "";
+    let last = segments.pop();
+    while (last !== undefined) {
+      const segmentBreak = last.text.lastIndexOf("\n");
+      if (segmentBreak === -1) {
+        last = segments.pop();
+        continue;
+      }
+      last.text = last.text.slice(0, segmentBreak + 1);
+      segments.push(last);
+      return;
+    }
+  };
+
+  /**
+   * Scan `input`, mutating style/link/buffer/segments as it goes. When
+   * `atEnd` is false (an `append()` mid-stream), a sequence that can't be
+   * resolved without more bytes than `input` has is left unconsumed and
+   * returned so the next `append()` can retry once it has more. When
+   * `atEnd` is true (from `finish()`), those same sequences are settled
+   * exactly like `parseAnsi` settles them at the end of a one-shot input
+   * (dropped — or, for a trailing lone `\r`, applied as an overwrite).
+   * @param {string} input
+   * @param {boolean} atEnd
+   * @returns {string} Unconsumed tail (always "" when `atEnd`).
+   */
+  const scan = (input, atEnd) => {
+    let i = 0;
+
+    while (i < input.length) {
+      const ch = input[i];
+
+      if (ch === ESC && input[i + 1] === "[") {
+        let j = i + 2;
+        while (j < input.length) {
+          const code = input.charCodeAt(j);
+          if (code >= 0x40 && code <= 0x7e) break;
+          j += 1;
+        }
+
+        if (j >= input.length) {
+          if (atEnd) break;
+          return input.slice(i);
+        }
+
+        const final = input[j];
+        if (final === "m") {
+          flush();
+          const body = input.slice(i + 2, j);
+          const params = body
+            .split(";")
+            .map((part) => (part === "" ? 0 : Number(part)))
+            .filter((n) => Number.isInteger(n));
+          applySgr(style, params);
+        }
+        i = j + 1;
+        continue;
+      }
+
+      if (ch === ESC && input[i + 1] === "]") {
+        let j = i + 2;
+        let terminatorLength = 0;
+        while (j < input.length) {
+          if (input[j] === "\x07") {
+            terminatorLength = 1;
+            break;
+          }
+          if (input[j] === ESC && input[j + 1] === "\\") {
+            terminatorLength = 2;
+            break;
+          }
+          j += 1;
+        }
+
+        if (terminatorLength === 0) {
+          if (atEnd) break;
+          return input.slice(i);
+        }
+
+        const body = input.slice(i + 2, j);
+        const firstSemi = body.indexOf(";");
+        const command = firstSemi === -1 ? body : body.slice(0, firstSemi);
+        if (command === "8" && firstSemi !== -1) {
+          const rest = body.slice(firstSemi + 1);
+          const secondSemi = rest.indexOf(";");
+          if (secondSemi !== -1) {
+            flush();
+            const uri = rest.slice(secondSemi + 1);
+            link = uri ? sanitizeLink(uri) : undefined;
+          }
+        }
+        i = j + terminatorLength;
+        continue;
+      }
+
+      if (ch === ESC) {
+        const next = input[i + 1];
+
+        if (next === "P" || next === "X" || next === "^" || next === "_") {
+          let j = i + 2;
+          let terminatorLength = 0;
+          while (j < input.length) {
+            if (input[j] === "\x07") {
+              terminatorLength = 1;
+              break;
+            }
+            if (input[j] === ESC && input[j + 1] === "\\") {
+              terminatorLength = 2;
+              break;
+            }
+            j += 1;
+          }
+
+          if (terminatorLength === 0) {
+            if (atEnd) break;
+            return input.slice(i);
+          }
+
+          i = j + terminatorLength;
+          continue;
+        }
+
+        if (next !== undefined && "()*+-./".includes(next)) {
+          if (i + 2 >= input.length) {
+            if (atEnd) break;
+            return input.slice(i);
+          }
+          i += 3;
+          continue;
+        }
+
+        if (next === undefined) {
+          if (!atEnd) return input.slice(i);
+          i += 1;
+          continue;
+        }
+
+        i += 2;
+        continue;
+      }
+
+      if (ch === "\r") {
+        if (i + 1 >= input.length) {
+          if (!atEnd) return input.slice(i);
+          resetLine();
+          i += 1;
+          continue;
+        }
+        if (input[i + 1] === "\n") {
+          buffer += "\n";
+          i += 2;
+          continue;
+        }
+        resetLine();
+        i += 1;
+        continue;
+      }
+
+      buffer += ch;
+      i += 1;
+    }
+
+    return "";
+  };
+
+  return {
+    append(chunk) {
+      if (finished) return;
+      pending = scan(pending + chunk, false);
+    },
+    segments() {
+      const result = segments.slice();
+      if (buffer) result.push(toSegment(buffer, style, link));
+      return result;
+    },
+    finish() {
+      if (!finished) {
+        scan(pending, true);
+        pending = "";
+        flush();
+        finished = true;
+      }
+      return segments.slice();
+    },
+  };
+}

--- a/tests/ansi-session.test.ts
+++ b/tests/ansi-session.test.ts
@@ -1,0 +1,112 @@
+import { createAnsiSession, parseAnsi } from "../src/ansi.js";
+
+const ESC = "\x1b";
+
+/**
+ * Feed `input` into a fresh session split at every possible boundary (two
+ * `append()` calls), asserting `finish()` always matches a plain
+ * `parseAnsi(input)` regardless of where the split falls.
+ */
+function expectSameAtEverySplit(input: string) {
+  for (let k = 0; k <= input.length; k += 1) {
+    const session = createAnsiSession();
+    session.append(input.slice(0, k));
+    session.append(input.slice(k));
+    expect(session.finish()).toEqual(parseAnsi(input));
+  }
+}
+
+describe("createAnsiSession", () => {
+  it("matches parseAnsi for plain text split at every boundary", () => {
+    expectSameAtEverySplit("hello world");
+  });
+
+  it("matches parseAnsi for one styled word split at every boundary", () => {
+    expectSameAtEverySplit(`${ESC}[1;31mhello${ESC}[0m world`);
+  });
+
+  it("matches parseAnsi for multiple colors split at every boundary", () => {
+    expectSameAtEverySplit(
+      `${ESC}[32mA B${ESC}[34mC${ESC}[0m ${ESC}[38;5;208mD${ESC}[0m`,
+    );
+  });
+
+  it("matches parseAnsi for an OSC 8 link split at every boundary", () => {
+    expectSameAtEverySplit(
+      `see ${ESC}]8;;https://example.com${ESC}\\docs${ESC}]8;;${ESC}\\ here`,
+    );
+  });
+
+  it("matches parseAnsi for a \\r overwrite split at every boundary", () => {
+    expectSameAtEverySplit("building 50%\rbuilding 100%\rdone");
+  });
+
+  it("matches parseAnsi for \\r\\n split at every boundary", () => {
+    expectSameAtEverySplit("a\r\nb");
+  });
+
+  it("holds back an SGR sequence split mid-parameter", () => {
+    const session = createAnsiSession();
+    session.append(`a${ESC}[3`);
+    // Mid-stream: the split SGR is still pending, so only "a" is settled.
+    expect(session.segments()).toEqual([{ text: "a" }]);
+    session.append("2mred");
+    expect(session.finish()).toEqual(parseAnsi(`a${ESC}[32mred`));
+  });
+
+  it("holds back an OSC 8 sequence split mid-URI", () => {
+    const session = createAnsiSession();
+    session.append(`${ESC}]8;;http`);
+    expect(session.segments()).toEqual([]);
+    session.append(`s://example.com${ESC}\\x${ESC}]8;;${ESC}\\`);
+    expect(session.finish()).toEqual(
+      parseAnsi(`${ESC}]8;;https://example.com${ESC}\\x${ESC}]8;;${ESC}\\`),
+    );
+  });
+
+  it("holds back a lone trailing ESC", () => {
+    const session = createAnsiSession();
+    session.append(`a${ESC}`);
+    expect(session.segments()).toEqual([{ text: "a" }]);
+    session.append("[31mb");
+    expect(session.finish()).toEqual(parseAnsi(`a${ESC}[31mb`));
+  });
+
+  it("collapses a lone trailing \\r immediately followed by \\n in the next chunk", () => {
+    const session = createAnsiSession();
+    session.append("a\r");
+    session.append("\nb");
+    expect(session.finish()).toEqual(parseAnsi("a\r\nb"));
+  });
+
+  it("resolves a lone trailing \\r as an overwrite when the session ends there", () => {
+    const session = createAnsiSession();
+    session.append("building 50%\rdone");
+    session.append("\r");
+    expect(session.finish()).toEqual(parseAnsi("building 50%\rdone\r"));
+  });
+
+  it("reflects the completed prefix plus a live trailing segment mid-stream", () => {
+    const session = createAnsiSession();
+    session.append(`before${ESC}[31m`);
+    expect(session.segments()).toEqual([{ text: "before" }]);
+    session.append("red text");
+    expect(session.segments()).toEqual([
+      { text: "before" },
+      { text: "red text", fg: { name: "red" } },
+    ]);
+    // Calling segments() again does not mutate state.
+    expect(session.segments()).toEqual([
+      { text: "before" },
+      { text: "red text", fg: { name: "red" } },
+    ]);
+  });
+
+  it("does not mutate state when reading segments() without finishing", () => {
+    const session = createAnsiSession();
+    session.append("abc");
+    session.segments();
+    session.append("def");
+    expect(session.finish()).toEqual([{ text: "abcdef" }]);
+  });
+});

--- a/tests/e2e/AnsiOutput.streaming.test.svelte
+++ b/tests/e2e/AnsiOutput.streaming.test.svelte
@@ -1,0 +1,35 @@
+<script lang="ts">
+  import { AnsiOutput } from "svelte-highlight";
+
+  const ESC = "\x1b";
+
+  // Chunk boundaries split mid-SGR-parameter ("...[3" | "2m...") and
+  // mid-OSC-8-URI ("...;;https://exa" | "mple.com...").
+  const CHUNKS = [
+    `${ESC}[3`,
+    `2mgreen${ESC}[0m `,
+    `see ${ESC}]8;;https://exa`,
+    `mple.com${ESC}\\docs${ESC}]8;;${ESC}\\`,
+  ];
+  const fullText = CHUNKS.join("");
+
+  let text = "";
+  let chunksSent = 0;
+  let done = false;
+
+  function appendChunk() {
+    if (chunksSent >= CHUNKS.length) return;
+    text += CHUNKS[chunksSent];
+    chunksSent += 1;
+    if (chunksSent >= CHUNKS.length) done = true;
+  }
+</script>
+
+<button type="button" data-testid="append-chunk" on:click={appendChunk}>
+  Append chunk
+</button>
+
+<AnsiOutput {text} data-testid="streamed" />
+{#if done}
+  <AnsiOutput text={fullText} data-testid="reference" />
+{/if}

--- a/tests/e2e/AnsiOutput.test.svelte
+++ b/tests/e2e/AnsiOutput.test.svelte
@@ -13,3 +13,5 @@
 <CodeWindow variant="terminal" title="bash" data-testid="window">
   <AnsiOutput {text} data-testid="ansi" />
 </CodeWindow>
+
+<AnsiOutput {text} wrap data-testid="ansi-wrap" />

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1,6 +1,7 @@
 import { expect, test } from "@playwright/experimental-ct-svelte";
 import AnsiOutputContrast from "./AnsiOutput.contrast.test.svelte";
 import AnsiOutputLink from "./AnsiOutput.link.test.svelte";
+import AnsiOutputStreaming from "./AnsiOutput.streaming.test.svelte";
 import AnsiOutput from "./AnsiOutput.test.svelte";
 import CodeWindow from "./CodeWindow.test.svelte";
 import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
@@ -211,6 +212,34 @@ test("AnsiOutput - OSC 8 hyperlink renders as an anchor", async ({
   const unsafe = page.getByTestId("ansi-unsafe");
   await expect(unsafe.locator("a")).toHaveCount(0);
   await expect(unsafe.locator("span", { hasText: "here" })).toBeVisible();
+});
+
+test("AnsiOutput - streamed appends match a single non-streamed render", async ({
+  mount,
+  page,
+}) => {
+  await mount(AnsiOutputStreaming);
+
+  const append = page.getByTestId("append-chunk");
+  // Each click appends a chunk; the 2nd and 4th split an SGR sequence and
+  // an OSC 8 URI respectively across the append() boundary.
+  await append.click();
+  await append.click();
+  await append.click();
+  await append.click();
+
+  const streamed = page.getByTestId("streamed");
+  await expect(streamed.getByText("green")).toHaveCSS(
+    "color",
+    "rgb(0, 205, 0)",
+  );
+  const link = streamed.locator("a");
+  await expect(link).toHaveText("docs");
+  await expect(link).toHaveAttribute("href", "https://example.com");
+
+  const reference = page.getByTestId("reference");
+  await expect(streamed).toHaveText(await reference.innerText());
+  expect(await streamed.innerHTML()).toBe(await reference.innerHTML());
 });
 
 test("Highlight", async ({ mount, page }) => {

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -177,6 +177,19 @@ test("AnsiOutput - renders styled spans inside a terminal window", async ({
   await expect(page.getByTestId("window").locator(".prompt")).toBeVisible();
 });
 
+test("AnsiOutput - wrap sets white-space: pre-wrap", async ({
+  mount,
+  page,
+}) => {
+  await mount(AnsiOutput);
+
+  await expect(page.getByTestId("ansi")).toHaveCSS("white-space", "pre");
+  await expect(page.getByTestId("ansi-wrap")).toHaveCSS(
+    "white-space",
+    "pre-wrap",
+  );
+});
+
 test("AnsiOutput - auto-contrast keeps low-contrast spans readable", async ({
   mount,
   page,

--- a/www/components/AnsiOutput/Examples.svelte
+++ b/www/components/AnsiOutput/Examples.svelte
@@ -74,6 +74,11 @@
 
   const gitMarkup = "<AnsiOutput {text} />";
 
+  const longLine =
+    `${sgr(31)}FAIL${R} tests/parser.test.ts` +
+    " > parses a very long line of streamed build output without wrapping the container itself, only the text inside it";
+  const wrapMarkup = "<AnsiOutput {text} wrap />";
+
   /** @param {string} uri */
   const osc8 = (uri) => `${ESC}]8;;${uri}${ESC}\\`;
   const links = [
@@ -131,6 +136,7 @@
   const gitSnippet = snippetFor("AnsiOutput", gitDiff, gitMarkup);
   const linksSnippet = snippetFor("AnsiOutput", links, linksMarkup);
   const lightSnippet = snippetFor("AnsiOutput", vitest, lightMarkup);
+  const wrapSnippet = snippetFor("AnsiOutput", longLine, wrapMarkup);
 </script>
 
 <div class="mb-5">
@@ -212,4 +218,14 @@
     --ansi-bold-weight="600"
     --ansi-dim-opacity="0.7"
   />
+</div>
+
+<p class="label-01 mb-3">
+  Wrapping a long line instead of scrolling. Set <code class="code">wrap</code>.
+</p>
+<div class="mb-3">
+  <HighlightSvelte code={wrapSnippet} class={THEME_MODULE_NAME} />
+</div>
+<div class="mb-5" style="max-width: 32em;">
+  <AnsiOutput text={longLine} wrap />
 </div>


### PR DESCRIPTION
Adds an incremental parser session for streamed/appended ANSI text,
wires AnsiOutput to use it for append-only text changes, and gives
AnsiOutput a wrap prop for long lines. Includes a repeated-append
benchmark and docs for the new prop.

## Benchmark

Measured with `bun x ostia bench --isolate bench/ansi.bench.ts`,
appending 200-byte chunks and comparing createAnsiSession against
re-parsing the whole accumulated string after every chunk (medians):

| segments | naive re-parse | createAnsiSession | speedup |
| -------- | -------------- | ------------------ | ------- |
| 2,000    | 179.9ms        | 1.37ms              | ~131x   |
| 20,000   | 21.7s          | 41.9ms              | ~518x   |