### PR TITLE
test(languages): round-trip a loaded grammar through registerAll

### DIFF
--- a/README.md
+++ b/README.md
@@ -1088,7 +1088,21 @@ The example above imports a specific language as a static string, which lets the
 {/await}
 ```
 
-`loadLanguage` accepts a [supported language name](SUPPORTED_LANGUAGES.md), dynamically imports its grammar, and resolves with the language object. It rejects with an `Unknown language` error for an unrecognized name, so handle the `{:catch}` block (or `.catch`) when the name comes from untrusted input. Grammars with embedded sublanguages (`astro`, `svelte`, and others with a `dependencies` list) register their dependencies automatically — `Highlight`, `HighlightAuto`, and `HighlightSvelte` all call `ensureRegistered` on the language they're given, which registers the grammar and recurses through its dependencies.
+`loadLanguage` accepts a [supported language name](SUPPORTED_LANGUAGES.md), dynamically imports its grammar, and resolves with the language object. It rejects with a `LanguageLoadError` for an unrecognized name, so handle the `{:catch}` block (or `.catch`) when the name comes from untrusted input. `LanguageLoadError` is importable from `svelte-highlight` for an `instanceof` check:
+
+```js
+import { LanguageLoadError } from "svelte-highlight";
+
+try {
+  const grammar = await loadLanguage(name);
+} catch (error) {
+  if (error instanceof LanguageLoadError) {
+    // handle a missing/misspelled language name
+  }
+}
+```
+
+Grammars with embedded sublanguages (`astro`, `svelte`, and others with a `dependencies` list) register their dependencies automatically — `Highlight`, `HighlightAuto`, and `HighlightSvelte` all call `ensureRegistered` on the language they're given, which registers the grammar and recurses through its dependencies.
 
 `loadLanguage` does a fresh `import()` on every call and keeps no explicit cache, but it's safe to call repeatedly for the same name: module loaders dedupe dynamic imports by resolved specifier rather than re-fetching, so repeated calls resolve to the same cached module.
 

--- a/README.md
+++ b/README.md
@@ -1061,6 +1061,8 @@ In the example below, the `HighlightAuto` component and injected styles are dyna
 />
 ```
 
+Registering a grammar checks its canonical name, not an alias lookup, before skipping — so a grammar that aliases another (highlight.js's "ini" aliases "toml") can't make the real grammar look already-registered before it has actually loaded.
+
 ### Loading a language by name
 
 The example above imports a specific language as a static string, which lets the bundler split out only the grammars you reference. When the language is known only at **runtime** — a Markdown fence (` ```ts `), an API field, or a user-selected value — use the `loadLanguage` helper to import a grammar by name:
@@ -1086,9 +1088,11 @@ The example above imports a specific language as a static string, which lets the
 {/await}
 ```
 
-`loadLanguage` accepts a [supported language name](SUPPORTED_LANGUAGES.md), dynamically imports its grammar, and resolves with the language object. It rejects with an `Unknown language` error for an unrecognized name, so handle the `{:catch}` block (or `.catch`) when the name comes from untrusted input.
+`loadLanguage` accepts a [supported language name](SUPPORTED_LANGUAGES.md), dynamically imports its grammar, and resolves with the language object. It rejects with an `Unknown language` error for an unrecognized name, so handle the `{:catch}` block (or `.catch`) when the name comes from untrusted input. Grammars with embedded sublanguages (`astro`, `svelte`, and others with a `dependencies` list) register their dependencies automatically — `Highlight`, `HighlightAuto`, and `HighlightSvelte` all call `ensureRegistered` on the language they're given, which registers the grammar and recurses through its dependencies.
 
-> **Note:** Because the imported name is dynamic, the bundler cannot prune unused grammars and will emit a chunk for every language. Prefer a static `import` when the language is known ahead of time, and reach for `loadLanguage` only when it is not.
+`loadLanguage` does a fresh `import()` on every call and keeps no explicit cache, but it's safe to call repeatedly for the same name: module loaders dedupe dynamic imports by resolved specifier rather than re-fetching, so repeated calls resolve to the same cached module.
+
+> **Note:** Because the imported name is dynamic, the bundler cannot prune unused grammars and will emit a chunk for every language — all 279 shipped grammars. Prefer a static `import` when the language is known ahead of time, and reach for `loadLanguage` only when it is not.
 
 A practical case is rendering Markdown, where each fenced block declares its own language:
 

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -16,7 +16,7 @@ export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as HighlightVirtual } from "./HighlightVirtual.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export type { LanguageName, LanguageType } from "./languages";
-export { loadLanguage } from "./load-language";
+export { LanguageLoadError, loadLanguage } from "./load-language";
 export {
   dualStyle,
   scopeClassFor,

--- a/src/index.js
+++ b/src/index.js
@@ -13,7 +13,7 @@ export { default as HighlightStyle } from "./HighlightStyle.svelte";
 export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as HighlightVirtual } from "./HighlightVirtual.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
-export { loadLanguage } from "./load-language.js";
+export { LanguageLoadError, loadLanguage } from "./load-language.js";
 export {
   dualStyle,
   scopeClassFor,

--- a/src/load-language.d.ts
+++ b/src/load-language.d.ts
@@ -1,6 +1,24 @@
 import type { LanguageName, LanguageType } from "./languages";
 
 /**
+ * Thrown by `loadLanguage` when `name` cannot be resolved to a shipped
+ * grammar module. Catchable via `instanceof` regardless of how the
+ * underlying dynamic `import()` failure is reported by the bundler.
+ *
+ * This still fires for *any* `import()` failure — a real typo, or a
+ * network-fetched chunk failing — not only a genuine unknown name; it
+ * doesn't validate `name` against the known-language list first, since
+ * that would require importing the full 279-grammar catalog, defeating
+ * the point of `loadLanguage`. What it provides: a stable,
+ * `instanceof`-checkable type across bundlers, a `.language` field, and
+ * the original failure on `.cause`.
+ */
+export declare class LanguageLoadError extends Error {
+  language: string;
+  constructor(name: string, options?: ErrorOptions);
+}
+
+/**
  * Load a highlight.js grammar by name at runtime.
  * Prefer a static import when the language is known up front.
  */

--- a/src/load-language.js
+++ b/src/load-language.js
@@ -1,4 +1,29 @@
 /**
+ * Thrown by `loadLanguage` when `name` cannot be resolved to a shipped
+ * grammar module. Catchable via `instanceof` regardless of how the
+ * underlying dynamic `import()` failure is reported by the bundler.
+ *
+ * This still fires for *any* `import()` failure — a real typo, or a
+ * network-fetched chunk failing — not only a genuine unknown name; it
+ * doesn't validate `name` against the known-language list first, since
+ * that would require importing the full 279-grammar catalog, defeating
+ * the point of `loadLanguage`. What it provides: a stable,
+ * `instanceof`-checkable type across bundlers, a `.language` field, and
+ * the original failure on `.cause`.
+ */
+export class LanguageLoadError extends Error {
+  /**
+   * @param {string} name
+   * @param {ErrorOptions} [options]
+   */
+  constructor(name, options) {
+    super(`Unknown language: "${name}"`, options);
+    this.name = "LanguageLoadError";
+    this.language = name;
+  }
+}
+
+/**
  * Load a highlight.js grammar by name at runtime.
  * Prefer a static import when the language is known up front.
  *
@@ -10,6 +35,6 @@ export async function loadLanguage(name) {
     const module = await import(`./languages/${name}.js`);
     return module.default;
   } catch (cause) {
-    throw new Error(`Unknown language: "${name}"`, { cause });
+    throw new LanguageLoadError(name, { cause });
   }
 }

--- a/tests/load-language.test.ts
+++ b/tests/load-language.test.ts
@@ -1,5 +1,5 @@
 import { createRegistry, registerAll } from "../src/engine.js";
-import { loadLanguage } from "../src/load-language.js";
+import { LanguageLoadError, loadLanguage } from "../src/load-language.js";
 
 describe("loadLanguage", () => {
   it("loads a known language", async () => {
@@ -10,9 +10,12 @@ describe("loadLanguage", () => {
 
   it("rejects an unknown language", async () => {
     // @ts-expect-error — intentionally invalid name
-    await expect(loadLanguage("not-a-language")).rejects.toThrow(
-      /Unknown language/,
-    );
+    const promise = loadLanguage("not-a-language");
+    await expect(promise).rejects.toThrow(/Unknown language/);
+    await expect(promise).rejects.toBeInstanceOf(LanguageLoadError);
+    await promise.catch((error) => {
+      expect(error.language).toBe("not-a-language");
+    });
   });
 
   it("round-trips through ensureRegistered/registerAll with its dependencies", async () => {

--- a/tests/load-language.test.ts
+++ b/tests/load-language.test.ts
@@ -1,3 +1,4 @@
+import { createRegistry, registerAll } from "../src/engine.js";
 import { loadLanguage } from "../src/load-language.js";
 
 describe("loadLanguage", () => {
@@ -12,5 +13,18 @@ describe("loadLanguage", () => {
     await expect(loadLanguage("not-a-language")).rejects.toThrow(
       /Unknown language/,
     );
+  });
+
+  it("round-trips through ensureRegistered/registerAll with its dependencies", async () => {
+    const registry = createRegistry();
+
+    const astro = await loadLanguage("astro");
+    registerAll(registry, astro);
+
+    expect(registry.get("astro")).toBeTruthy();
+    expect(registry.get("html")).toBeTruthy();
+    expect(registry.get("typescript")).toBeTruthy();
+    expect(registry.get("css")).toBeTruthy();
+    expect(registry.get("javascript")).toBeTruthy();
   });
 });


### PR DESCRIPTION
Also documents registerAll's dedup contract and loadLanguage's costs
in the README, and swaps loadLanguage's plain Error rejection for a
typed, instanceof-checkable LanguageLoadError with a .language field.