### PR TITLE
fix(components): fall back to the auto-hash when scopeClass is empty

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Wrap each `Highlight` in `HighlightStyle` to keep a theme on that block:
 
 The component prefixes each selector with a scope class on the wrapper, so the theme only hits markup inside it.
 
-`theme` is required. `scopeClass` defaults to a hash of the theme string. Pass your own, or bind it (`bind:scopeClass`) / read it from the slot (`let:scopeClass`).
+`theme` is required. `scopeClass` defaults to a hash of the theme string. Pass your own, or bind it (`bind:scopeClass`) / read it from the slot (`let:scopeClass`). An empty string is treated the same as omitting `scopeClass` — it falls back to the auto-hash. `scopeClass` must be a single valid CSS class name; a value like `"a b"` will warn in the console and won't scope as expected.
 
 For a page-wide theme, use `{@html theme}` as shown above.
 

--- a/src/HighlightStyle.svelte
+++ b/src/HighlightStyle.svelte
@@ -70,7 +70,7 @@
 
   // Captured once: a consumer-supplied scopeClass is honored for the
   // lifetime of the instance instead of being overwritten by the hash below.
-  const hasOwnScopeClass = scopeClass !== undefined;
+  const hasOwnScopeClass = scopeClass !== undefined && scopeClass !== "";
 
   $: usingPair = light !== undefined && dark !== undefined;
   $: usingObjectPair =

--- a/src/HighlightStyle.svelte.d.ts
+++ b/src/HighlightStyle.svelte.d.ts
@@ -44,7 +44,8 @@ export type HighlightStyleProps = HTMLAttributes<HTMLDivElement> & {
 
   /**
    * Wrapper class the scoped selectors target. Inert on the `ThemePalette`
-   * path (kept for back-compat / slot access).
+   * path (kept for back-compat / slot access). An empty string is treated
+   * the same as omitting the prop (falls back to the auto-hash).
    * @default hash of `theme`
    */
   scopeClass?: string;

--- a/src/scoped.js
+++ b/src/scoped.js
@@ -23,6 +23,17 @@ const GROUP_AT_RULES = new Set([
 const AT_RULE_NAME = /^@([a-zA-Z-]+)/;
 const WHITESPACE = /\s/;
 
+const VALID_SCOPE_TOKEN = /^-?[a-zA-Z_][\w-]*$/;
+
+/** @param {string} scope */
+function warnIfInvalidScope(scope) {
+  if (typeof console !== "undefined" && !VALID_SCOPE_TOKEN.test(scope)) {
+    console.warn(
+      `[svelte-highlight/scoped] "${scope}" is not a single valid CSS class name; the scoped selector and any class attribute built from it may not match as expected.`,
+    );
+  }
+}
+
 /**
  * @param {string} selector
  * @returns {[string, string, string]} `[leading, core, trailing]`
@@ -157,6 +168,7 @@ export function scopeSelectors(css, transform) {
  * @returns {string}
  */
 export function scopeStyle(style, scope) {
+  warnIfInvalidScope(scope);
   const body = scopedBody(style, scope);
   const match = STYLE_TAG.exec(style);
   return match ? `${match[1] ?? ""}${body}${match[3] ?? ""}` : body;
@@ -193,6 +205,7 @@ function scopedBody(style, scope, prefix = "") {
  * @returns {string}
  */
 export function dualStyle(light, dark, scope, mode = "auto") {
+  warnIfInvalidScope(scope);
   let css;
   if (mode === "light") {
     css = scopedBody(light, scope);

--- a/tests/e2e/HighlightStyle.emptyScopeClass.test.svelte
+++ b/tests/e2e/HighlightStyle.emptyScopeClass.test.svelte
@@ -1,0 +1,11 @@
+<script>
+  import Highlight, { HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import a11yDark from "svelte-highlight/styles/a11y-dark";
+
+  const code = "const add = (a, b) => a + b;";
+</script>
+
+<HighlightStyle theme={a11yDark} scopeClass="" data-testid="wrapper">
+  <Highlight language={typescript} {code} />
+</HighlightStyle>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -34,6 +34,7 @@ import HighlightStreamTemplateLiteral from "./HighlightStream.templateLiteral.te
 import HighlightStream from "./HighlightStream.test.svelte";
 import HighlightStreamVirtualize from "./HighlightStream.virtualize.test.svelte";
 import HighlightStyleDedupe from "./HighlightStyle.dedupe.test.svelte";
+import HighlightStyleEmptyScopeClass from "./HighlightStyle.emptyScopeClass.test.svelte";
 import HighlightStyleNoTheme from "./HighlightStyle.noTheme.test.svelte";
 import HighlightStyleThemeSwitch from "./HighlightStyle.themeSwitch.test.svelte";
 import HighlightSvelteDispatchOnce from "./HighlightSvelte.dispatchOnce.test.svelte";
@@ -120,6 +121,23 @@ test("HighlightStyle - renders nothing when no theme is provided", async ({
     .evaluate((head) => head.textContent ?? "");
   expect(headText).not.toContain("undefined");
   await expect(page.locator("style")).toHaveCount(0);
+});
+
+test("HighlightStyle - falls back to the auto-hash when scopeClass is an empty string", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStyleEmptyScopeClass);
+
+  const wrapper = page.getByTestId("wrapper");
+  const scopeClass = await wrapper.getAttribute("class");
+  expect(scopeClass).not.toBe("");
+  expect(scopeClass).not.toBeNull();
+
+  await expect(page.locator(".hljs-keyword").first()).toHaveCSS(
+    "color",
+    "rgb(220, 198, 224)",
+  );
 });
 
 test("CodeWindow - renders each variant wrapping a Highlight", async ({

--- a/tests/scoped.test.ts
+++ b/tests/scoped.test.ts
@@ -1,4 +1,4 @@
-import { scopeClassFor, scopeStyle } from "../src/scoped.js";
+import { dualStyle, scopeClassFor, scopeStyle } from "../src/scoped.js";
 import a11yDark from "../src/styles/a11y-dark.js";
 import brownPaper from "../src/styles/brown-paper.js";
 
@@ -75,6 +75,48 @@ describe("scopeStyle", () => {
     const out = scopeStyle(brownPaper, "svh-scope-2");
     expect(out).toContain(".svh-scope-2 .hljs{");
     expect(out).toContain("url(data:image/png;base64,");
+  });
+});
+
+describe("invalid scope token warnings", () => {
+  let warnings: unknown[][];
+  let originalWarn: typeof console.warn;
+
+  beforeEach(() => {
+    warnings = [];
+    originalWarn = console.warn;
+    console.warn = (...args: unknown[]) => {
+      warnings.push(args);
+    };
+  });
+
+  afterEach(() => {
+    console.warn = originalWarn;
+  });
+
+  it("warns once for a scope containing a space", () => {
+    scopeStyle(".hljs{color:red}", "a b");
+    expect(warnings.length).toBe(1);
+  });
+
+  it("warns once for a scope with a leading digit", () => {
+    scopeStyle(".hljs{color:red}", "1abc");
+    expect(warnings.length).toBe(1);
+  });
+
+  it("does not warn for a valid hyphenated scope", () => {
+    scopeStyle(".hljs{color:red}", "valid-scope");
+    expect(warnings.length).toBe(0);
+  });
+
+  it("does not warn for a scope starting with an underscore", () => {
+    scopeStyle(".hljs{color:red}", "_valid");
+    expect(warnings.length).toBe(0);
+  });
+
+  it("warns exactly once per dualStyle call, not once per theme", () => {
+    dualStyle(".hljs{color:red}", ".hljs{color:blue}", "a b");
+    expect(warnings.length).toBe(1);
   });
 });
 


### PR DESCRIPTION
Also adds a console warning when scopeClass isn't a single valid CSS
class name (e.g. "a b"), since that silently produces a
descendant-combinator selector instead of a scoped match.