### PR TITLE
docs(components): add HighlightStyle to the Component API reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -254,7 +254,7 @@ const palette = fromTextMate(nightOwl, {
 
 Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility.
 
-These legacy styles are stable and will not be removed; new projects should still prefer [Theming](#theming) (the `ThemePalette` path) instead.
+These legacy styles are stable and will not be removed; new projects should still prefer [Theming](#theming) (the `ThemePalette` path) instead. The main reason to pick this path over `ThemePalette` is a custom `classPrefix`: `base.css` (used by `ThemePalette` themes) assumes the default `hljs-` class prefix, so projects using a custom prefix should stay on the legacy string path.
 
 There are two ways to apply `highlight.js` styles.
 

--- a/README.md
+++ b/README.md
@@ -1696,6 +1696,20 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 />
 ```
 
+### `HighlightStyle`
+
+#### Props
+
+| Name       | Type                                     | Default value    |
+| :--------- | :--------------------------------------- | :---------------- |
+| theme      | `string \| ThemePalette`                 | N/A                |
+| light      | `string \| ThemePalette`                 | N/A                |
+| dark       | `string \| ThemePalette`                 | N/A                |
+| mode       | `"auto" \| "light" \| "dark" \| string`  | `"auto"`           |
+| scopeClass | `string`                                 | hash of `theme`    |
+
+The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the wrapper `div` element.
+
 ### `LineNumbers`
 
 #### Props

--- a/README.md
+++ b/README.md
@@ -279,6 +279,18 @@ This component exports `highlight.js` themes in JavaScript. Import the theme fro
 <Highlight language={typescript} {code} />
 ```
 
+> [!WARNING]
+> This pattern injects a raw `<style>` tag via `{@html}`. Under a strict
+> Content-Security-Policy without `'unsafe-inline'` for `style-src`, the
+> browser silently drops that tag with no error surfaced to the developer.
+> [CSS StyleSheet](#css-stylesheet) below is CSP-safe by construction, since
+> it's a normal stylesheet reference.
+>
+> The snippet above also has no protection against duplicate output: placing
+> it inside a component that's mounted more than once emits one `<style>` tag
+> per mount. For anything mounted more than once, use
+> [`HighlightStyle`](#highlightstyle) instead, which dedupes automatically.
+
 ### CSS StyleSheet
 
 Depending on your set-up, importing a CSS StyleSheet in Svelte may require a CSS file loader. SvelteKit/Vite automatically supports this. For Webpack, refer to [examples/webpack](examples/webpack).

--- a/README.md
+++ b/README.md
@@ -254,6 +254,8 @@ const palette = fromTextMate(nightOwl, {
 
 Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility.
 
+These legacy styles are stable and will not be removed; new projects should still prefer [Theming](#theming) (the `ThemePalette` path) instead.
+
 There are two ways to apply `highlight.js` styles.
 
 1. Injected styles through [svelte:head](https://svelte.dev/docs#template-syntax-svelte-head)


### PR DESCRIPTION
Also covers the Injected Styles caveats (CSP and dedup), a stability
banner for legacy styles, and the classPrefix cross-link in Styling.