### PR TITLE
docs(compat): replace the custom-language stub with a real grammar

### DIFF
--- a/README.md
+++ b/README.md
@@ -1062,6 +1062,8 @@ Most hljs grammars are plain-JSON `contains`/`begin`/`end`/`className` rules, wh
 
 Any other `on:begin`/`on:end`/`__beforeBegin` body converts too, but with a `console.warn` and the rule's relevance forced to zero — it still matches, unconditionally, without skewing auto-detection. Check `language.warnings` (see above) to catch this without reading the console.
 
+Upgrading a custom language written before 7.16? Before 7.16, a custom language was `{ name, register: (hljs) => modeObject }` passed synchronously straight to `<Highlight>`'s `language` prop. Since 7.16 replaced the highlight.js runtime with this package's own engine, `register` must be plain-JSON grammar IR instead, and `fromHighlightJs` (now async, requiring `{#await}`) is the replacement shown above.
+
 ## Custom Plugin
 
 Third-party hljs language plugins work the same way: pass their `register(hljs)` export to `fromHighlightJs`.

--- a/README.md
+++ b/README.md
@@ -1047,6 +1047,21 @@ const language: LanguageType<"dotenv"> = await fromHighlightJs(
 
 Building a package for others to install? Ship the converted grammar directly instead of calling `fromHighlightJs` at runtime — see [`scripts/convert-grammars.ts`](scripts/convert-grammars.ts) for the converter this package's own bundled languages go through.
 
+### Conversion fidelity
+
+`fromHighlightJs` and [`scripts/convert-grammars.ts`](scripts/convert-grammars.ts) (the pipeline behind every one of the ~244 bundled `svelte-highlight/languages/*` grammars) share the exact same converter, so a custom grammar goes through identical logic to every shipped one, not a lesser path.
+
+Most hljs grammars are plain-JSON `contains`/`begin`/`end`/`className` rules, which convert as-is. A grammar can also use `on:begin`, `on:end`, or `__beforeBegin` callbacks for cases regexes alone can't express; the converter recognizes six specific shapes and turns them into declarative flags:
+
+- An `on:begin` callback that copies the matched text so the closing delimiter must equal the opening one (heredocs).
+- An `on:begin` callback that only accepts a match at the very start of input (a shebang guard).
+- An `on:begin` callback that disambiguates an opening tag from a generic comparison (JSX).
+- An `on:begin` callback that checks the character immediately before the match (a letter-boundary guard).
+- An `on:begin` callback checking `SOME_SET.has(match[0])` against a module-level word list — recovered only when you also pass the grammar's own source text as `fromHighlightJs`'s third argument, since the compiled callback alone doesn't expose the backing array.
+- A `__beforeBegin` callback that rejects a match immediately following a `.` (hljs's `beginKeywords` dot-guard).
+
+Any other `on:begin`/`on:end`/`__beforeBegin` body converts too, but with a `console.warn` and the rule's relevance forced to zero — it still matches, unconditionally, without skewing auto-detection. Check `language.warnings` (see above) to catch this without reading the console.
+
 ## Custom Plugin
 
 Third-party hljs language plugins work the same way: pass their `register(hljs)` export to `fromHighlightJs`.

--- a/README.md
+++ b/README.md
@@ -990,18 +990,29 @@ The easiest way to author one is with `svelte-highlight/compat`'s `fromHighlight
   import { Highlight } from "svelte-highlight";
   import { fromHighlightJs } from "svelte-highlight/compat";
 
-  function defineCustomLanguage(hljs) {
+  function defineDotenv(hljs) {
     return {
-      /** custom language rules */
-      contains: [],
+      name: "dotenv",
+      contains: [
+        hljs.HASH_COMMENT_MODE,
+        { className: "keyword", begin: /^[ \t]*export(?=[ \t])/ },
+        { className: "attr", begin: /[A-Za-z_][A-Za-z0-9_]*(?=[ \t]*=)/ },
+        {
+          className: "string",
+          variants: [
+            { begin: /"/, end: /"/, contains: [hljs.BACKSLASH_ESCAPE] },
+            { begin: /'/, end: /'/ },
+          ],
+        },
+      ],
     };
   }
 
-  const languagePromise = fromHighlightJs("custom-language", defineCustomLanguage);
+  const languagePromise = fromHighlightJs("dotenv", defineDotenv);
 </script>
 
 {#await languagePromise then language}
-  <Highlight {language} code="..." />
+  <Highlight {language} code={'PORT=3000\n# comment'} />
 {/await}
 ```
 
@@ -1010,9 +1021,9 @@ The easiest way to author one is with `svelte-highlight/compat`'s `fromHighlight
 `fromHighlightJs` also accepts an optional third `source` argument (raw source text, e.g. via a bundler's `?raw` import) to recover array-membership `on:begin` guards the compiled callback alone can't expose, and the returned object carries a `warnings: string[]` field (empty when clean) so you can detect a degraded conversion without reading the console.
 
 ```ts
-const language = await fromHighlightJs("custom-language", defineCustomLanguage, grammarSourceText);
+const language = await fromHighlightJs("dotenv", defineDotenv, grammarSourceText);
 if (language.warnings.length > 0) {
-  console.error("custom-language degraded:", language.warnings);
+  console.error("dotenv degraded:", language.warnings);
 }
 ```
 
@@ -1022,9 +1033,15 @@ If you're using TypeScript, use the `LanguageType` interface to type the languag
 import type { LanguageType } from "svelte-highlight";
 import { fromHighlightJs } from "svelte-highlight/compat";
 
-const language: LanguageType<"custom-language"> = await fromHighlightJs(
-  "custom-language",
-  (hljs) => ({ contains: [] }),
+const language: LanguageType<"dotenv"> = await fromHighlightJs(
+  "dotenv",
+  (hljs) => ({
+    name: "dotenv",
+    contains: [
+      hljs.HASH_COMMENT_MODE,
+      { className: "attr", begin: /[A-Za-z_][A-Za-z0-9_]*(?=[ \t]*=)/ },
+    ],
+  }),
 );
 ```
 

--- a/www/components/CustomLanguage.svelte
+++ b/www/components/CustomLanguage.svelte
@@ -1,0 +1,64 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import Highlight, { HighlightSvelte } from "svelte-highlight";
+  import { fromHighlightJs } from "svelte-highlight/compat";
+
+  const EXPORT_RE = /^[ \t]*export(?=[ \t])/;
+  const ATTR_RE = /[A-Za-z_][A-Za-z0-9_]*(?=[ \t]*=)/;
+  const DOUBLE_QUOTE_RE = /"/;
+  const SINGLE_QUOTE_RE = /'/;
+
+  function defineDotenv(hljs) {
+    return {
+      name: "dotenv",
+      contains: [
+        hljs.HASH_COMMENT_MODE,
+        { className: "keyword", begin: EXPORT_RE },
+        { className: "attr", begin: ATTR_RE },
+        {
+          className: "string",
+          variants: [
+            {
+              begin: DOUBLE_QUOTE_RE,
+              end: DOUBLE_QUOTE_RE,
+              contains: [hljs.BACKSLASH_ESCAPE],
+            },
+            { begin: SINGLE_QUOTE_RE, end: SINGLE_QUOTE_RE },
+          ],
+        },
+      ],
+    };
+  }
+
+  const code = "export PORT=3000\nAPI_KEY='sk-demo'\n# comment";
+
+  const languagePromise = fromHighlightJs("dotenv-demo", defineDotenv);
+
+  const snippet = `<script>
+  import { Highlight } from "svelte-highlight";
+  import { fromHighlightJs } from "svelte-highlight/compat";
+
+  function defineDotenv(hljs) {
+    return {
+      name: "dotenv",
+      contains: [
+        hljs.HASH_COMMENT_MODE,
+        { className: "keyword", begin: /^[ \\t]*export(?=[ \\t])/ },
+        { className: "attr", begin: /[A-Za-z_][A-Za-z0-9_]*(?=[ \\t]*=)/ },
+      ],
+    };
+  }
+
+  const languagePromise = fromHighlightJs("dotenv-demo", defineDotenv);
+<\/script>
+
+{#await languagePromise then language}
+  <Highlight {language} code={${JSON.stringify(code)}} />
+{/await}`;
+</script>
+
+<HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+
+{#await languagePromise then language}
+  <Highlight {language} {code} class={THEME_MODULE_NAME} />
+{/await}

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -8,6 +8,7 @@
   import CopyButtonLineNumbers from "@components/CopyButton/LineNumbers.svelte";
   import CopyButtonSlot from "@components/CopyButton/Slot.svelte";
   import CopyButtonStyleProps from "@components/CopyButton/StyleProps.svelte";
+  import CustomLanguage from "@components/CustomLanguage.svelte";
   import FileTabs from "@components/FileTabs.svelte";
   import HighlightWrap from "@components/Highlight/Wrap.svelte";
   import EditableBasic from "@components/HighlightEditable/Basic.svelte";
@@ -907,6 +908,33 @@ export default {
       --langtag-padding="0.5rem"
     />
   </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Custom Language</h3> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">fromHighlightJs</code>
+      converts a user-authored hljs-format grammar (a
+      <code class="code">register(hljs)</code>
+      function returning a mode object) into this package's
+      <code class="code">LanguageType</code>
+      at runtime — no build step, no bundled hljs code.
+    </p>
+    <p class="mb-5">
+      See the{" "}
+      <Link
+        size="lg"
+        href="https://github.com/metonym/svelte-highlight#custom-language"
+      >
+        Custom Language section
+      </Link>
+      {" "}
+      of the README for conversion fidelity details and third-party plugin
+      support.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CustomLanguage /> </Column>
 </Row>
 
 <Row class="mb-9">


### PR DESCRIPTION
Also documents which hljs on:begin/on:end/__beforeBegin shapes the
converter turns into declarative flags versus which ones degrade to a
console warning, cross-links the pre-7.16 custom-language migration
note, and adds a live fromHighlightJs demo to the docs site.