### PR TITLE
docs(components): cross-link the langtag static-mode opt-out

### DIFF
--- a/README.md
+++ b/README.md
@@ -949,6 +949,8 @@ Customize the language tag `background`, `color`, and `border-radius` using styl
 
 Setting `langtag` opts a `<Highlight>` usage out of the [`svelte-highlight/static`](#static-mode) build-time transform, since static output can't pull in `langtag.css`.
 
+If the highlighted output is empty (e.g. empty `code`, or code that highlights to an empty string), the badge and code block still render, but the code falls back to plain, unhighlighted text — the `hljs` class is still applied, there's just no syntax-highlighting markup inside it.
+
 See the [Languages page](SUPPORTED_LANGUAGES.md) for a list of supported languages.
 
 | Style prop              | Description                     | Default value |

--- a/README.md
+++ b/README.md
@@ -457,6 +457,7 @@ These apply when `langtag` is set to `true`.
 | --langtag-color         | Text color of the langtag       | `inherit`     |
 | --langtag-border-radius | Border radius of the langtag    | `0`           |
 | --langtag-padding       | Padding of the langtag          | `1em`         |
+| --langtag-font-size     | Font size of the langtag        | `inherit`     |
 
 ### `CodeWindow` variables
 
@@ -961,6 +962,7 @@ See the [Languages page](SUPPORTED_LANGUAGES.md) for a list of supported languag
 | --langtag-color         | Text color of the langtag       | `inherit`     |
 | --langtag-border-radius | Border radius of the langtag    | `0`           |
 | --langtag-padding       | Padding of the langtag          | `1em`         |
+| --langtag-font-size     | Font size of the langtag        | `inherit`     |
 
 ```svelte
 <script>

--- a/README.md
+++ b/README.md
@@ -944,6 +944,8 @@ See [SUPPORTED_LANGUAGES.md](SUPPORTED_LANGUAGES.md) for a list of supported lan
 
 ## Language Tags
 
+The language tag is one badge (`LangTag.svelte` + `langtag.css`) reached three ways: automatically, via `Highlight`/`HighlightAuto`/`HighlightSvelte`'s built-in fallback render when `langtag` is set; directly, via the standalone `LangTag` component; or via `LineNumbers`' own `langtag`/`languageName` props, which are not wired to a wrapping `Highlight` automatically and must be forwarded manually from slot props (see [Language Tag](#language-tag) under Line Numbers).
+
 Set `langtag` to `true` to display the language name in the top right corner of the code block.
 
 Customize the language tag `background`, `color`, and `border-radius` using style props.

--- a/README.md
+++ b/README.md
@@ -947,6 +947,8 @@ Set `langtag` to `true` to display the language name in the top right corner of 
 
 Customize the language tag `background`, `color`, and `border-radius` using style props.
 
+Setting `langtag` opts a `<Highlight>` usage out of the [`svelte-highlight/static`](#static-mode) build-time transform, since static output can't pull in `langtag.css`.
+
 See the [Languages page](SUPPORTED_LANGUAGES.md) for a list of supported languages.
 
 | Style prop              | Description                     | Default value |

--- a/src/Highlight.svelte.d.ts
+++ b/src/Highlight.svelte.d.ts
@@ -15,6 +15,9 @@ export type LangtagProps = {
    * - `--langtag-border-radius`
    * - `--langtag-padding`
    *
+   * Opts this usage out of the `svelte-highlight/static` build-time
+   * transform, since static output can't pull in `langtag.css`.
+   *
    * @default false
    */
   langtag?: boolean;

--- a/src/Highlight.svelte.d.ts
+++ b/src/Highlight.svelte.d.ts
@@ -14,6 +14,7 @@ export type LangtagProps = {
    * - `--langtag-color`
    * - `--langtag-border-radius`
    * - `--langtag-padding`
+   * - `--langtag-font-size`
    *
    * Opts this usage out of the `svelte-highlight/static` build-time
    * transform, since static output can't pull in `langtag.css`.
@@ -57,6 +58,12 @@ export type LangtagProps = {
    * @default "1em"
    */
   "--langtag-padding"?: string;
+
+  /**
+   * Langtag font size.
+   * @default "inherit"
+   */
+  "--langtag-font-size"?: string;
 
   /**
    * Wrap long lines instead of scrolling horizontally: sets

--- a/src/LangTag.svelte.d.ts
+++ b/src/LangTag.svelte.d.ts
@@ -12,6 +12,9 @@ export type LangTagProps = HTMLAttributes<HTMLPreElement> &
 
     /**
      * Highlighted HTML.
+     *
+     * When empty, `code` is rendered instead as plain, Svelte-escaped text —
+     * the `hljs` class is still applied, there's just no highlighting markup.
      */
     highlighted: string;
 

--- a/tests/e2e/LangTag.copyButton.test.svelte
+++ b/tests/e2e/LangTag.copyButton.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import Highlight, { CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<div style="position: relative">
+  <Highlight
+    language={typescript}
+    {code}
+    langtag
+    --langtag-top="0"
+    --langtag-right="3em"
+    --langtag-padding="0.25em 0.5em"
+    --langtag-font-size="0.75em"
+  />
+  <CopyButton {code} />
+</div>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -40,6 +40,7 @@ import HighlightSvelteDispatchOnce from "./HighlightSvelte.dispatchOnce.test.sve
 import HighlightSvelteEmptyCode from "./HighlightSvelte.emptyCode.test.svelte";
 import HighlightSvelteEvents from "./HighlightSvelte.events.test.svelte";
 import HighlightVirtual from "./HighlightVirtual.test.svelte";
+import LangTagCopyButton from "./LangTag.copyButton.test.svelte";
 import LangTag from "./LangTag.test.svelte";
 import LineNumbersCssVariables from "./LineNumbers.cssVariables.test.svelte";
 import LineNumbersCustomStartingLine from "./LineNumbers.customStartingLine.test.svelte";
@@ -680,6 +681,34 @@ test("LangTag", async ({ mount, page }) => {
 
   const preElement = page.locator("pre.langtag");
   await expect(preElement).toHaveCSS("position", "relative");
+});
+
+test("LangTag - offset recipe combines correctly with CopyButton", async ({
+  mount,
+  page,
+}) => {
+  await mount(LangTagCopyButton);
+
+  const pre = page.locator("pre.langtag");
+  await expect(pre).toBeVisible();
+  await expect(pre).toHaveAttribute("data-language", "typescript");
+  await expect(page.getByRole("button", { name: "Copy" })).toBeVisible();
+
+  const vars = await pre.evaluate((el) => {
+    const cs = getComputedStyle(el);
+    return {
+      top: cs.getPropertyValue("--langtag-top").trim(),
+      right: cs.getPropertyValue("--langtag-right").trim(),
+      padding: cs.getPropertyValue("--langtag-padding").trim(),
+      fontSize: cs.getPropertyValue("--langtag-font-size").trim(),
+    };
+  });
+  expect(vars).toEqual({
+    top: "0",
+    right: "3em",
+    padding: "0.25em 0.5em",
+    fontSize: "0.75em",
+  });
 });
 
 test("CopyButton - copies via the native Clipboard API", async ({

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -896,6 +896,7 @@ export default {
   --langtag-color="#fff"
   --langtag-border-radius="6px"
   --langtag-padding="0.5rem"
+  --langtag-font-size="0.75em"
 />`}
       class={THEME_MODULE_NAME}
       langtag
@@ -905,6 +906,7 @@ export default {
       --langtag-color="#fff"
       --langtag-border-radius="6px"
       --langtag-padding="0.5rem"
+      --langtag-font-size="0.75em"
     />
   </Column>
 </Row>


### PR DESCRIPTION
Also documents the previously-undocumented --langtag-font-size
variable and LangTag's empty-highlighted fallback, adds an orienting
paragraph on how the three langtag code paths (Highlight's built-in
fallback, standalone LangTag, LineNumbers) relate, and adds e2e
coverage for the langtag + CopyButton offset recipe.