### PR TITLE
fix(components): let Escape then Tab leave HighlightEditable

### DIFF
--- a/README.md
+++ b/README.md
@@ -857,6 +857,7 @@ Use `bind:code` to keep your state in sync.
 
 - **Enter** inserts a newline.
 - **Tab** / **Shift+Tab** indent or dedent the selected lines (or insert one indent at the caret). Set the indent size with the `tabSize` prop (default `2`).
+- **Escape** then **Tab**/**Shift+Tab** moves keyboard focus out of the editor instead of indenting, so the block never traps focus. Any other key clears this and restores normal Tab behavior.
 - **Cmd/Ctrl+Z** undo and **Shift+Cmd/Ctrl+Z** (or **Ctrl+Y**) redo. Typing bursts collapse into a single undo step; cap the retained history with the `historyLimit` prop (default `200`).
 
 ### Dispatched Events

--- a/README.md
+++ b/README.md
@@ -929,7 +929,7 @@ Set `readonly` to keep highlighting, caret placement, and selection active while
 
 Requires Chrome 105+, Safari 17.2+, or Firefox 140+. Where `CSS.highlights` is unavailable, `HighlightEditable` falls back to `engine="dom"` silently; check what actually ran with `editor.resolvedEngine()`.
 
-Pass `theme` (the same theme string you'd give `HighlightStyle`) to generate `::highlight()` rules from it. Only `color`/`background-color` convert — `::highlight()` doesn't support `font-style`/`font-weight`/`text-decoration` across browsers, so bold/italic scopes render in plain color.
+Pass `theme` (the same theme string you'd give `HighlightStyle`) to generate `::highlight()` rules from it. Only `color`/`background-color` convert, and only for single-class `.hljs-<scope>` rules — compound (`.hljs-title.class_`) and descendant-selector (`.hljs-meta .hljs-keyword`) scopes have no `::highlight()` equivalent and get **no color at all**, not just plain weight/style.
 
 `theme` only covers token colors — you still need `HighlightStyle` (or an injected stylesheet) for the base `.hljs` layout rules (padding, overflow, background), exactly as with the default engine.
 

--- a/README.md
+++ b/README.md
@@ -906,6 +906,21 @@ Customize the focus outline with the `--outline-color`, `--outline-width`, and `
 />
 ```
 
+### Read-only
+
+Set `readonly` to keep highlighting, caret placement, and selection active while blocking edits (typing, paste, drag-and-drop, and Tab/Shift+Tab indent). The imperative API still works, so a consumer can toggle a document read-only without swapping components.
+
+```svelte
+<script>
+  let readonly = false;
+</script>
+
+<HighlightEditable language={typescript} bind:code {readonly} />
+<button on:click={() => (readonly = !readonly)}>
+  {readonly ? "Unlock" : "Lock"}
+</button>
+```
+
 ### Experimental: CSS Custom Highlight engine
 
 `engine="css-highlights"` paints tokens with the [CSS Custom Highlight API](https://developer.mozilla.org/en-US/docs/Web/API/CSS_Custom_Highlight_API) (`CSS.highlights`, `::highlight()`) instead of wrapping them in `<span>`s. The editable `<code>` stays plain text (one `<span>` per line, reused from the default engine's line structure, but with no per-token spans inside), so a repaint never replaces the DOM the caret is sitting in.
@@ -1851,6 +1866,7 @@ import type { LanguageName } from "svelte-highlight";
 | language     | { name: `string`; register: `object` } | N/A (required) |
 | tabSize      | `number`                                       | `2`            |
 | historyLimit | `number`                                       | `200`          |
+| readonly     | `boolean`                                      | `false`        |
 
 `$$restProps` are forwarded to the top-level `pre` element.
 

--- a/README.md
+++ b/README.md
@@ -860,6 +860,8 @@ Use `bind:code` to keep your state in sync.
 - **Escape** then **Tab**/**Shift+Tab** moves keyboard focus out of the editor instead of indenting, so the block never traps focus. Any other key clears this and restores normal Tab behavior.
 - **Cmd/Ctrl+Z** undo and **Shift+Cmd/Ctrl+Z** (or **Ctrl+Y**) redo. Typing bursts collapse into a single undo step; cap the retained history with the `historyLimit` prop (default `200`).
 
+Pasting and dragging content into the editor both insert plain text only, regardless of the source payload (rich text, HTML, etc.).
+
 ### Dispatched Events
 
 `HighlightEditable` dispatches `change` (on every edit), `blur`, and `history` (whenever the undo/redo stack changes).

--- a/README.md
+++ b/README.md
@@ -947,6 +947,25 @@ Pass `theme` (the same theme string you'd give `HighlightStyle`) to generate `::
 </HighlightStyle>
 ```
 
+### Adding a gutter
+
+`HighlightEditable` has no slot and doesn't expose `highlighted`/`languageName`, so it can't be wrapped directly in `LineNumbers` the way a static `Highlight` block can. Mirror the same `code` in a second, read-only `Highlight` instance wrapped in `LineNumbers`, and position it alongside the editable block:
+
+```svelte
+<script>
+  import { Highlight, HighlightEditable, LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  let code = "const add = (a: number, b: number) => a + b";
+</script>
+
+<HighlightEditable language={typescript} bind:code />
+
+<Highlight language={typescript} {code} let:highlighted let:languageName>
+  <LineNumbers {highlighted} {languageName} />
+</Highlight>
+```
+
 ## Language Targeting
 
 All `Highlight` components apply a `data-language` attribute on the codeblock containing the language name.

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -64,6 +64,10 @@
   let mounted = false;
   let restoringSelection = false;
 
+  // Set by Escape, consumed by the next Tab/Shift+Tab to release focus
+  // instead of indenting; cleared by any other keydown or blur.
+  let tabTrapReleased = false;
+
   // One <span> per line, painted incrementally (see `renderLines`).
   /** @type {HTMLSpanElement[]} */
   let lineEls = [];
@@ -804,6 +808,15 @@
   function onKeydown(event) {
     const mod = event.metaKey || event.ctrlKey;
 
+    if (event.key === "Escape") {
+      tabTrapReleased = true;
+      return;
+    }
+    if (tabTrapReleased) {
+      tabTrapReleased = false;
+      if (event.key === "Tab") return;
+    }
+
     if (mod && event.key === "z" && !event.shiftKey) {
       event.preventDefault();
       undo();
@@ -844,6 +857,7 @@
   }
 
   function onBlur() {
+    tabTrapReleased = false;
     dispatch("blur", { code: getCode() });
   }
 

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -852,6 +852,11 @@
     insertText(event.clipboardData?.getData("text/plain") ?? "");
   }
 
+  function onDrop(event) {
+    event.preventDefault();
+    insertText(event.dataTransfer?.getData("text/plain") ?? "");
+  }
+
   // Edit-menu / execCommand undo-redo bypass onKeydown; intercept here so the
   // browser doesn't mutate DOM that paint() has already rebuilt.
   function onBeforeInput(event) {
@@ -909,6 +914,7 @@
     editor.addEventListener("keydown", onKeydown);
     editor.addEventListener("beforeinput", onBeforeInput);
     editor.addEventListener("paste", onPaste);
+    editor.addEventListener("drop", onDrop);
     editor.addEventListener("mouseup", syncCaretToHistory);
     editor.addEventListener("keyup", syncCaretToHistory);
     editor.addEventListener("focusin", onFocusIn);
@@ -922,6 +928,7 @@
       editor.removeEventListener("keydown", onKeydown);
       editor.removeEventListener("beforeinput", onBeforeInput);
       editor.removeEventListener("paste", onPaste);
+      editor.removeEventListener("drop", onDrop);
       editor.removeEventListener("mouseup", syncCaretToHistory);
       editor.removeEventListener("keyup", syncCaretToHistory);
       editor.removeEventListener("focusin", onFocusIn);

--- a/src/HighlightEditable.svelte
+++ b/src/HighlightEditable.svelte
@@ -19,6 +19,13 @@
   export let historyLimit = 200;
 
   /**
+   * Keeps highlighting, caret placement, and selection active while
+   * blocking edits (typing, paste, drag-and-drop, Tab/Shift+Tab indent).
+   * @type {boolean}
+   */
+  export let readonly = false;
+
+  /**
    * Rendering engine. `"css-highlights"` (experimental) paints tokens via
    * the CSS Custom Highlight API over plain-text line nodes instead of
    * wrapping them in `<span>`s, so a repaint never replaces DOM the caret
@@ -602,6 +609,7 @@
   }
 
   function commit(value, start, end, coalesce) {
+    if (readonly) return;
     const previousCode = code;
     code = value;
     internalCode = value;
@@ -725,7 +733,7 @@
   }
 
   export function setCode(value) {
-    if (value === code) return;
+    if (readonly || value === code) return;
     const previousCode = code;
     internalCode = value;
     code = value;
@@ -819,12 +827,12 @@
 
     if (mod && event.key === "z" && !event.shiftKey) {
       event.preventDefault();
-      undo();
+      if (!readonly) undo();
       return;
     }
     if (mod && (event.key === "y" || (event.key === "z" && event.shiftKey))) {
       event.preventDefault();
-      redo();
+      if (!readonly) redo();
       return;
     }
     if (event.key === "Enter") {
@@ -940,7 +948,7 @@
 ><code
     bind:this={editor}
     class:hljs={true}
-    contenteditable="true"
+    contenteditable={readonly ? "false" : "true"}
     spellcheck="false"
 >{code}</code></pre>
 

--- a/src/HighlightEditable.svelte.d.ts
+++ b/src/HighlightEditable.svelte.d.ts
@@ -31,6 +31,13 @@ export type HighlightEditableProps = HTMLAttributes<HTMLPreElement> & {
   historyLimit?: number;
 
   /**
+   * Keeps highlighting, caret placement, and selection active while
+   * blocking edits (typing, paste, drag-and-drop, Tab/Shift+Tab indent).
+   * @default false
+   */
+  readonly?: boolean;
+
+  /**
    * Rendering engine. `"css-highlights"` (experimental) paints tokens via
    * the CSS Custom Highlight API (`CSS.highlights`) over plain-text line
    * nodes instead of wrapping them in `<span>`s, so a repaint never

--- a/src/HighlightEditable.svelte.d.ts
+++ b/src/HighlightEditable.svelte.d.ts
@@ -46,9 +46,10 @@ export type HighlightEditableProps = HTMLAttributes<HTMLPreElement> & {
    * Safari 17.2+, Firefox 140+); check what was actually used with the
    * `resolvedEngine()` method.
    *
-   * Colors only: `::highlight()` doesn't support `font-style`/
-   * `font-weight`/`text-decoration` across browsers, so bold/italic scopes
-   * render plain in this mode.
+   * Colors only, and only for single-class `.hljs-<scope>` rules: compound
+   * (`.hljs-title.class_`) and descendant-selector (`.hljs-meta
+   * .hljs-keyword`) scopes have no `::highlight()` equivalent and get no
+   * color at all, not just plain weight/style.
    * @default "dom"
    */
   engine?: "dom" | "css-highlights";
@@ -57,7 +58,9 @@ export type HighlightEditableProps = HTMLAttributes<HTMLPreElement> & {
    * Theme CSS from `svelte-highlight/styles/<theme>`, or a `ThemePalette`
    * from `svelte-highlight/themes/<theme>`, used only in
    * `"css-highlights"` mode to generate `::highlight()` rules. Colors only
-   * (`color`/`background-color`); other declarations are dropped.
+   * (`color`/`background-color`); other declarations are dropped. Only
+   * single-class `.hljs-<scope>` rules convert — compound and
+   * descendant-selector scopes get no color at all.
    * @example
    * import a11yDark from "svelte-highlight/styles/a11y-dark";
    * @example

--- a/tests/e2e/HighlightEditable.test.svelte
+++ b/tests/e2e/HighlightEditable.test.svelte
@@ -22,6 +22,7 @@
   on:change={() => (changes += 1)}
   on:history={(e) => (historyState = e.detail)}
 />
+<input type="text" data-testid="after" />
 
 <div data-testid="code" data-value={code}></div>
 <div data-testid="changes" data-value={changes}></div>

--- a/tests/e2e/HighlightEditable.test.svelte
+++ b/tests/e2e/HighlightEditable.test.svelte
@@ -4,6 +4,7 @@
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
 
   export let initialCode = "const a = 1;";
+  export let readonly = false;
 
   let editor;
   let code = initialCode;
@@ -18,6 +19,7 @@
   language={typescript}
   bind:code
   tabSize={2}
+  {readonly}
   --outline-color="rgb(255, 0, 0)"
   on:change={() => (changes += 1)}
   on:history={(e) => (historyState = e.detail)}

--- a/tests/e2e/HighlightEditable.test.svelte
+++ b/tests/e2e/HighlightEditable.test.svelte
@@ -22,7 +22,7 @@
   on:change={() => (changes += 1)}
   on:history={(e) => (historyState = e.detail)}
 />
-<input type="text" data-testid="after" />
+<input type="text" data-testid="after">
 
 <div data-testid="code" data-value={code}></div>
 <div data-testid="changes" data-value={changes}></div>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1058,6 +1058,41 @@ test("HighlightEditable - setCode and clear replace the document", async ({
   await expect(page.getByTestId("code")).toHaveAttribute("data-value", "");
 });
 
+test("HighlightEditable - readonly blocks edits but keeps selection and reads working", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable, {
+    props: { initialCode: "const a = 1;", readonly: true },
+  });
+
+  const editor = page.locator("[contenteditable='false']");
+  await expect(editor).toHaveCount(1);
+
+  await editor.click();
+  await page.keyboard.type("XYZ");
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "const a = 1;",
+  );
+  await expect(page.getByTestId("changes")).toHaveAttribute("data-value", "0");
+
+  await page.getByTestId("insert").click();
+  await page.getByTestId("indent").click();
+  await page.getByTestId("outdent").click();
+  await page.getByTestId("set-code").click();
+  await page.getByTestId("clear").click();
+  await expect(page.getByTestId("code")).toHaveAttribute(
+    "data-value",
+    "const a = 1;",
+  );
+  await expect(page.getByTestId("changes")).toHaveAttribute("data-value", "0");
+
+  await page.getByTestId("select-all").click();
+  const selected = await page.evaluate(() => window.getSelection()?.toString());
+  expect(selected).toBe("const a = 1;");
+});
+
 test("HighlightEditable - focus outline uses the --outline-color variable", async ({
   mount,
   page,

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -899,6 +899,37 @@ test("HighlightEditable - Enter inserts a newline and Tab inserts indent", async
   );
 });
 
+test("HighlightEditable - Escape then Tab releases focus instead of indenting", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable, { props: { initialCode: "a" } });
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowRight"); // caret to end
+
+  // Plain Tab still indents.
+  await page.keyboard.press("Tab");
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "a  ");
+
+  // Escape then Tab moves focus out instead of indenting; code is unchanged.
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("Tab");
+  await expect(page.getByTestId("after")).toBeFocused();
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "a  ");
+
+  // Escape then any other key clears the flag, so the next Tab indents again.
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowRight");
+  await page.keyboard.press("Escape");
+  await page.keyboard.press("ArrowLeft");
+  await page.keyboard.press("Tab");
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "a    ");
+});
+
 test("HighlightEditable - Tab and Shift+Tab indent/dedent selected lines", async ({
   mount,
   page,

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1093,6 +1093,49 @@ test("HighlightEditable - readonly blocks edits but keeps selection and reads wo
   expect(selected).toBe("const a = 1;");
 });
 
+test("HighlightEditable - drop inserts only the plain-text payload", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable, { props: { initialCode: "a" } });
+
+  const editor = page.locator("[contenteditable='true']");
+  await editor.click();
+  await page.keyboard.press("ControlOrMeta+a");
+  await page.keyboard.press("ArrowRight"); // caret to end
+
+  await editor.evaluate((el) => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData("text/plain", "b");
+    dataTransfer.setData("text/html", "<b>bold</b>");
+    el.dispatchEvent(
+      new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer }),
+    );
+  });
+
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "ab");
+});
+
+test("HighlightEditable - readonly blocks dropped text", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightEditable, {
+    props: { initialCode: "a", readonly: true },
+  });
+
+  const editor = page.locator("[contenteditable='false']");
+  await editor.evaluate((el) => {
+    const dataTransfer = new DataTransfer();
+    dataTransfer.setData("text/plain", "b");
+    el.dispatchEvent(
+      new DragEvent("drop", { bubbles: true, cancelable: true, dataTransfer }),
+    );
+  });
+
+  await expect(page.getByTestId("code")).toHaveAttribute("data-value", "a");
+});
+
 test("HighlightEditable - focus outline uses the --outline-color variable", async ({
   mount,
   page,

--- a/www/components/HighlightEditable/Composition.svelte
+++ b/www/components/HighlightEditable/Composition.svelte
@@ -1,0 +1,21 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Highlight, HighlightEditable, LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  let code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<HighlightEditable language={typescript} bind:code class={THEME_MODULE_NAME} />
+
+<div style="margin-top: 0.75rem">
+  <Highlight
+    language={typescript}
+    {code}
+    let:highlighted
+    let:languageName
+    class={THEME_MODULE_NAME}
+  >
+    <LineNumbers {highlighted} {languageName} />
+  </Highlight>
+</div>

--- a/www/components/HighlightEditable/ReadOnly.svelte
+++ b/www/components/HighlightEditable/ReadOnly.svelte
@@ -1,0 +1,22 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import { HighlightEditable } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  let code = "const add = (a: number, b: number) => a + b;";
+  let readonly = false;
+</script>
+
+<HighlightEditable
+  language={typescript}
+  bind:code
+  {readonly}
+  class={THEME_MODULE_NAME}
+/>
+
+<div style="margin-top: 0.5rem">
+  <Button size="small" kind="tertiary" on:click={() => (readonly = !readonly)}>
+    {readonly ? "Unlock" : "Lock"}
+  </Button>
+</div>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -12,6 +12,7 @@
   import HighlightWrap from "@components/Highlight/Wrap.svelte";
   import EditableBasic from "@components/HighlightEditable/Basic.svelte";
   import EditableCommands from "@components/HighlightEditable/Commands.svelte";
+  import EditableComposition from "@components/HighlightEditable/Composition.svelte";
   import EditableCssHighlights from "@components/HighlightEditable/CssHighlights.svelte";
   import EditableReadOnly from "@components/HighlightEditable/ReadOnly.svelte";
   import HighlightStreamBasic from "@components/HighlightStream/Basic.svelte";
@@ -801,6 +802,18 @@ export default {
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <EditableReadOnly /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      There's no slot for
+      <code class="code">LineNumbers</code>
+      to wrap the editable block directly. Mirror
+      <code class="code">bind:code</code>
+      into a second, read-only <code class="code">Highlight</code> instance
+      wrapped in <code class="code">LineNumbers</code>, positioned alongside the
+      editor.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <EditableComposition /> </Column>
 </Row>
 
 <Row class="mb-9">

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -13,6 +13,7 @@
   import EditableBasic from "@components/HighlightEditable/Basic.svelte";
   import EditableCommands from "@components/HighlightEditable/Commands.svelte";
   import EditableCssHighlights from "@components/HighlightEditable/CssHighlights.svelte";
+  import EditableReadOnly from "@components/HighlightEditable/ReadOnly.svelte";
   import HighlightStreamBasic from "@components/HighlightStream/Basic.svelte";
   import HighlightStreamControls from "@components/HighlightStream/Controls.svelte";
   import HighlightStreamVirtualize from "@components/HighlightStream/Virtualize.svelte";
@@ -791,6 +792,15 @@ export default {
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <EditableCssHighlights /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Set <code class="code">readonly</code> to keep highlighting, caret
+      placement, and selection active while blocking edits. The imperative API
+      still works, so a consumer can toggle a document read-only without
+      swapping components.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <EditableReadOnly /> </Column>
 </Row>
 
 <Row class="mb-9">


### PR DESCRIPTION
Also adds a readonly prop, makes drag-and-drop insert plain text the
same way paste already does, corrects a docs claim about color loss
in the css-highlights engine, and documents the LineNumbers mirror
pattern for adding a gutter to the editable block.