### PR TITLE
docs(components): add HighlightStyle to the Component API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ const palette = fromTextMate(nightOwl, {
 
 ## Styling
 
-Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility.
+Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility. Legacy styles are stable and will not be removed.
 
 There are two ways to apply `highlight.js` styles.
 

--- a/README.md
+++ b/README.md
@@ -279,6 +279,10 @@ This component exports `highlight.js` themes in JavaScript. Import the theme fro
 <Highlight language={typescript} {code} />
 ```
 
+Under a strict Content Security Policy without `'unsafe-inline'` for `style-src`, the browser silently drops this injected `<style>` tag with no visible error. Use [CSS StyleSheet](#css-stylesheet) below instead, which is CSP-safe by construction since it's a normal stylesheet reference.
+
+This snippet also has no protection against duplicate `<style>` tags: placing it inside a component that's mounted more than once emits one `<style>` tag per mount. For anything mounted more than once, use [`HighlightStyle`](#highlightstyle) instead, which dedupes automatically across instances of the same theme.
+
 ### CSS StyleSheet
 
 Depending on your set-up, importing a CSS StyleSheet in Svelte may require a CSS file loader. SvelteKit/Vite automatically supports this. For Webpack, refer to [examples/webpack](examples/webpack).

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ const palette = fromTextMate(nightOwl, {
 
 ## Styling
 
-Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility. Legacy styles are stable and will not be removed.
+Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility. Legacy styles are stable and will not be removed. One concrete reason to pick this path over `ThemePalette`: `base.css` assumes the default `hljs-` class prefix, so projects using a custom `classPrefix` should stay here.
 
 There are two ways to apply `highlight.js` styles.
 

--- a/README.md
+++ b/README.md
@@ -1696,6 +1696,20 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 />
 ```
 
+### `HighlightStyle`
+
+#### Props
+
+| Name       | Type                    | Default value            |
+| :--------- | :---------------------- | :------------------------ |
+| theme      | `string \| ThemePalette` | N/A                       |
+| light      | `string \| ThemePalette` | N/A                       |
+| dark       | `string \| ThemePalette` | N/A                       |
+| mode       | `"auto" \| "light" \| "dark" \| string` | `"auto"`   |
+| scopeClass | `string`                | hash of `theme`           |
+
+The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the top-level `div` element.
+
 ### `LineNumbers`
 
 #### Props


### PR DESCRIPTION
Also covers the Styling section: notes where the Injected Styles
pattern breaks under a strict CSP and can duplicate <style> tags,
and states plainly that legacy styles are stable and when
classPrefix is the reason to reach for them over ThemePalette.