### PR TITLE
feat(theme): add validatePalette and warn on unknown scope keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ const midnight = defineTheme({
 </HighlightStyle>
 ```
 
-`roles` are `foreground`, `background`, `comment`, `keyword`, `string`, `literal`, `function`, `type`, `variable`, `property`, `tag`, `punctuation`, `meta`, `addition`, `deletion` — each expands to a documented set of `--shl-*` scope vars. A bare string is shorthand for `{ color: string }`; both roles and `scopes` also accept a `{ color, background, fontStyle, fontWeight, textDecoration }` object. Precedence is `extends` palette vars → `roles` → `scopes` (later layers win per-var, not per-role). `foreground`/`background` are required unless `extends` is given.
+`roles` are `foreground`, `background`, `comment`, `keyword`, `string`, `literal`, `function`, `type`, `variable`, `property`, `tag`, `punctuation`, `meta`, `addition`, `deletion` — each expands to a documented set of `--shl-*` scope vars. A bare string is shorthand for `{ color: string }`; both roles and `scopes` also accept a `{ color, background, fontStyle, fontWeight, textDecoration }` object. Precedence is `extends` palette vars → `roles` → `scopes` (later layers win per-var, not per-role). `foreground`/`background` are required unless `extends` is given. `ROLE_SCOPES` is exported for tooling that wants to enumerate exactly which scopes a role expands to.
 
 **`extendTheme()`** derives a new palette from any shipped or user palette with role- or scope-level overrides:
 

--- a/README.md
+++ b/README.md
@@ -231,6 +231,21 @@ writeFileSync("public/midnight.css", paletteToCss(midnight));
 
 `defineTheme` output is a plain `ThemePalette` — spreadable, serializable, diffable, and valid everywhere shipped palettes work, per [Themes are data](#theming) above.
 
+**`validatePalette()`** self-checks a `ThemePalette` — useful for a hand-built or hand-edited palette, e.g. one assembled via the [Themes are data](#theming) spread pattern above:
+
+```js
+import { validatePalette } from "svelte-highlight/theme";
+
+const custom = {
+  ...atomOneDark,
+  vars: { ...atomOneDark.vars, "--shl-keyword": "#ff79c6" },
+};
+
+validatePalette(custom); // -> [] when clean; otherwise a list of issues
+```
+
+It flags a missing/malformed `vars` object, a missing `--shl-fg`/`--shl-bg`, a `vars` key outside the `--shl-*` grammar, and a `--shl-fg`/`--shl-bg` value that doesn't look like a recognized color — never throws. `defineTheme` already runs it (plus an unknown-`scopes`-key check) automatically in dev mode.
+
 ### Importing VS Code themes
 
 `svelte-highlight/theme/textmate` imports VS Code / TextMate theme JSON (thousands of existing editor themes) into a `ThemePalette`:

--- a/src/theme-vars.js
+++ b/src/theme-vars.js
@@ -158,6 +158,31 @@ export const ROLE_SCOPES = {
   deletion: ["deletion"],
 };
 
+/** Every scope segment `ROLE_SCOPES` maps a role to, flattened into a single
+ * vocabulary. Built once; used to flag a typo'd `scopes` key like
+ * `"titel.calss_"` (see `unknownScopeSegments`).
+ * @type {Set<string>}
+ */
+export const KNOWN_SCOPE_SEGMENTS = new Set(
+  Object.values(ROLE_SCOPES).flatMap((scopeKeys) =>
+    scopeKeys.flatMap((scopeKey) => parseScopeKey(scopeKey)),
+  ),
+);
+
+/**
+ * The subset of `parseScopeKey(scopeKey)`'s segments that aren't in
+ * `KNOWN_SCOPE_SEGMENTS` — `[]` when every segment is known. Only checks
+ * segment membership against `ROLE_SCOPES`'s flattened vocabulary; not a
+ * general TextMate scope-selector validator.
+ * @param {string} scopeKey
+ * @returns {string[]}
+ */
+export function unknownScopeSegments(scopeKey) {
+  return parseScopeKey(scopeKey).filter(
+    (segment) => !KNOWN_SCOPE_SEGMENTS.has(segment),
+  );
+}
+
 /** `TokenStyle` field -> CSS property in the `--shl-*` var contract. Shared
  * between `defineTheme`'s role/scope expansion and the TextMate importer so
  * both write vars the same way. */

--- a/src/theme.d.ts
+++ b/src/theme.d.ts
@@ -111,3 +111,10 @@ export function paletteToCss(
  * clean. `defineTheme` runs this automatically in dev mode.
  */
 export function validatePalette(palette: ThemePalette): string[];
+
+/** The same `ThemeRole` -> raw hljs scope-key table `defineTheme`'s `roles`
+ * expansion uses. Read-only. */
+export const ROLE_SCOPES: Record<
+  Exclude<ThemeRole, "foreground" | "background">,
+  string[]
+>;

--- a/src/theme.d.ts
+++ b/src/theme.d.ts
@@ -102,3 +102,12 @@ export function paletteToCss(
   palette: ThemePalette,
   options?: PaletteToCssOptions,
 ): string;
+
+/**
+ * Self-check a `ThemePalette` for common authoring mistakes: a missing or
+ * malformed `vars` object, a missing `--shl-fg`/`--shl-bg`, a `vars` key
+ * outside the `--shl-*` grammar, or a `--shl-fg`/`--shl-bg` value that
+ * doesn't look like a recognized color. Never throws; returns `[]` when
+ * clean. `defineTheme` runs this automatically in dev mode.
+ */
+export function validatePalette(palette: ThemePalette): string[];

--- a/src/theme.js
+++ b/src/theme.js
@@ -21,6 +21,10 @@ import {
   varName,
 } from "./theme-vars.js";
 
+/** The same `ThemeRole` -> raw hljs scope-key table `defineTheme`'s `roles`
+ * expansion uses. Read-only. */
+export { ROLE_SCOPES };
+
 const DEFAULT_NAME = "custom-theme";
 
 const THEME_VAR_GRAMMAR = /^--shl-[\w-]+$/;

--- a/src/theme.js
+++ b/src/theme.js
@@ -13,13 +13,25 @@
 import {
   applyTokenStyle,
   colorSchemeFor,
+  parseColorToRgb,
   parseScopeKey,
   ROLE_SCOPES,
   serializeVars,
+  unknownScopeSegments,
   varName,
 } from "./theme-vars.js";
 
 const DEFAULT_NAME = "custom-theme";
+
+const THEME_VAR_GRAMMAR = /^--shl-[\w-]+$/;
+const CSS_KEYWORD_COLORS = new Set([
+  "currentcolor",
+  "transparent",
+  "inherit",
+  "initial",
+  "unset",
+  "revert",
+]);
 
 /**
  * @param {string | TokenStyle} value
@@ -81,6 +93,14 @@ export function defineTheme(definition) {
   }
 
   for (const [scopeKey, rawValue] of Object.entries(definition.scopes ?? {})) {
+    if (import.meta.env?.DEV) {
+      const unknown = unknownScopeSegments(scopeKey);
+      if (unknown.length > 0) {
+        console.warn(
+          `[svelte-highlight] defineTheme(): scope key "${scopeKey}" has unfamiliar segment(s): ${unknown.join(", ")}.`,
+        );
+      }
+    }
     applyTokenStyle(vars, parseScopeKey(scopeKey), normalizeStyle(rawValue));
   }
 
@@ -96,6 +116,13 @@ export function defineTheme(definition) {
   if (definition.extends?.extras !== undefined) {
     palette.extras = definition.extends.extras;
   }
+
+  if (import.meta.env?.DEV) {
+    for (const message of validatePalette(palette)) {
+      console.warn(`[svelte-highlight] defineTheme(): ${message}`);
+    }
+  }
+
   return palette;
 }
 
@@ -127,4 +154,53 @@ export function paletteToCss(palette, options = {}) {
   css += `${selector}{${varsCss}}`;
   if (palette.extras) css += palette.extras;
   return css;
+}
+
+/**
+ * Self-check a `ThemePalette` for common authoring mistakes: a missing or
+ * malformed `vars` object, a missing `--shl-fg`/`--shl-bg`, a `vars` key
+ * outside the `--shl-*` grammar, or a `--shl-fg`/`--shl-bg` value that
+ * doesn't look like a recognized color. Never throws; `defineTheme` runs
+ * this automatically in dev mode.
+ * @param {ThemePalette} palette
+ * @returns {string[]}
+ */
+export function validatePalette(palette) {
+  /** @type {string[]} */
+  const messages = [];
+  const vars = palette?.vars;
+
+  if (vars === null || typeof vars !== "object") {
+    messages.push('"vars" is missing or not a plain object.');
+    return messages;
+  }
+
+  if (vars["--shl-fg"] === undefined) {
+    messages.push('"--shl-fg" (roles.foreground) is missing from "vars".');
+  }
+  if (vars["--shl-bg"] === undefined) {
+    messages.push('"--shl-bg" (roles.background) is missing from "vars".');
+  }
+
+  for (const key of Object.keys(vars)) {
+    if (!THEME_VAR_GRAMMAR.test(key)) {
+      messages.push(`"${key}" does not match the --shl-* var grammar.`);
+    }
+  }
+
+  for (const key of /** @type {const} */ (["--shl-fg", "--shl-bg"])) {
+    const value = vars[key];
+    if (!value) continue;
+    if (
+      parseColorToRgb(value) === null &&
+      !value.includes("(") &&
+      !CSS_KEYWORD_COLORS.has(value.toLowerCase())
+    ) {
+      messages.push(
+        `"${key}" value "${value}" doesn't look like a recognized color.`,
+      );
+    }
+  }
+
+  return messages;
 }

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -6,9 +6,13 @@ import {
   defineTheme,
   extendTheme,
   paletteToCss,
+  ROLE_SCOPES,
   validatePalette,
 } from "../src/theme.js";
-import { unknownScopeSegments } from "../src/theme-vars.js";
+import {
+  ROLE_SCOPES as INTERNAL_ROLE_SCOPES,
+  unknownScopeSegments,
+} from "../src/theme-vars.js";
 
 const THEME_VAR_GRAMMAR = /^--shl-[\w-]+$/;
 
@@ -390,6 +394,13 @@ describe("unknownScopeSegments", () => {
 
   it("returns [] for a known compound scope key", () => {
     expect(unknownScopeSegments("title.class_")).toEqual([]);
+  });
+});
+
+describe("ROLE_SCOPES", () => {
+  it("is the same table src/theme-vars.js exports", () => {
+    expect(ROLE_SCOPES).toEqual(INTERNAL_ROLE_SCOPES);
+    expect(ROLE_SCOPES.keyword).toContain("keyword");
   });
 });
 

--- a/tests/theme.test.ts
+++ b/tests/theme.test.ts
@@ -2,7 +2,13 @@ import fs from "node:fs";
 import path from "node:path";
 import postcss from "postcss";
 import type { ThemeDefinition, ThemePalette } from "../src/theme.d.ts";
-import { defineTheme, extendTheme, paletteToCss } from "../src/theme.js";
+import {
+  defineTheme,
+  extendTheme,
+  paletteToCss,
+  validatePalette,
+} from "../src/theme.js";
+import { unknownScopeSegments } from "../src/theme-vars.js";
 
 const THEME_VAR_GRAMMAR = /^--shl-[\w-]+$/;
 
@@ -292,6 +298,98 @@ describe("paletteToCss", () => {
     };
     const css = paletteToCss(palette);
     expect(css).toContain(".hljs{background-image:linear-gradient(red,blue)}");
+  });
+});
+
+describe("validatePalette", () => {
+  it("returns [] for a clean shipped-shape palette", async () => {
+    const { default: atomOneDark } = (await import(
+      "../src/themes/atom-one-dark.js"
+    )) as {
+      default: ThemePalette;
+    };
+    expect(validatePalette(atomOneDark)).toEqual([]);
+  });
+
+  it("flags a missing vars object", () => {
+    const messages = validatePalette({
+      name: "broken",
+      colorScheme: "dark",
+    } as unknown as ThemePalette);
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toMatch(/vars/);
+  });
+
+  it("flags a missing --shl-fg", () => {
+    const messages = validatePalette({
+      name: "broken",
+      colorScheme: "dark",
+      vars: { "--shl-bg": "#000" },
+    });
+    expect(messages).toEqual(
+      expect.arrayContaining([expect.stringMatching(/roles\.foreground/)]),
+    );
+  });
+
+  it("flags a missing --shl-bg", () => {
+    const messages = validatePalette({
+      name: "broken",
+      colorScheme: "dark",
+      vars: { "--shl-fg": "#fff" },
+    });
+    expect(messages).toEqual(
+      expect.arrayContaining([expect.stringMatching(/roles\.background/)]),
+    );
+  });
+
+  it("flags one message per key outside the --shl-* grammar", () => {
+    const messages = validatePalette({
+      name: "broken",
+      colorScheme: "dark",
+      vars: {
+        "--shl-fg": "#fff",
+        "--shl-bg": "#000",
+        color: "#f00",
+      } as unknown as ThemePalette["vars"],
+    });
+    expect(messages).toHaveLength(1);
+    expect(messages[0]).toContain("color");
+  });
+
+  it("flags a --shl-fg value that doesn't look like a color", () => {
+    const messages = validatePalette({
+      name: "broken",
+      colorScheme: "dark",
+      vars: { "--shl-fg": "#ggg", "--shl-bg": "#000" },
+    });
+    expect(messages).toEqual(
+      expect.arrayContaining([expect.stringMatching(/--shl-fg/)]),
+    );
+  });
+
+  it("passes light-dark(), var(), and CSS color keywords through without a message", () => {
+    for (const value of ["light-dark(#000, #fff)", "var(--x)", "transparent"]) {
+      const messages = validatePalette({
+        name: "ok",
+        colorScheme: "dark",
+        vars: { "--shl-fg": value, "--shl-bg": "#000" },
+      });
+      expect(messages).toEqual([]);
+    }
+  });
+});
+
+describe("unknownScopeSegments", () => {
+  it("returns [] for a known single-segment scope key", () => {
+    expect(unknownScopeSegments("keyword")).toEqual([]);
+  });
+
+  it("returns both segments of a typo'd compound scope key", () => {
+    expect(unknownScopeSegments("titel.calss_")).toEqual(["titel", "calss_"]);
+  });
+
+  it("returns [] for a known compound scope key", () => {
+    expect(unknownScopeSegments("title.class_")).toEqual([]);
   });
 });
 

--- a/www/components/DefineThemePreview.svelte
+++ b/www/components/DefineThemePreview.svelte
@@ -4,7 +4,11 @@
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/themes/atom-one-dark";
   import "svelte-highlight/themes/base.css";
-  import { defineTheme, extendTheme } from "svelte-highlight/theme";
+  import {
+    defineTheme,
+    extendTheme,
+    ROLE_SCOPES,
+  } from "svelte-highlight/theme";
 
   const code = `interface User {
   id: number;
@@ -21,32 +25,37 @@ const greet = (user: User): string => {
   /** @type {"defineTheme" | "extendTheme"} */
   let mode = "defineTheme";
 
-  let background = "#0b1021";
-  let foreground = "#d6deeb";
-  let comment = "#637777";
-  let keyword = "#c792ea";
-  let string = "#ecc48d";
-  let fn = "#82aaff";
-  let type = "#ffcb8b";
-  let tag = "#7fdbca";
+  const roleNames = ["foreground", "background", ...Object.keys(ROLE_SCOPES)];
+
+  let roleColors = {
+    foreground: "#d6deeb",
+    background: "#0b1021",
+    comment: "#637777",
+    keyword: "#c792ea",
+    string: "#ecc48d",
+    literal: "#f78c6c",
+    function: "#82aaff",
+    type: "#ffcb8b",
+    variable: "#addb67",
+    property: "#7fdbca",
+    tag: "#7fdbca",
+    punctuation: "#c5e4fd",
+    meta: "#82aaff",
+    addition: "#a1cd5e",
+    deletion: "#ef5350",
+  };
 
   $: customTheme = defineTheme({
     name: "midnight",
     roles: {
-      background,
-      foreground,
-      comment: { color: comment, fontStyle: "italic" },
-      keyword,
-      string,
-      function: fn,
-      type,
-      tag,
+      ...roleColors,
+      comment: { color: roleColors.comment, fontStyle: "italic" },
     },
   });
 
   $: brandedTheme = extendTheme(atomOneDark, {
     name: "atom-one-dark-branded",
-    roles: { keyword },
+    roles: { keyword: roleColors.keyword },
   });
 
   $: theme = mode === "defineTheme" ? customTheme : brandedTheme;
@@ -98,29 +107,16 @@ const greet = (user: User): string => {
 
   {#if mode === "defineTheme"}
     <div class="swatches">
-      <label class="swatch"
-        ><input type="color" bind:value={background}>background</label
-      >
-      <label class="swatch"
-        ><input type="color" bind:value={foreground}>foreground</label
-      >
-      <label class="swatch"
-        ><input type="color" bind:value={comment}>comment</label
-      >
-      <label class="swatch"
-        ><input type="color" bind:value={keyword}>keyword</label
-      >
-      <label class="swatch"
-        ><input type="color" bind:value={string}>string</label
-      >
-      <label class="swatch"><input type="color" bind:value={fn}>function</label>
-      <label class="swatch"><input type="color" bind:value={type}>type</label>
-      <label class="swatch"><input type="color" bind:value={tag}>tag</label>
+      {#each roleNames as role}
+        <label class="swatch"
+          ><input type="color" bind:value={roleColors[role]}>{role}</label
+        >
+      {/each}
     </div>
   {:else}
     <div class="swatches">
       <label class="swatch"
-        ><input type="color" bind:value={keyword}>keyword</label
+        ><input type="color" bind:value={roleColors.keyword}>keyword</label
       >
     </div>
   {/if}


### PR DESCRIPTION
Also exports ROLE_SCOPES from the public theme entry point and wires
all 14 semantic roles into the www defineTheme preview, which
previously only exposed 8.