### PR TITLE
feat(compat): accept grammar source and return warnings

### DIFF
--- a/README.md
+++ b/README.md
@@ -986,6 +986,15 @@ The easiest way to author one is with `svelte-highlight/compat`'s `fromHighlight
 
 `fromHighlightJs` needs `highlight.js` itself, which svelte-highlight does not bundle — install it as your own dependency (`npm install highlight.js`). It's only imported the first time you call `fromHighlightJs`, so pages that never use it don't pay for it.
 
+`fromHighlightJs` also accepts an optional third `source` argument (raw source text, e.g. via a bundler's `?raw` import) to recover array-membership `on:begin` guards the compiled callback alone can't expose, and the returned object carries a `warnings: string[]` field (empty when clean) so you can detect a degraded conversion without reading the console.
+
+```ts
+const language = await fromHighlightJs("custom-language", defineCustomLanguage, grammarSourceText);
+if (language.warnings.length > 0) {
+  console.error("custom-language degraded:", language.warnings);
+}
+```
+
 If you're using TypeScript, use the `LanguageType` interface to type the language.
 
 ```ts

--- a/src/compat.d.ts
+++ b/src/compat.d.ts
@@ -6,8 +6,15 @@ import type { LanguageType } from "./languages/index.d.ts";
  * `HighlightAuto`, `HighlightEditable`, `HighlightStream`, the `highlight`
  * action, or `loadLanguage`-style dynamic registration. Requires
  * `highlight.js` as your own dependency (not bundled by svelte-highlight).
+ *
+ * @param source raw source text of the grammar's own file (e.g. via a
+ *   bundler's `?raw` import); recovers array-membership `on:begin` guards
+ *   that the compiled callback alone can't expose.
+ * @returns `warnings` lists hljs features with no IR equivalent; empty when
+ *   the conversion is clean.
  */
 export function fromHighlightJs(
   name: string,
   languageFn: (hljs: unknown) => object,
-): Promise<LanguageType<string>>;
+  source?: string,
+): Promise<LanguageType<string> & { warnings: string[] }>;

--- a/src/compat.js
+++ b/src/compat.js
@@ -17,9 +17,13 @@ let hljs;
  * @param {string} name
  * @param {(hljs: unknown) => object} languageFn hljs's `register(hljs)`
  *   shape: returns the grammar's root mode object.
- * @returns {Promise<LanguageType>}
+ * @param {string} [source] raw source text of the grammar's own file (e.g.
+ *   via a bundler's `?raw` import); recovers array-membership `on:begin`
+ *   guards that the compiled callback alone can't expose.
+ * @returns {Promise<LanguageType & { warnings: string[] }>} `warnings` lists
+ *   hljs features with no IR equivalent; empty when the conversion is clean.
  */
-export async function fromHighlightJs(name, languageFn) {
+export async function fromHighlightJs(name, languageFn, source) {
   if (!hljs) {
     const { default: coreFactory } = await import("highlight.js/lib/core");
     hljs = coreFactory.newInstance();
@@ -29,14 +33,14 @@ export async function fromHighlightJs(name, languageFn) {
       hljs
     );
   hl.registerLanguage(name, languageFn);
-  const { ir, warnings } = convertLanguage(hljs, name);
+  const { ir, warnings } = convertLanguage(hljs, name, source);
   if (warnings.length > 0 && typeof console !== "undefined") {
     console.warn(
       `[svelte-highlight/compat] "${name}" uses hljs features with no declarative IR equivalent yet, and may not highlight identically to real hljs:\n${warnings.map((w) => `  - ${w}`).join("\n")}`,
     );
   }
-  /** @type {LanguageType} */
-  const language = { name: ir.name, register: ir };
+  /** @type {LanguageType & { warnings: string[] }} */
+  const language = { name: ir.name, register: ir, warnings };
   if (ir.aliases) language.aliases = ir.aliases;
   return language;
 }

--- a/tests/compat.test.ts
+++ b/tests/compat.test.ts
@@ -45,4 +45,104 @@ describe("fromHighlightJs", () => {
     const language = await fromHighlightJs("curl", defineCurl);
     expect(language.name).toBe("curl");
   });
+
+  it("recovers an on:begin word-set guard only when given the grammar's source", async () => {
+    function defineWordSetGrammar(_hljs: any) {
+      // biome-ignore lint/style/useNamingConvention: must match grammarSource's literal text below
+      const SYMS = ["Alpha", "Beta"];
+      // biome-ignore lint/style/useNamingConvention: must match grammarSource's literal text below
+      const SYMS_SET = new Set(SYMS);
+      return {
+        name: "wordset-lang",
+        contains: [
+          {
+            className: "built_in",
+            begin: /[A-Za-z]+/,
+            "on:begin": (match: any, response: any) => {
+              if (!SYMS_SET.has(match[0])) response.ignoreMatch();
+            },
+          },
+        ],
+      };
+    }
+    const grammarSource = `
+      const SYMS_SET = new Set(SYMS);
+      const SYMS = ["Alpha", "Beta"];
+    `;
+
+    const withoutSource = await fromHighlightJs(
+      "wordset-a",
+      defineWordSetGrammar,
+    );
+    expect(
+      withoutSource.warnings.some((w) =>
+        w.includes("on:begin not convertible"),
+      ),
+    ).toBe(true);
+    const registryWithout = createRegistry();
+    registryWithout.register(withoutSource.register);
+    const resultWithout = registryWithout.highlight("Alpha Zulu", {
+      language: "wordset-a",
+    });
+    expect(resultWithout.value).toContain(
+      '<span class="hljs-built_in">Alpha</span>',
+    );
+    expect(resultWithout.value).toContain(
+      '<span class="hljs-built_in">Zulu</span>',
+    );
+
+    const withSource = await fromHighlightJs(
+      "wordset-b",
+      defineWordSetGrammar,
+      grammarSource,
+    );
+    expect(withSource.warnings).toEqual([]);
+    const registryWith = createRegistry();
+    registryWith.register(withSource.register);
+    const resultWith = registryWith.highlight("Alpha Zulu", {
+      language: "wordset-b",
+    });
+    expect(resultWith.value).toContain(
+      '<span class="hljs-built_in">Alpha</span>',
+    );
+    expect(resultWith.value).not.toContain(
+      '<span class="hljs-built_in">Zulu</span>',
+    );
+  });
+
+  it("degrades an unrecognized on:begin guard regardless of source", async () => {
+    function defineUnrecognizedGuardGrammar(_hljs: any) {
+      return {
+        name: "unrecognized-guard-lang",
+        contains: [
+          {
+            className: "built_in",
+            begin: /[A-Za-z]+/,
+            "on:begin": (match: any, response: any) => {
+              if (match[0].length < 3) response.ignoreMatch();
+            },
+          },
+        ],
+      };
+    }
+
+    const language = await fromHighlightJs(
+      "unrecognized-guard-lang",
+      defineUnrecognizedGuardGrammar,
+      "irrelevant source text",
+    );
+    expect(
+      language.warnings.some((w) => w.includes("on:begin not convertible")),
+    ).toBe(true);
+
+    const registry = createRegistry();
+    registry.register(language.register);
+    const result = registry.highlight("Hi Alphabet", {
+      language: "unrecognized-guard-lang",
+    });
+    expect(result.value).toContain('<span class="hljs-built_in">Hi</span>');
+    expect(result.value).toContain(
+      '<span class="hljs-built_in">Alphabet</span>',
+    );
+  });
 });


### PR DESCRIPTION
fromHighlightJs only ever called convertLanguage with two arguments,
so custom grammars with an hljs array-membership on:begin guard (e.g.
a Set.has(match[0]) check) always degraded to an unconditional match
at runtime, even though the build-time converter already threads the
grammar's source through for exactly this case. This also adds a
MIGRATION.md covering the 7.16 custom-language break.