### PR TITLE
docs(components): fix HighlightAuto's prop table to say languageNames

### DIFF
--- a/README.md
+++ b/README.md
@@ -1799,12 +1799,12 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 
 #### Props
 
-| Name      | Type             | Default value  |
-| :-------- | :--------------- | :------------- |
-| code      | `any`            | N/A (required) |
-| languages | `LanguageName[]` | `undefined`    |
-| langtag   | `boolean`        | `false`        |
-| wrap      | `boolean`        | `false`        |
+| Name          | Type             | Default value  |
+| :------------ | :--------------- | :------------- |
+| code          | `any`            | N/A (required) |
+| languageNames | `LanguageName[]` | `undefined`    |
+| langtag       | `boolean`        | `false`        |
+| wrap          | `boolean`        | `false`        |
 
 `$$restProps` are forwarded to the top-level `pre` element.
 

--- a/README.md
+++ b/README.md
@@ -526,7 +526,7 @@ See the [kitchen-sink live demo](https://svhe.onrender.com/preview-svelte) for a
 
 ## Auto-highlighting
 
-The `HighlightAuto` component uses the [highlightAuto API](https://highlightjs.readthedocs.io/en/latest/api.html#highlightauto) and attempts to guess what grammar to use based on the provided `code`.
+The `HighlightAuto` component uses the [highlightAuto API](https://highlightjs.readthedocs.io/en/latest/api.html#highlightauto) and attempts to guess what grammar to use based on the provided `code`. Its `on:highlight` event's `secondBest` field surfaces the runner-up candidate and its relevance, for showing detection confidence.
 
 > [!WARNING]
 > Auto-highlighting will result in a larger bundle size. Specify a language if possible.
@@ -1836,6 +1836,13 @@ import type { LanguageName } from "svelte-highlight";
 
     /** The scope-event stream behind `highlighted`. See "Headless usage" below. */
     console.log(e.detail.events);
+
+    /**
+     * The runner-up candidate and its relevance, for surfacing detection
+     * confidence. `undefined` when no other candidate scored above zero.
+     * @example { language: "typescript", relevance: 6 }
+     */
+    console.log(e.detail.secondBest);
   }}
 />
 ```

--- a/README.md
+++ b/README.md
@@ -529,7 +529,7 @@ See the [kitchen-sink live demo](https://svhe.onrender.com/preview-svelte) for a
 The `HighlightAuto` component uses the [highlightAuto API](https://highlightjs.readthedocs.io/en/latest/api.html#highlightauto) and attempts to guess what grammar to use based on the provided `code`. Its `on:highlight` event's `secondBest` field surfaces the runner-up candidate and its relevance, for showing detection confidence.
 
 > [!WARNING]
-> Auto-highlighting will result in a larger bundle size. Specify a language if possible.
+> Mounting `HighlightAuto` statically imports all 279 shipped grammars, regardless of `languageNames`, so bundle size is unconditionally larger than a `Highlight` with a single named language. Specify a language if possible.
 
 ```svelte
 <script>
@@ -548,7 +548,7 @@ The `HighlightAuto` component uses the [highlightAuto API](https://highlightjs.r
 
 ### Limiting Language Detection
 
-You can restrict [language auto-detection](https://highlightjs.readthedocs.io/en/latest/api.html#highlightauto-value-languagesubset) to a subset using the `languageNames` prop. This can improve performance and accuracy.
+You can restrict [language auto-detection](https://highlightjs.readthedocs.io/en/latest/api.html#highlightauto-value-languagesubset) to a subset using the `languageNames` prop. This can improve performance and accuracy — it narrows the candidates scored during detection, but it does not reduce bundle size, since all shipped grammars are imported unconditionally (see the warning above). A grammar registered with `disableAutodetect: true` stays excluded from detection even when explicitly named in `languageNames`.
 
 ```svelte
 <script>

--- a/src/HighlightAuto.svelte
+++ b/src/HighlightAuto.svelte
@@ -21,7 +21,7 @@
   import { registry } from "./registry.js";
 
   /**
-   * @typedef {{ highlighted: string; language: string; events: import("./engine.d.ts").ScopeEvent[] }} HighlightEventDetail
+   * @typedef {{ highlighted: string; language: string; events: import("./engine.d.ts").ScopeEvent[]; secondBest?: { language: string | undefined; relevance: number } }} HighlightEventDetail
    * @type {import("svelte").EventDispatcher<{ highlight: HighlightEventDetail}>}
    */
   const dispatch = createEventDispatcher();
@@ -44,13 +44,16 @@
   /** @type {import("./engine.d.ts").ScopeEvent[]} */
   let events = [];
 
+  /** @type {{ language: string | undefined; relevance: number } | undefined} */
+  let secondBest;
+
   /** @type {import("./engine.d.ts").ScopeEvent[] | undefined} */
   let lastDispatchedEvents;
 
   afterUpdate(() => {
     if (events !== lastDispatchedEvents) {
       lastDispatchedEvents = events;
-      dispatch("highlight", { highlighted, language, events });
+      dispatch("highlight", { highlighted, language, events, secondBest });
     }
   });
 
@@ -61,6 +64,7 @@
       value: highlighted,
       language = "",
       events,
+      secondBest,
     } = registry.highlightAuto(source, languageNames));
   }
 </script>

--- a/src/HighlightAuto.svelte.d.ts
+++ b/src/HighlightAuto.svelte.d.ts
@@ -45,6 +45,14 @@ export type HighlightAutoEvents = {
      * `toRanges`, custom renderers).
      */
     events: ScopeEvent[];
+
+    /**
+     * The runner-up candidate and its relevance score, for surfacing
+     * detection confidence (e.g. "detected javascript, runner-up
+     * typescript at relevance 6"). `undefined` when no other candidate
+     * scored above zero, or only one candidate was viable.
+     */
+    secondBest?: { language: string | undefined; relevance: number };
   }>;
 };
 

--- a/tests/e2e/HighlightAuto.secondBest.test.svelte
+++ b/tests/e2e/HighlightAuto.secondBest.test.svelte
@@ -1,0 +1,26 @@
+<script lang="ts">
+  import { HighlightAuto } from "svelte-highlight";
+  import { registry } from "svelte-highlight/registry";
+
+  const code = "const add = (a, b) => a + b;";
+  const languageNames = ["javascript", "typescript"];
+
+  let dispatchLanguage = "";
+  let dispatchSecondBestJson = "";
+</script>
+
+<HighlightAuto
+  {code}
+  {languageNames}
+  on:highlight={(e) => {
+    dispatchLanguage = e.detail.language;
+    dispatchSecondBestJson = JSON.stringify(e.detail.secondBest) ?? "";
+  }}
+/>
+
+<p data-testid="expected-second-best">
+  {dispatchLanguage
+    ? JSON.stringify(registry.highlightAuto(code, languageNames).secondBest)
+    : ""}
+</p>
+<p data-testid="dispatch-second-best">{dispatchSecondBestJson}</p>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -22,6 +22,7 @@ import HighlightAutoEmptyCode from "./HighlightAuto.emptyCode.test.svelte";
 import HighlightAutoEvents from "./HighlightAuto.events.test.svelte";
 import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestriction.test.svelte";
 import HighlightAutoNoCandidate from "./HighlightAuto.noCandidate.test.svelte";
+import HighlightAutoSecondBest from "./HighlightAuto.secondBest.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
 import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
 import HighlightEditableCssHighlights from "./HighlightEditable.cssHighlights.test.svelte";
@@ -467,6 +468,19 @@ test("HighlightAuto - dispatches on:highlight once per change, not per re-render
   await expect(page.getByTestId("dispatch-count")).toHaveText("1");
   await page.getByRole("button", { name: "Toggle langtag" }).click();
   await expect(page.getByTestId("dispatch-count")).toHaveText("1");
+});
+
+test("HighlightAuto - exposes secondBest in the event detail", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightAutoSecondBest);
+
+  const expected = await page.getByTestId("expected-second-best").textContent();
+  expect(expected).not.toBe("");
+  await expect(page.getByTestId("dispatch-second-best")).toHaveText(
+    expected ?? "",
+  );
 });
 
 test("HighlightSvelte - exposes the scope-event stream via slot prop and on:highlight detail", async ({

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -266,7 +266,7 @@ export default {
       hideCloseButton
       kind="warning"
       title="Note:"
-      subtitle="Auto-highlighting will result in a larger bundle size. Specify a language if possible."
+      subtitle="Mounting HighlightAuto statically imports all 279 shipped grammars, regardless of languageNames, so bundle size is unconditionally larger. Specify a language if possible."
     />
   </Column>
   <Column xlg={6} lg={6} md={12}>


### PR DESCRIPTION
Also surfaces the engine's secondBest runner-up in HighlightAuto's
on:highlight event, and spells out the auto-detect bundle cost (all
279 grammars, unconditionally) plus the disableAutodetect interaction
with languageNames.