### PR TITLE
fix(components): dispatch on:highlight for empty code, once per change

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,8 @@ Import languages from `svelte-highlight/languages`.
 
 See [SUPPORTED_LANGUAGES.md](SUPPORTED_LANGUAGES.md) for a list of supported languages.
 
+`code` accepts any value and is coerced with `String(code ?? "")`: an object like `{}` renders as `"[object Object]"`, while `undefined`/`null` render as nothing.
+
 ```svelte
 <script>
   import Highlight from "svelte-highlight";

--- a/README.md
+++ b/README.md
@@ -49,6 +49,16 @@ See [SUPPORTED_LANGUAGES.md](SUPPORTED_LANGUAGES.md) for a list of supported lan
 <Highlight language={typescript} {code} />
 ```
 
+### Wrapping Long Lines
+
+By default, overflowing horizontal content is contained by a scrollbar. Set `wrap` to `true` to wrap long lines instead.
+
+```svelte
+<Highlight wrap language={typescript} {code} />
+```
+
+Don't combine `wrap` with `HighlightStream`'s `virtualize` mode or `HighlightVirtual` -- both assume one fixed-height line per row, which wrapping breaks.
+
 ## Theming
 
 Every `highlight.js` theme is also compiled into a **`ThemePalette`**: a typed object of `--shl-*` CSS custom properties plus a shared structural stylesheet (`svelte-highlight/themes/base.css`) that maps `.hljs*` classes to those variables. This is the recommended way to theme new projects — themes are data, scoping is an inline `style` attribute (SSR-safe by construction), and any token is overridable with one CSS line or a Svelte style prop. See [SUPPORTED_THEMES.md](SUPPORTED_THEMES.md) for a list of compiled themes.
@@ -1600,6 +1610,7 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 | code     | `any`                                          | N/A (required) |
 | language | { name: `string`; register: `object` } | N/A (required) |
 | langtag  | `boolean`                                      | `false`        |
+| wrap     | `boolean`                                      | `false`        |
 
 `$$restProps` are forwarded to the top-level `pre` element.
 
@@ -1703,6 +1714,7 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 | :------ | :-------- | :------------- |
 | code    | `any`     | N/A (required) |
 | langtag | `boolean` | `false`        |
+| wrap    | `boolean` | `false`        |
 
 `$$restProps` are forwarded to the top-level `pre` element.
 
@@ -1735,6 +1747,7 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 | code      | `any`            | N/A (required) |
 | languages | `LanguageName[]` | `undefined`    |
 | langtag   | `boolean`        | `false`        |
+| wrap      | `boolean`        | `false`        |
 
 `$$restProps` are forwarded to the top-level `pre` element.
 

--- a/README.md
+++ b/README.md
@@ -1605,7 +1605,7 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 
 #### Dispatched Events
 
-- **on:highlight**: fired after `code` is highlighted
+- **on:highlight**: fired after `code` is highlighted, once per change (not on unrelated re-renders), including when the result is empty (empty `code`)
 
 ```svelte
 <Highlight
@@ -1708,7 +1708,7 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 
 #### Dispatched Events
 
-- **on:highlight**: fired after `code` is highlighted
+- **on:highlight**: fired after `code` is highlighted, once per change (not on unrelated re-renders), including when the result is empty (empty `code`)
 
 ```svelte
 <HighlightSvelte
@@ -1746,7 +1746,7 @@ import type { LanguageName } from "svelte-highlight";
 
 #### Dispatched Events
 
-- **on:highlight**: fired after `code` is highlighted
+- **on:highlight**: fired after `code` is highlighted, once per change (not on unrelated re-renders), including when the result is empty (empty `code`, or no candidate language matches)
 
 ```svelte
 <HighlightAuto

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -8,6 +8,9 @@
   /** @type {boolean} */
   export let langtag = false;
 
+  /** @type {boolean} */
+  export let wrap = false;
+
   import { afterUpdate, createEventDispatcher } from "svelte";
   import LangTag from "./LangTag.svelte";
   import { ensureRegistered, registry } from "./registry.js";
@@ -43,11 +46,12 @@
   }
 </script>
 
-<slot {highlighted} {langtag} languageName={language.name} {events}>
+<slot {highlighted} {langtag} {wrap} languageName={language.name} {events}>
   <LangTag
     {...$$restProps}
     languageName={language.name}
     {langtag}
+    {wrap}
     {highlighted}
     {code}
   />

--- a/src/Highlight.svelte
+++ b/src/Highlight.svelte
@@ -24,8 +24,14 @@
   /** @type {import("./engine.d.ts").ScopeEvent[]} */
   let events = [];
 
+  /** @type {import("./engine.d.ts").ScopeEvent[] | undefined} */
+  let lastDispatchedEvents;
+
   afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted, events });
+    if (events !== lastDispatchedEvents) {
+      lastDispatchedEvents = events;
+      dispatch("highlight", { highlighted, events });
+    }
   });
 
   $: {

--- a/src/Highlight.svelte.d.ts
+++ b/src/Highlight.svelte.d.ts
@@ -73,6 +73,10 @@ export type HighlightProps = HTMLAttributes<HTMLPreElement> &
   LangtagProps & {
     /**
      * Code to highlight.
+     *
+     * The container also exposes `--overflow-x`, `--overflow-y`,
+     * `--border-radius`, `--width`, and `--max-width` CSS variables. See
+     * README's "Container variables" section.
      */
     code: any;
 

--- a/src/Highlight.svelte.d.ts
+++ b/src/Highlight.svelte.d.ts
@@ -73,6 +73,11 @@ export type HighlightProps = HTMLAttributes<HTMLPreElement> &
   };
 
 export type HighlightEvents = {
+  /**
+   * Fires once per highlight (when `code`/`language` change and the
+   * highlighting result actually changes), including when the result is
+   * empty (empty `code`).
+   */
   highlight: CustomEvent<{
     /**
      * The highlighted HTML as a string.

--- a/src/Highlight.svelte.d.ts
+++ b/src/Highlight.svelte.d.ts
@@ -54,6 +54,19 @@ export type LangtagProps = {
    * @default "1em"
    */
   "--langtag-padding"?: string;
+
+  /**
+   * Wrap long lines instead of scrolling horizontally: sets
+   * `white-space: pre-wrap; overflow-wrap: anywhere` on the container.
+   *
+   * Only affects the built-in `LangTag` fallback; a consumer overriding the
+   * default slot must set `white-space` themselves. Not compatible with
+   * `HighlightStream`'s `virtualize` mode or `HighlightVirtual`, which
+   * assume one fixed-height line per row.
+   *
+   * @default false
+   */
+  wrap?: boolean;
 };
 
 export type HighlightProps = HTMLAttributes<HTMLPreElement> &

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -10,6 +10,9 @@
   /** @type {boolean} */
   export let langtag = false;
 
+  /** @type {boolean} */
+  export let wrap = false;
+
   import { afterUpdate, createEventDispatcher } from "svelte";
   import { registerAll } from "./engine.js";
   // All shipped grammars so auto-detect sees customs too. Static import keeps
@@ -62,11 +65,12 @@
   }
 </script>
 
-<slot {highlighted} {langtag} languageName={language} {events}>
+<slot {highlighted} {langtag} {wrap} languageName={language} {events}>
   <LangTag
     {...$$restProps}
     languageName={language}
     {langtag}
+    {wrap}
     {highlighted}
     {code}
   />

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -41,8 +41,14 @@
   /** @type {import("./engine.d.ts").ScopeEvent[]} */
   let events = [];
 
+  /** @type {import("./engine.d.ts").ScopeEvent[] | undefined} */
+  let lastDispatchedEvents;
+
   afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted, language, events });
+    if (events !== lastDispatchedEvents) {
+      lastDispatchedEvents = events;
+      dispatch("highlight", { highlighted, language, events });
+    }
   });
 
   $: {

--- a/src/HighlightAuto.svelte.d.ts
+++ b/src/HighlightAuto.svelte.d.ts
@@ -20,6 +20,11 @@ export type HighlightAutoProps = HTMLAttributes<HTMLPreElement> &
   };
 
 export type HighlightAutoEvents = {
+  /**
+   * Fires once per highlight (when `code`/`languageNames` change and the
+   * highlighting result actually changes), including when the result is
+   * empty (empty `code`, or no candidate language matches).
+   */
   highlight: CustomEvent<{
     /**
      * The highlighted HTML as a string.

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -23,8 +23,14 @@
   /** @type {import("./engine.d.ts").ScopeEvent[]} */
   let events = [];
 
+  /** @type {import("./engine.d.ts").ScopeEvent[] | undefined} */
+  let lastDispatchedEvents;
+
   afterUpdate(() => {
-    if (highlighted) dispatch("highlight", { highlighted, events });
+    if (events !== lastDispatchedEvents) {
+      lastDispatchedEvents = events;
+      dispatch("highlight", { highlighted, events });
+    }
   });
 
   $: {

--- a/src/HighlightSvelte.svelte
+++ b/src/HighlightSvelte.svelte
@@ -7,6 +7,9 @@
   /** @type {boolean} */
   export let langtag = false;
 
+  /** @type {boolean} */
+  export let wrap = false;
+
   import { afterUpdate, createEventDispatcher } from "svelte";
   import svelte from "./languages/svelte";
   import { ensureRegistered, registry } from "./registry.js";
@@ -42,11 +45,12 @@
   }
 </script>
 
-<slot {highlighted} {langtag} languageName="svelte" {events}>
+<slot {highlighted} {langtag} {wrap} languageName="svelte" {events}>
   <LangTag
     {...$$restProps}
     languageName="svelte"
     {langtag}
+    {wrap}
     {highlighted}
     {code}
   />

--- a/src/HighlightSvelte.svelte.d.ts
+++ b/src/HighlightSvelte.svelte.d.ts
@@ -12,6 +12,11 @@ export type HighlightSvelteProps = HTMLAttributes<HTMLPreElement> &
   };
 
 export type HighlightSvelteEvents = {
+  /**
+   * Fires once per highlight (when `code` changes and the highlighting
+   * result actually changes), including when the result is empty (empty
+   * `code`).
+   */
   highlight: CustomEvent<{
     /**
      * The highlighted HTML as a string.

--- a/src/LangTag.svelte
+++ b/src/LangTag.svelte
@@ -10,10 +10,14 @@
 
   /** @type {boolean} */
   export let langtag = false;
+
+  /** @type {boolean} */
+  export let wrap = false;
 </script>
 
 <pre
   class:langtag={langtag}
+  class:wrap={wrap}
   data-language={languageName}
   style:overflow-x="var(--overflow-x, auto)"
   style:overflow-y="var(--overflow-y, auto)"

--- a/src/langtag.css
+++ b/src/langtag.css
@@ -2,6 +2,11 @@
   position: relative;
 }
 
+.wrap {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 .langtag::after {
   content: attr(data-language);
   position: absolute;

--- a/tests/e2e/Highlight.dispatchOnce.test.svelte
+++ b/tests/e2e/Highlight.dispatchOnce.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import Highlight from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+
+  let langtag = false;
+  let dispatchCount = 0;
+</script>
+
+<button type="button" on:click={() => (langtag = !langtag)}>
+  Toggle langtag
+</button>
+
+<Highlight
+  {langtag}
+  language={typescript}
+  {code}
+  on:highlight={() => dispatchCount++}
+/>
+
+<p data-testid="dispatch-count">{dispatchCount}</p>

--- a/tests/e2e/Highlight.emptyCode.test.svelte
+++ b/tests/e2e/Highlight.emptyCode.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import Highlight from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  let dispatchCount = 0;
+  let highlightedJson = "";
+  let eventsJson = "";
+</script>
+
+<Highlight
+  language={typescript}
+  code=""
+  on:highlight={(e) => {
+    dispatchCount++;
+    highlightedJson = JSON.stringify(e.detail.highlighted);
+    eventsJson = JSON.stringify(e.detail.events);
+  }}
+/>
+
+<p data-testid="dispatch-count">{dispatchCount}</p>
+<p data-testid="highlighted">{highlightedJson}</p>
+<p data-testid="events">{eventsJson}</p>

--- a/tests/e2e/Highlight.wrap.test.svelte
+++ b/tests/e2e/Highlight.wrap.test.svelte
@@ -1,0 +1,9 @@
+<script lang="ts">
+  import Highlight from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code =
+    "const veryLongLine = 'this is a single very long line of code that should wrap instead of scrolling horizontally when the wrap prop is set on the Highlight component';";
+</script>
+
+<Highlight wrap language={typescript} {code} style="max-width: 200px" />

--- a/tests/e2e/HighlightAuto.dispatchOnce.test.svelte
+++ b/tests/e2e/HighlightAuto.dispatchOnce.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import { HighlightAuto } from "svelte-highlight";
+
+  const code = "const add = (a, b) => a + b;";
+
+  let langtag = false;
+  let dispatchCount = 0;
+</script>
+
+<button type="button" on:click={() => (langtag = !langtag)}>
+  Toggle langtag
+</button>
+
+<HighlightAuto
+  {langtag}
+  {code}
+  languageNames={["javascript", "typescript"]}
+  on:highlight={() => dispatchCount++}
+/>
+
+<p data-testid="dispatch-count">{dispatchCount}</p>

--- a/tests/e2e/HighlightAuto.emptyCode.test.svelte
+++ b/tests/e2e/HighlightAuto.emptyCode.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { HighlightAuto } from "svelte-highlight";
+
+  let dispatchCount = 0;
+  let highlightedJson = "";
+  let eventsJson = "";
+</script>
+
+<HighlightAuto
+  code=""
+  on:highlight={(e) => {
+    dispatchCount++;
+    highlightedJson = JSON.stringify(e.detail.highlighted);
+    eventsJson = JSON.stringify(e.detail.events);
+  }}
+/>
+
+<p data-testid="dispatch-count">{dispatchCount}</p>
+<p data-testid="highlighted">{highlightedJson}</p>
+<p data-testid="events">{eventsJson}</p>

--- a/tests/e2e/HighlightAuto.noCandidate.test.svelte
+++ b/tests/e2e/HighlightAuto.noCandidate.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { HighlightAuto } from "svelte-highlight";
+
+  const code = "some plain text with no recognizable grammar";
+
+  let dispatchCount = 0;
+  let languageJson = "";
+</script>
+
+<HighlightAuto
+  {code}
+  languageNames={["not-a-registered-language"]}
+  on:highlight={(e) => {
+    dispatchCount++;
+    languageJson = JSON.stringify(e.detail.language);
+  }}
+/>
+
+<p data-testid="dispatch-count">{dispatchCount}</p>
+<p data-testid="language">{languageJson}</p>

--- a/tests/e2e/HighlightSvelte.dispatchOnce.test.svelte
+++ b/tests/e2e/HighlightSvelte.dispatchOnce.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import { HighlightSvelte } from "svelte-highlight";
+
+  const code =
+    "<script>\n  let count = 0;\n<\\/script>\n<button>{count}</button>\n";
+
+  let langtag = false;
+  let dispatchCount = 0;
+</script>
+
+<button type="button" on:click={() => (langtag = !langtag)}>
+  Toggle langtag
+</button>
+
+<HighlightSvelte {langtag} {code} on:highlight={() => dispatchCount++} />
+
+<p data-testid="dispatch-count">{dispatchCount}</p>

--- a/tests/e2e/HighlightSvelte.emptyCode.test.svelte
+++ b/tests/e2e/HighlightSvelte.emptyCode.test.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+  import { HighlightSvelte } from "svelte-highlight";
+
+  let dispatchCount = 0;
+  let highlightedJson = "";
+  let eventsJson = "";
+</script>
+
+<HighlightSvelte
+  code=""
+  on:highlight={(e) => {
+    dispatchCount++;
+    highlightedJson = JSON.stringify(e.detail.highlighted);
+    eventsJson = JSON.stringify(e.detail.events);
+  }}
+/>
+
+<p data-testid="dispatch-count">{dispatchCount}</p>
+<p data-testid="highlighted">{highlightedJson}</p>
+<p data-testid="events">{eventsJson}</p>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -13,6 +13,7 @@ import HighlightDispatchOnce from "./Highlight.dispatchOnce.test.svelte";
 import HighlightEmptyCode from "./Highlight.emptyCode.test.svelte";
 import HighlightEvents from "./Highlight.events.test.svelte";
 import Highlight from "./Highlight.test.svelte";
+import HighlightWrap from "./Highlight.wrap.test.svelte";
 import HighlightActionOmittedCode from "./HighlightAction.omittedCode.test.svelte";
 import HighlightActionRegisterThrows from "./HighlightAction.registerThrows.test.svelte";
 import HighlightAction from "./HighlightAction.test.svelte";
@@ -414,6 +415,12 @@ test("Highlight - dispatches on:highlight once per change, not per re-render", a
   await expect(page.getByTestId("dispatch-count")).toHaveText("1");
   await page.getByRole("button", { name: "Toggle langtag" }).click();
   await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+});
+
+test("Highlight - wrap sets white-space: pre-wrap", async ({ mount, page }) => {
+  await mount(HighlightWrap);
+
+  await expect(page.locator("pre")).toHaveCSS("white-space", "pre-wrap");
 });
 
 test("HighlightAuto - exposes the scope-event stream via slot prop and on:highlight detail", async ({

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -9,13 +9,18 @@ import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
 import CopyButton from "./CopyButton.test.svelte";
 import CopyButtonTransform from "./CopyButton.transform.test.svelte";
 import FileTabs from "./FileTabs.test.svelte";
+import HighlightDispatchOnce from "./Highlight.dispatchOnce.test.svelte";
+import HighlightEmptyCode from "./Highlight.emptyCode.test.svelte";
 import HighlightEvents from "./Highlight.events.test.svelte";
 import Highlight from "./Highlight.test.svelte";
 import HighlightActionOmittedCode from "./HighlightAction.omittedCode.test.svelte";
 import HighlightActionRegisterThrows from "./HighlightAction.registerThrows.test.svelte";
 import HighlightAction from "./HighlightAction.test.svelte";
+import HighlightAutoDispatchOnce from "./HighlightAuto.dispatchOnce.test.svelte";
+import HighlightAutoEmptyCode from "./HighlightAuto.emptyCode.test.svelte";
 import HighlightAutoEvents from "./HighlightAuto.events.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
+import HighlightAutoNoCandidate from "./HighlightAuto.noCandidate.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
 import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
 import HighlightEditableCssHighlights from "./HighlightEditable.cssHighlights.test.svelte";
@@ -30,6 +35,8 @@ import HighlightStreamVirtualize from "./HighlightStream.virtualize.test.svelte"
 import HighlightStyleDedupe from "./HighlightStyle.dedupe.test.svelte";
 import HighlightStyleNoTheme from "./HighlightStyle.noTheme.test.svelte";
 import HighlightStyleThemeSwitch from "./HighlightStyle.themeSwitch.test.svelte";
+import HighlightSvelteDispatchOnce from "./HighlightSvelte.dispatchOnce.test.svelte";
+import HighlightSvelteEmptyCode from "./HighlightSvelte.emptyCode.test.svelte";
 import HighlightSvelteEvents from "./HighlightSvelte.events.test.svelte";
 import HighlightVirtual from "./HighlightVirtual.test.svelte";
 import LangTag from "./LangTag.test.svelte";
@@ -387,6 +394,28 @@ test("Highlight - exposes the scope-event stream via slot prop and on:highlight 
   await expect(page.getByTestId("dispatch-events")).toHaveText(expected ?? "");
 });
 
+test("Highlight - dispatches on:highlight for empty code", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEmptyCode);
+
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+  await expect(page.getByTestId("highlighted")).toHaveText('""');
+  await expect(page.getByTestId("events")).toHaveText("[]");
+});
+
+test("Highlight - dispatches on:highlight once per change, not per re-render", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightDispatchOnce);
+
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+  await page.getByRole("button", { name: "Toggle langtag" }).click();
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+});
+
 test("HighlightAuto - exposes the scope-event stream via slot prop and on:highlight detail", async ({
   mount,
   page,
@@ -399,6 +428,40 @@ test("HighlightAuto - exposes the scope-event stream via slot prop and on:highli
   await expect(page.getByTestId("dispatch-events")).toHaveText(expected ?? "");
 });
 
+test("HighlightAuto - dispatches on:highlight for empty code", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightAutoEmptyCode);
+
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+  await expect(page.getByTestId("highlighted")).toHaveText('""');
+  const events = await page.getByTestId("events").textContent();
+  expect(events).not.toBe("");
+  expect(JSON.parse(events ?? "[]")).not.toEqual([]);
+});
+
+test("HighlightAuto - dispatches on:highlight when no candidate language matches", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightAutoNoCandidate);
+
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+  await expect(page.getByTestId("language")).toHaveText('""');
+});
+
+test("HighlightAuto - dispatches on:highlight once per change, not per re-render", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightAutoDispatchOnce);
+
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+  await page.getByRole("button", { name: "Toggle langtag" }).click();
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+});
+
 test("HighlightSvelte - exposes the scope-event stream via slot prop and on:highlight detail", async ({
   mount,
   page,
@@ -409,6 +472,28 @@ test("HighlightSvelte - exposes the scope-event stream via slot prop and on:high
   expect(expected).not.toBe("");
   await expect(page.getByTestId("slot-events")).toHaveText(expected ?? "");
   await expect(page.getByTestId("dispatch-events")).toHaveText(expected ?? "");
+});
+
+test("HighlightSvelte - dispatches on:highlight for empty code", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightSvelteEmptyCode);
+
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+  await expect(page.getByTestId("highlighted")).toHaveText('""');
+  await expect(page.getByTestId("events")).toHaveText("[]");
+});
+
+test("HighlightSvelte - dispatches on:highlight once per change, not per re-render", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightSvelteDispatchOnce);
+
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+  await page.getByRole("button", { name: "Toggle langtag" }).click();
+  await expect(page.getByTestId("dispatch-count")).toHaveText("1");
 });
 
 test("SvelteHighlight", async ({ mount, page }) => {

--- a/www/components/Highlight/Wrap.svelte
+++ b/www/components/Highlight/Wrap.svelte
@@ -1,0 +1,17 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import Highlight, { HighlightSvelte } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code =
+    'const message = "This is a single very long line of code that demonstrates how the wrap prop lets long lines wrap instead of scrolling horizontally.";';
+
+  const snippet = "<Highlight wrap language={typescript} {code} />";
+</script>
+
+<div class="mb-3">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+<div class="mb-5" style="max-width: 28em;">
+  <Highlight wrap language={typescript} {code} />
+</div>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -9,6 +9,7 @@
   import CopyButtonSlot from "@components/CopyButton/Slot.svelte";
   import CopyButtonStyleProps from "@components/CopyButton/StyleProps.svelte";
   import FileTabs from "@components/FileTabs.svelte";
+  import HighlightWrap from "@components/Highlight/Wrap.svelte";
   import EditableBasic from "@components/HighlightEditable/Basic.svelte";
   import EditableCommands from "@components/HighlightEditable/Commands.svelte";
   import EditableCssHighlights from "@components/HighlightEditable/CssHighlights.svelte";
@@ -156,6 +157,18 @@ export default {
       title="Note:"
       subtitle="Using a CDN is best suited for prototyping and not recommended for production use."
     />
+  </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12} lg={12} md={12}>
+    <p class="mb-5">
+      By default, overflowing horizontal content is contained by a scrollbar.
+      Set <code class="code">wrap</code> to wrap long lines instead.
+    </p>
+  </Column>
+  <Column xlg={16} lg={16} md={12}>
+    <HighlightWrap />
   </Column>
 </Row>
 


### PR DESCRIPTION
Also adds a wrap prop to Highlight/HighlightAuto/HighlightSvelte for
wrapping long lines instead of scrolling, and fills a couple of small
gaps in the README and type docs (code coercion, container CSS
variables).