### PR TITLE
fix(components): hide the LineNumbers gutter from assistive technology

### DIFF
--- a/README.md
+++ b/README.md
@@ -624,6 +624,30 @@ The line number starts at `1`. Customize this via the `startingLineNumber` prop.
 </Highlight>
 ```
 
+### Windowed Lines
+
+`LineNumbers` re-splits the entire `highlighted` string into lines on every update, which is wasteful once you're already rendering a window out of a much larger document. Pass a pre-split `lines` array instead -- the same per-line HTML shape `svelte-highlight/tokenized-document`'s `lineRange` (see [Large documents](#large-documents)) and `HighlightStream`'s incremental rendering already produce -- and set `lineCount` to the *total* document line count so the gutter is sized for the whole document instead of jittering as the window scrolls. `startingLineNumber` offsets the row numbers to match the window's position; `highlightedLines`/`lineStates` index relative to the `lines` array actually rendered, not the absolute document line.
+
+```svelte
+<script>
+  import { LineNumbers } from "svelte-highlight";
+  import { createTokenizedDocument } from "svelte-highlight/tokenized-document";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const doc = createTokenizedDocument({ language: typescript });
+  doc.setCode(bigFile);
+
+  const start = 50_000;
+  const end = 50_040;
+</script>
+
+<LineNumbers
+  lines={doc.lineRange(start, end)}
+  startingLineNumber={start + 1}
+  lineCount={doc.lineCount()}
+/>
+```
+
 ### Highlighted Lines
 
 Specify the lines to highlight using the `highlightedLines` prop. Indices start at zero.
@@ -1882,15 +1906,17 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 
 #### Props
 
-| Name               | Type       | Default value  |
-| :----------------- | :--------- | :------------- |
-| highlighted        | `string`   | N/A (required) |
-| hideBorder         | `boolean`  | `false`        |
-| wrapLines          | `boolean`  | `false`        |
-| startingLineNumber | `number`   | `1`            |
-| highlightedLines   | `number[]` | `[]`           |
-| langtag            | `boolean`  | `false`        |
-| languageName       | `string`   | `"plaintext"`  |
+| Name               | Type       | Default value                       |
+| :----------------- | :--------- | :----------------------------------- |
+| highlighted        | `string`   | N/A (required unless `lines` is set) |
+| lines              | `string[]` | `undefined`                          |
+| lineCount          | `number`   | `undefined`                          |
+| hideBorder         | `boolean`  | `false`                              |
+| wrapLines          | `boolean`  | `false`                              |
+| startingLineNumber | `number`   | `1`                                  |
+| highlightedLines   | `number[]` | `[]`                                 |
+| langtag            | `boolean`  | `false`                              |
+| languageName       | `string`   | `"plaintext"`                        |
 
 `$$restProps` are forwarded to the top-level `div` element.
 

--- a/README.md
+++ b/README.md
@@ -424,16 +424,18 @@ These apply to the outer container of every component (the `pre` element for `Hi
 
 ### `LineNumbers` variables
 
-| Variable                 | Description                                       | Default value             |
-| :----------------------- | :------------------------------------------------ | :------------------------ |
-| --line-number-color      | Text color of the line numbers                    | `currentColor`            |
-| --border-color           | Border color of the column of line numbers        | `currentColor`            |
-| --highlighted-background | Background color of highlighted lines             | `rgba(254, 241, 96, 0.2)` |
-| --unhighlighted-opacity  | Opacity of un-highlighted lines (focus mode)      | `1`                       |
-| --unhighlighted-filter   | CSS filter for un-highlighted lines (focus mode)  | `none`                    |
-| --padding                | Fallback padding for `--padding-left` / `--padding-right` | `1em`              |
-| --padding-left           | Left padding for `td` elements                    | `var(--padding, 1em)`     |
-| --padding-right          | Right padding for `td` elements                   | `var(--padding, 1em)`     |
+| Variable                  | Description                                       | Default value               |
+| :------------------------ | :------------------------------------------------ | :--------------------------- |
+| --line-number-color       | Text color of the line numbers                    | `currentColor`               |
+| --border-color            | Border color of the column of line numbers        | `currentColor`               |
+| --highlighted-background  | Background color of highlighted lines             | `rgba(254, 241, 96, 0.2)`    |
+| --line-added-background   | Background color of `lineStates` `"added"` lines   | `rgba(46, 204, 113, 0.15)`   |
+| --line-removed-background | Background color of `lineStates` `"removed"` lines | `rgba(231, 76, 60, 0.15)`    |
+| --unhighlighted-opacity   | Opacity of un-highlighted lines (focus mode)      | `1`                          |
+| --unhighlighted-filter    | CSS filter for un-highlighted lines (focus mode)  | `none`                       |
+| --padding                 | Fallback padding for `--padding-left` / `--padding-right` | `1em`                 |
+| --padding-left            | Left padding for `td` elements                    | `var(--padding, 1em)`        |
+| --padding-right           | Right padding for `td` elements                   | `var(--padding, 1em)`        |
 
 ### `CopyButton` variables
 
@@ -682,20 +684,48 @@ Use `--highlighted-background` to customize the background color of highlighted 
 </Highlight>
 ```
 
+### Line States
+
+`highlightedLines` only supports one visual treatment. Use `lineStates` for a per-line state map -- `"highlighted"` (same treatment as `highlightedLines`), `"focus"` (exempt from dimming, no background color), `"added"`, or `"removed"` -- so diff-style and meta-string-style decorations can share one primitive. Indices start at zero and are merged with `highlightedLines`, which is equivalent to setting `"highlighted"` here.
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers
+    {highlighted}
+    lineStates={{ 1: "added", 2: "removed", 4: "focus" }}
+  />
+</Highlight>
+```
+
+Use `--line-added-background` and `--line-removed-background` to customize the background colors.
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers
+    {highlighted}
+    lineStates={{ 1: "added", 2: "removed" }}
+    --line-added-background="rgba(0, 255, 0, 0.15)"
+    --line-removed-background="rgba(255, 0, 0, 0.15)"
+  />
+</Highlight>
+```
+
 ### Custom Styles
 
 Use `--style-props` to customize styles.
 
-| Style prop               | Description                                              | Default value             |
-| :----------------------- | :------------------------------------------------------ | :------------------------ |
-| --line-number-color      | Text color of the line numbers                          | `currentColor`            |
-| --border-color           | Border color of the column of line numbers              | `currentColor`            |
-| --padding                | Fallback padding for `--padding-left` / `--padding-right` | `1em`                   |
-| --padding-left           | Left padding for `td` elements                          | `var(--padding, 1em)`     |
-| --padding-right          | Right padding for `td` elements                         | `var(--padding, 1em)`     |
-| --highlighted-background | Background color of highlighted lines                   | `rgba(254, 241, 96, 0.2)` |
-| --unhighlighted-opacity  | Opacity of un-highlighted lines (focus mode)            | `1`                       |
-| --unhighlighted-filter   | CSS filter for un-highlighted lines (focus mode)        | `none`                    |
+| Style prop                | Description                                              | Default value              |
+| :------------------------ | :------------------------------------------------------ | :-------------------------- |
+| --line-number-color       | Text color of the line numbers                          | `currentColor`              |
+| --border-color            | Border color of the column of line numbers              | `currentColor`              |
+| --padding                 | Fallback padding for `--padding-left` / `--padding-right` | `1em`                     |
+| --padding-left            | Left padding for `td` elements                          | `var(--padding, 1em)`       |
+| --padding-right           | Right padding for `td` elements                         | `var(--padding, 1em)`       |
+| --highlighted-background  | Background color of highlighted lines                   | `rgba(254, 241, 96, 0.2)`   |
+| --line-added-background   | Background color of `lineStates` `"added"` lines         | `rgba(46, 204, 113, 0.15)`  |
+| --line-removed-background | Background color of `lineStates` `"removed"` lines        | `rgba(231, 76, 60, 0.15)`   |
+| --unhighlighted-opacity   | Opacity of un-highlighted lines (focus mode)             | `1`                         |
+| --unhighlighted-filter    | CSS filter for un-highlighted lines (focus mode)         | `none`                      |
 
 See [Styling with CSS variables](#styling-with-css-variables) for the full list, including container-level variables like `--border-radius`, `--width`, and `--overflow-x`.
 
@@ -1906,17 +1936,18 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 
 #### Props
 
-| Name               | Type       | Default value                       |
-| :----------------- | :--------- | :----------------------------------- |
-| highlighted        | `string`   | N/A (required unless `lines` is set) |
-| lines              | `string[]` | `undefined`                          |
-| lineCount          | `number`   | `undefined`                          |
-| hideBorder         | `boolean`  | `false`                              |
-| wrapLines          | `boolean`  | `false`                              |
-| startingLineNumber | `number`   | `1`                                  |
-| highlightedLines   | `number[]` | `[]`                                 |
-| langtag            | `boolean`  | `false`                              |
-| languageName       | `string`   | `"plaintext"`                        |
+| Name               | Type                                                        | Default value                       |
+| :----------------- | :---------------------------------------------------------- | :----------------------------------- |
+| highlighted        | `string`                                                     | N/A (required unless `lines` is set) |
+| lines              | `string[]`                                                   | `undefined`                          |
+| lineCount          | `number`                                                     | `undefined`                          |
+| hideBorder         | `boolean`                                                    | `false`                              |
+| wrapLines          | `boolean`                                                    | `false`                              |
+| startingLineNumber | `number`                                                     | `1`                                  |
+| highlightedLines   | `number[]`                                                   | `[]`                                 |
+| lineStates         | `Record<number, "highlighted" \| "focus" \| "added" \| "removed">` | `{}`                           |
+| langtag            | `boolean`                                                    | `false`                              |
+| languageName       | `string`                                                     | `"plaintext"`                        |
 
 `$$restProps` are forwarded to the top-level `div` element.
 

--- a/README.md
+++ b/README.md
@@ -427,6 +427,7 @@ These apply to the outer container of every component (the `pre` element for `Hi
 | Variable                  | Description                                       | Default value               |
 | :------------------------ | :------------------------------------------------ | :--------------------------- |
 | --line-number-color       | Text color of the line numbers                    | `currentColor`               |
+| --line-number-digit-width | Width of a single gutter digit                    | `0.6em`                      |
 | --border-color            | Border color of the column of line numbers        | `currentColor`               |
 | --highlighted-background  | Background color of highlighted lines             | `rgba(254, 241, 96, 0.2)`    |
 | --line-added-background   | Background color of `lineStates` `"added"` lines   | `rgba(46, 204, 113, 0.15)`   |
@@ -717,6 +718,7 @@ Use `--style-props` to customize styles.
 | Style prop                | Description                                              | Default value              |
 | :------------------------ | :------------------------------------------------------ | :-------------------------- |
 | --line-number-color       | Text color of the line numbers                          | `currentColor`              |
+| --line-number-digit-width | Width of a single gutter digit                          | `0.6em`                     |
 | --border-color            | Border color of the column of line numbers              | `currentColor`              |
 | --padding                 | Fallback padding for `--padding-left` / `--padding-right` | `1em`                     |
 | --padding-left            | Left padding for `td` elements                          | `var(--padding, 1em)`       |
@@ -734,6 +736,7 @@ See [Styling with CSS variables](#styling-with-css-variables) for the full list,
   <LineNumbers
     {highlighted}
     --line-number-color="pink"
+    --line-number-digit-width="0.75em"
     --border-color="rgba(255, 255, 255, 0.2)"
     --padding-left={0}
     --padding-right="3em"

--- a/README.md
+++ b/README.md
@@ -744,6 +744,8 @@ See [Styling with CSS variables](#styling-with-css-variables) for the full list,
 </Highlight>
 ```
 
+The gutter's position and border use logical CSS properties (`inset-inline-start`/`inset-inline-end`), so it follows `dir="rtl"` without any extra configuration.
+
 ### Language Tag
 
 When using a custom slot, forward `langtag` and `languageName` from `Highlight` to `LineNumbers`.

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -51,6 +51,7 @@
         {@const isHighlighted = highlightedLineSet.has(i)}
         <tr class:dimmed={focusMode && !isHighlighted}>
           <td
+            aria-hidden="true"
             class:hljs={true}
             class:hideBorder
             style:position="sticky"

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -1,8 +1,27 @@
 <script>
   import { splitLines } from "./split-lines.js";
 
-  /** @type {string} */
-  export let highlighted;
+  /**
+   * Highlighted `code` HTML. Required at runtime unless `lines` is passed.
+   * @type {string | undefined}
+   */
+  export let highlighted = undefined;
+
+  /**
+   * Pre-split per-line HTML, the same shape `splitLines`/`extendLines`/
+   * `TokenizedDocument#lineRange` produce. Overrides `highlighted` --
+   * pass this to render a window of a larger document without re-splitting
+   * the full string on every update.
+   * @type {string[] | undefined}
+   */
+  export let lines = undefined;
+
+  /**
+   * Total document line count, for gutter-width purposes, when `lines` is a
+   * partial window rather than the whole document.
+   * @type {number | undefined}
+   */
+  export let lineCount = undefined;
 
   /** @type {boolean} */
   export let hideBorder = false;
@@ -26,10 +45,14 @@
   const MIN_DIGITS = 2;
   const HIGHLIGHTED_BACKGROUND = "rgba(254, 241, 96, 0.2)";
 
-  $: lines = splitLines(highlighted);
+  $: renderedLines = lines ?? splitLines(highlighted ?? "");
   $: highlightedLineSet = new Set(highlightedLines);
   $: focusMode = highlightedLines.length > 0;
-  $: len_digits = (startingLineNumber + lines.length - 1).toString().length;
+  $: len_digits = (
+    startingLineNumber +
+    (lineCount ?? renderedLines.length) -
+    1
+  ).toString().length;
   $: len = len_digits - MIN_DIGITS < 1 ? MIN_DIGITS : len_digits;
   $: width = len * DIGIT_WIDTH;
 </script>
@@ -46,7 +69,7 @@
 >
   <table>
     <tbody class:hljs={true}>
-      {#each lines as line, i}
+      {#each renderedLines as line, i}
         {@const lineNumber = i + startingLineNumber}
         {@const isHighlighted = highlightedLineSet.has(i)}
         <tr class:dimmed={focusMode && !isHighlighted}>

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -113,8 +113,8 @@
             class:hljs={true}
             class:hideBorder
             style:position="sticky"
-            style:left="0"
-            style:text-align="right"
+            style:inset-inline-start="0"
+            style:text-align="end"
             style:user-select="none"
             style:width={`${width}px`}
           >
@@ -186,7 +186,7 @@
     content: "";
     position: absolute;
     top: 0;
-    right: 0;
+    inset-inline-end: 0;
     width: 1px;
     height: 100%;
     background: var(--border-color, currentColor);

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -49,7 +49,6 @@
   /** @type {boolean} */
   export let langtag = false;
 
-  const DIGIT_WIDTH = 12;
   const MIN_DIGITS = 2;
   const HIGHLIGHTED_BACKGROUND = "rgba(254, 241, 96, 0.2)";
   const ADDED_BACKGROUND = "rgba(46, 204, 113, 0.15)";
@@ -88,7 +87,6 @@
     1
   ).toString().length;
   $: len = len_digits - MIN_DIGITS < 1 ? MIN_DIGITS : len_digits;
-  $: width = len * DIGIT_WIDTH;
 </script>
 
 <div
@@ -116,7 +114,7 @@
             style:inset-inline-start="0"
             style:text-align="end"
             style:user-select="none"
-            style:width={`${width}px`}
+            style:width={`calc(${len} * var(--line-number-digit-width, 0.6em))`}
           >
             <code style:color="var(--line-number-color, currentColor)">
               {lineNumber}

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -35,6 +35,14 @@
   /** @type {number[]} */
   export let highlightedLines = [];
 
+  /**
+   * Per-line decoration state, indexed relative to `lines`/`highlighted`
+   * (not the absolute document line when rendering a window). Merged with
+   * `highlightedLines`, which is equivalent to setting `"highlighted"` here.
+   * @type {Record<number, "highlighted" | "focus" | "added" | "removed">}
+   */
+  export let lineStates = {};
+
   /** @type {import('./languages').LanguageName | (string & {})} */
   export let languageName = "plaintext";
 
@@ -44,10 +52,36 @@
   const DIGIT_WIDTH = 12;
   const MIN_DIGITS = 2;
   const HIGHLIGHTED_BACKGROUND = "rgba(254, 241, 96, 0.2)";
+  const ADDED_BACKGROUND = "rgba(46, 204, 113, 0.15)";
+  const REMOVED_BACKGROUND = "rgba(231, 76, 60, 0.15)";
+
+  /**
+   * @param {number[]} highlightedLines
+   * @param {Record<number, "highlighted" | "focus" | "added" | "removed">} lineStates
+   */
+  function buildStateByIndex(highlightedLines, lineStates) {
+    const map = new Map(highlightedLines.map((i) => [i, "highlighted"]));
+    for (const key in lineStates) map.set(Number(key), lineStates[key]);
+    return map;
+  }
+
+  /** @param {"highlighted" | "focus" | "added" | "removed" | undefined} state */
+  function lineBackground(state) {
+    if (state === "added") {
+      return `var(--line-added-background, ${ADDED_BACKGROUND})`;
+    }
+    if (state === "removed") {
+      return `var(--line-removed-background, ${REMOVED_BACKGROUND})`;
+    }
+    if (state === "highlighted") {
+      return `var(--highlighted-background, ${HIGHLIGHTED_BACKGROUND})`;
+    }
+    return undefined;
+  }
 
   $: renderedLines = lines ?? splitLines(highlighted ?? "");
-  $: highlightedLineSet = new Set(highlightedLines);
-  $: focusMode = highlightedLines.length > 0;
+  $: stateByIndex = buildStateByIndex(highlightedLines, lineStates);
+  $: focusMode = stateByIndex.size > 0;
   $: len_digits = (
     startingLineNumber +
     (lineCount ?? renderedLines.length) -
@@ -71,8 +105,9 @@
     <tbody class:hljs={true}>
       {#each renderedLines as line, i}
         {@const lineNumber = i + startingLineNumber}
-        {@const isHighlighted = highlightedLineSet.has(i)}
-        <tr class:dimmed={focusMode && !isHighlighted}>
+        {@const lineState = stateByIndex.get(i)}
+        {@const background = lineBackground(lineState)}
+        <tr class:dimmed={focusMode && !lineState}>
           <td
             aria-hidden="true"
             class:hljs={true}
@@ -86,20 +121,14 @@
             <code style:color="var(--line-number-color, currentColor)">
               {lineNumber}
             </code>
-            {#if isHighlighted}
-              <div
-                class:line-background={true}
-                style:background="var(--highlighted-background, {HIGHLIGHTED_BACKGROUND})"
-              ></div>
+            {#if background}
+              <div class:line-background={true} style:background></div>
             {/if}
           </td>
           <td>
             <pre class:wrapLines><code>{@html line || "\n"}</code></pre>
-            {#if isHighlighted}
-              <div
-                class:line-background={true}
-                style:background="var(--highlighted-background, {HIGHLIGHTED_BACKGROUND})"
-              ></div>
+            {#if background}
+              <div class:line-background={true} style:background></div>
             {/if}
           </td>
         </tr>

--- a/src/LineNumbers.svelte.d.ts
+++ b/src/LineNumbers.svelte.d.ts
@@ -67,6 +67,18 @@ export type LineNumbersProps = HTMLAttributes<HTMLDivElement> &
     highlightedLines?: number[];
 
     /**
+     * Per-line decoration state, indexed relative to `lines`/`highlighted`
+     * (not the absolute document line when rendering a window). Merged with
+     * `highlightedLines`, which is equivalent to setting `"highlighted"`
+     * here. `"focus"` is exempt from dimming but renders no background --
+     * the primitive for a meta-string highlight or a diff's context-line
+     * emphasis without red/green paint.
+     * @default {}
+     * @example { 1: "added", 2: "removed", 4: "focus" }
+     */
+    lineStates?: Record<number, "highlighted" | "focus" | "added" | "removed">;
+
+    /**
      * Line number text color.
      * Defaults to the current theme color applied to `.hljs code`.
      * @default currentColor
@@ -104,8 +116,22 @@ export type LineNumbersProps = HTMLAttributes<HTMLDivElement> &
     "--highlighted-background"?: string;
 
     /**
+     * Background of lines with a `lineStates` `"added"` state.
+     * @default "rgba(46, 204, 113, 0.15)"
+     * @example "#fff"
+     */
+    "--line-added-background"?: string;
+
+    /**
+     * Background of lines with a `lineStates` `"removed"` state.
+     * @default "rgba(231, 76, 60, 0.15)"
+     * @example "#fff"
+     */
+    "--line-removed-background"?: string;
+
+    /**
      * Un-highlighted line opacity.
-     * Only applies when `highlightedLines` is non-empty.
+     * Only applies when `highlightedLines` or `lineStates` is non-empty.
      * @default 1
      * @example 0.4
      */
@@ -113,7 +139,7 @@ export type LineNumbersProps = HTMLAttributes<HTMLDivElement> &
 
     /**
      * Un-highlighted line filter.
-     * Only applies when `highlightedLines` is non-empty.
+     * Only applies when `highlightedLines` or `lineStates` is non-empty.
      * @default none
      * @example "blur(2px)"
      */

--- a/src/LineNumbers.svelte.d.ts
+++ b/src/LineNumbers.svelte.d.ts
@@ -87,6 +87,15 @@ export type LineNumbersProps = HTMLAttributes<HTMLDivElement> &
     "--line-number-color"?: string;
 
     /**
+     * Width of a single gutter digit. The gutter's total width is
+     * `calc(<digit count> * --line-number-digit-width)`, so it scales
+     * automatically with the code font-size instead of a fixed pixel guess.
+     * @default "0.6em"
+     * @example "0.65em"
+     */
+    "--line-number-digit-width"?: string;
+
+    /**
      * Border color.
      * Defaults to the current background color applied to `.hljs`.
      * @default currentColor

--- a/src/LineNumbers.svelte.d.ts
+++ b/src/LineNumbers.svelte.d.ts
@@ -6,13 +6,34 @@ import type { LanguageName } from "./languages";
 export type LineNumbersProps = HTMLAttributes<HTMLDivElement> &
   LangtagProps & {
     /**
-     * Pass the highlighted `code` to `LineNumbers`.
+     * Pass the highlighted `code` to `LineNumbers`. Required unless `lines`
+     * is passed instead.
      * @example
      * <Highlight language={typescript} {code} langtag let:highlighted let:langtag let:languageName>
      *  <LineNumbers {highlighted} {langtag} {languageName} />
      * </Highlight>
      */
-    highlighted: string;
+    highlighted?: string;
+
+    /**
+     * Pre-split per-line HTML, the same shape `splitLines`/`extendLines`/
+     * `TokenizedDocument#lineRange` produce. Overrides `highlighted` --
+     * pass a window of a larger document to render it without re-splitting
+     * the full string on every update. `highlightedLines`/`lineStates`
+     * index relative to this array, not the absolute document line.
+     * @default undefined
+     */
+    lines?: string[];
+
+    /**
+     * Total document line count, for gutter-width purposes, when `lines` is
+     * a partial window rather than the whole document. Combine with
+     * `startingLineNumber` to offset row numbers for the window.
+     * @default undefined
+     * @example
+     * <LineNumbers lines={doc.lineRange(start, end)} startingLineNumber={start + 1} lineCount={doc.lineCount()} />
+     */
+    lineCount?: number;
 
     /**
      * Language name.

--- a/tests/e2e/LineNumbers.gutterOverflow.test.svelte
+++ b/tests/e2e/LineNumbers.gutterOverflow.test.svelte
@@ -10,6 +10,14 @@ const c = 3;`;
 
 <svelte:head> {@html horizonDark} </svelte:head>
 
-<Highlight language={typescript} {code} let:highlighted>
-  <LineNumbers {highlighted} startingLineNumber={999} />
-</Highlight>
+<div data-testid="small">
+  <Highlight language={typescript} {code} let:highlighted>
+    <LineNumbers {highlighted} startingLineNumber={999} />
+  </Highlight>
+</div>
+
+<div data-testid="large">
+  <Highlight language={typescript} {code} let:highlighted>
+    <LineNumbers {highlighted} startingLineNumber={99_999} />
+  </Highlight>
+</div>

--- a/tests/e2e/LineNumbers.lineStates.test.svelte
+++ b/tests/e2e/LineNumbers.lineStates.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Highlight, { LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+
+  const code = `const a = 1;
+const b = 2;
+const c = 3;
+const d = 4;
+const e = 5;`;
+</script>
+
+<svelte:head> {@html horizonDark} </svelte:head>
+
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers
+    {highlighted}
+    lineStates={{ 1: "added", 2: "removed", 4: "focus" }}
+    --unhighlighted-opacity="0.4"
+  />
+</Highlight>

--- a/tests/e2e/LineNumbers.linesInput.test.svelte
+++ b/tests/e2e/LineNumbers.linesInput.test.svelte
@@ -1,0 +1,30 @@
+<script lang="ts">
+  import Highlight, { LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+  import { splitLines } from "../../src/split-lines.js";
+
+  // 100 lines so the full document needs 3 digits for its gutter, while the
+  // 2-line window alone (without lineCount) would only need 2 -- exercising
+  // lineCount actually overriding the window's own length for sizing.
+  const code = Array.from(
+    { length: 100 },
+    (_, i) => `const line${i} = ${i};`,
+  ).join("\n");
+</script>
+
+<svelte:head> {@html horizonDark} </svelte:head>
+
+<Highlight language={typescript} {code} let:highlighted>
+  {@const allLines = splitLines(highlighted)}
+  <div data-testid="windowed">
+    <LineNumbers
+      lines={allLines.slice(2, 4)}
+      startingLineNumber={3}
+      lineCount={allLines.length}
+    />
+  </div>
+  <div data-testid="full">
+    <LineNumbers {highlighted} startingLineNumber={3} />
+  </div>
+</Highlight>

--- a/tests/e2e/LineNumbers.rtl.test.svelte
+++ b/tests/e2e/LineNumbers.rtl.test.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+  import Highlight, { LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+
+  const code = `const a = 1;
+const b = 2;
+const c = 3;`;
+</script>
+
+<svelte:head> {@html horizonDark} </svelte:head>
+
+<div dir="rtl">
+  <Highlight language={typescript} {code} let:highlighted>
+    <LineNumbers {highlighted} />
+  </Highlight>
+</div>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -627,13 +627,24 @@ test("LineNumbers - sizes the gutter by the final rendered line number", async (
 }) => {
   await mount(LineNumbersGutterOverflow);
 
-  const gutterCells = page.locator("td.hljs");
-  await expect(gutterCells.last()).toHaveText("1001");
+  const smallGutterCells = page.getByTestId("small").locator("td.hljs");
+  await expect(smallGutterCells.last()).toHaveText("1001");
 
-  const overflows = await gutterCells
+  const smallOverflows = await smallGutterCells
     .last()
     .evaluate((el) => el.scrollWidth > el.clientWidth);
-  expect(overflows).toBe(false);
+  expect(smallOverflows).toBe(false);
+
+  // A much larger line count (6 digits) still gets a gutter wide enough to
+  // avoid overflow -- the calc()-based width scales linearly with digit
+  // count, not just the two digits DIGIT_WIDTH used to be tuned for.
+  const largeGutterCells = page.getByTestId("large").locator("td.hljs");
+  await expect(largeGutterCells.last()).toHaveText("100001");
+
+  const largeOverflows = await largeGutterCells
+    .last()
+    .evaluate((el) => el.scrollWidth > el.clientWidth);
+  expect(largeOverflows).toBe(false);
 });
 
 test("LineNumbers - langtag", async ({ mount, page }) => {

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -50,6 +50,7 @@ import LineNumbersFocusLines from "./LineNumbers.focusLines.test.svelte";
 import LineNumbersGutterOverflow from "./LineNumbers.gutterOverflow.test.svelte";
 import LineNumbersHideBorder from "./LineNumbers.hideBorder.test.svelte";
 import LineNumbersLangtag from "./LineNumbers.langtag.test.svelte";
+import LineNumbersLineStates from "./LineNumbers.lineStates.test.svelte";
 import LineNumbersLinesInput from "./LineNumbers.linesInput.test.svelte";
 import LineNumbersMultilineSpan from "./LineNumbers.multilineSpan.test.svelte";
 import LineNumbers from "./LineNumbers.test.svelte";
@@ -684,6 +685,38 @@ test("LineNumbers - focus lines dim/blur un-highlighted lines", async ({
   const dimmedCode = rows.nth(0).locator("pre");
   await expect(dimmedCode).toHaveCSS("opacity", "0.4");
   await expect(dimmedCode).toHaveCSS("filter", "blur(2px)");
+});
+
+test("LineNumbers - lineStates colors added/removed lines and exempts focus lines from dimming", async ({
+  mount,
+  page,
+}) => {
+  await mount(LineNumbersLineStates);
+
+  const rows = page.locator("tr");
+
+  // Index 1: "added" -- colored, not dimmed.
+  await expect(rows.nth(1)).not.toHaveClass(/dimmed/);
+  await expect(rows.nth(1).locator("td:last-child .line-background")).toHaveCSS(
+    "background-color",
+    "rgba(46, 204, 113, 0.15)",
+  );
+
+  // Index 2: "removed" -- colored, not dimmed.
+  await expect(rows.nth(2)).not.toHaveClass(/dimmed/);
+  await expect(rows.nth(2).locator("td:last-child .line-background")).toHaveCSS(
+    "background-color",
+    "rgba(231, 76, 60, 0.15)",
+  );
+
+  // Index 4: "focus" -- exempt from dimming, but no background overlay.
+  await expect(rows.nth(4)).not.toHaveClass(/dimmed/);
+  await expect(rows.nth(4).locator(".line-background")).toHaveCount(0);
+
+  // Index 0 and 3: untouched -- dimmed like plain highlightedLines behavior.
+  await expect(rows.nth(0)).toHaveClass(/dimmed/);
+  await expect(rows.nth(3)).toHaveClass(/dimmed/);
+  await expect(rows.nth(0).locator("pre")).toHaveCSS("opacity", "0.4");
 });
 
 test("Language tag styling", async ({ mount, page }) => {

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -554,6 +554,7 @@ test("LineNumbers - basic functionality", async ({ mount, page }) => {
   const lineNumbersColumn = page.locator("td.hljs").first();
   await expect(lineNumbersColumn).toHaveCSS("position", "sticky");
   await expect(lineNumbersColumn).not.toHaveClass(/hideBorder/);
+  await expect(lineNumbersColumn).toHaveAttribute("aria-hidden", "true");
 });
 
 test("LineNumbers - hide border", async ({ mount, page }) => {

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -53,6 +53,7 @@ import LineNumbersLangtag from "./LineNumbers.langtag.test.svelte";
 import LineNumbersLineStates from "./LineNumbers.lineStates.test.svelte";
 import LineNumbersLinesInput from "./LineNumbers.linesInput.test.svelte";
 import LineNumbersMultilineSpan from "./LineNumbers.multilineSpan.test.svelte";
+import LineNumbersRtl from "./LineNumbers.rtl.test.svelte";
 import LineNumbers from "./LineNumbers.test.svelte";
 import LineNumbersWrapLines from "./LineNumbers.wrapLines.test.svelte";
 import ScopedStyle from "./ScopedStyle.test.svelte";
@@ -645,6 +646,31 @@ test("LineNumbers - langtag", async ({ mount, page }) => {
   );
   await expect(page.locator("div.langtag")).toHaveCSS("position", "relative");
   await expect(page.locator(".hljs-keyword")).toHaveText("const");
+});
+
+test("LineNumbers - gutter follows dir=rtl via logical properties", async ({
+  mount,
+  page,
+}) => {
+  await mount(LineNumbersRtl);
+
+  const gutter = page.locator("td.hljs").first();
+  // "text-align: end" is preserved as a logical keyword in computed style;
+  // it resolves to right-aligned text under dir="rtl".
+  await expect(gutter).toHaveCSS("text-align", "end");
+
+  const table = page.locator("table");
+  const gutterBox = await gutter.boundingBox();
+  const tableBox = await table.boundingBox();
+  expect(gutterBox).not.toBeNull();
+  expect(tableBox).not.toBeNull();
+  expect(
+    Math.abs(
+      (gutterBox?.x ?? 0) +
+        (gutterBox?.width ?? 0) -
+        ((tableBox?.x ?? 0) + (tableBox?.width ?? 0)),
+    ),
+  ).toBeLessThan(1);
 });
 
 test("LineNumbers - CSS variables override container styles without !important", async ({

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -50,6 +50,7 @@ import LineNumbersFocusLines from "./LineNumbers.focusLines.test.svelte";
 import LineNumbersGutterOverflow from "./LineNumbers.gutterOverflow.test.svelte";
 import LineNumbersHideBorder from "./LineNumbers.hideBorder.test.svelte";
 import LineNumbersLangtag from "./LineNumbers.langtag.test.svelte";
+import LineNumbersLinesInput from "./LineNumbers.linesInput.test.svelte";
 import LineNumbersMultilineSpan from "./LineNumbers.multilineSpan.test.svelte";
 import LineNumbers from "./LineNumbers.test.svelte";
 import LineNumbersWrapLines from "./LineNumbers.wrapLines.test.svelte";
@@ -575,6 +576,31 @@ test("LineNumbers - custom starting number", async ({ mount, page }) => {
   await mount(LineNumbersCustomStartingLine);
 
   await expect(page.getByText("100")).toBeVisible();
+});
+
+test("LineNumbers - renders a windowed lines array sized for the full document", async ({
+  mount,
+  page,
+}) => {
+  await mount(LineNumbersLinesInput);
+
+  const windowed = page.getByTestId("windowed");
+  const full = page.getByTestId("full");
+
+  // The window covers lines 3-4 of the 100-line document, rendered as row
+  // numbers 3 and 4 (not 1 and 2), with the gutter sized for all 100.
+  const windowedNumbers = await windowed.locator("td.hljs").allTextContents();
+  expect(windowedNumbers.map((text) => text.trim())).toEqual(["3", "4"]);
+
+  const windowedWidth = await windowed
+    .locator("td.hljs")
+    .first()
+    .evaluate((el) => getComputedStyle(el).width);
+  const fullWidth = await full
+    .locator("td.hljs")
+    .first()
+    .evaluate((el) => getComputedStyle(el).width);
+  expect(windowedWidth).toBe(fullWidth);
 });
 
 test("LineNumbers - preserves a span across a multi-line block comment", async ({

--- a/www/components/LineNumbers/LineStates.svelte
+++ b/www/components/LineNumbers/LineStates.svelte
@@ -1,0 +1,10 @@
+<script>
+  import Basic from "./Basic.svelte";
+
+  const snippet = `<LineNumbers
+    {highlighted}
+    lineStates={{ 1: "added", 2: "removed" }}
+  />`;
+</script>
+
+<Basic {snippet} lineStates={{ 1: "added", 2: "removed" }} />

--- a/www/components/LineNumbers/Rtl.svelte
+++ b/www/components/LineNumbers/Rtl.svelte
@@ -1,0 +1,7 @@
+<script>
+  import Basic from "./Basic.svelte";
+
+  const snippet = "<LineNumbers {highlighted} />";
+</script>
+
+<Basic {snippet} dir="rtl" />

--- a/www/components/LineNumbers/Streaming.svelte
+++ b/www/components/LineNumbers/Streaming.svelte
@@ -1,0 +1,71 @@
+<script>
+  import { generateTypeScript } from "@components/HighlightVirtual/generate-large-code.js";
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { onMount } from "svelte";
+  import { LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import { createTokenizedDocument } from "svelte-highlight/tokenized-document";
+
+  const LINE_COUNT = 5_000;
+  const OVERSCAN = 10;
+  const CONTAINER_HEIGHT = 320;
+
+  const doc = createTokenizedDocument({ language: typescript });
+  doc.setCode(generateTypeScript(LINE_COUNT));
+  const lineCount = doc.lineCount();
+
+  /** @type {HTMLElement} */
+  let container;
+  // Re-measured from a rendered row after mount; only an initial guess.
+  let rowHeight = 24;
+  let start = 0;
+  let end = Math.min(
+    lineCount,
+    Math.ceil(CONTAINER_HEIGHT / rowHeight) + OVERSCAN,
+  );
+
+  function updateWindow() {
+    if (!container) return;
+    const row = container.querySelector("tbody tr");
+    if (row) rowHeight = row.getBoundingClientRect().height || rowHeight;
+    const first = Math.max(
+      0,
+      Math.floor(container.scrollTop / rowHeight) - OVERSCAN,
+    );
+    const visible =
+      Math.ceil(container.clientHeight / rowHeight) + OVERSCAN * 2;
+    start = Math.min(first, lineCount);
+    end = Math.min(lineCount, start + visible);
+  }
+
+  onMount(updateWindow);
+
+  $: lines = doc.lineRange(start, end);
+</script>
+
+<p class="label-01 mb-3">
+  {lineCount.toLocaleString()}
+  lines total. <code class="code">lines</code>
+  only ever holds the scrolled-into-view window;
+  <code class="code">lineCount</code> keeps the gutter sized for the full
+  document.
+</p>
+
+<div
+  bind:this={container}
+  on:scroll={updateWindow}
+  style="height: {CONTAINER_HEIGHT}px; overflow-y: auto; position: relative;"
+>
+  <div style="height: {lineCount * rowHeight}px; position: relative;">
+    <div
+      style="position: absolute; top: {start * rowHeight}px; left: 0; right: 0;"
+    >
+      <LineNumbers
+        {lines}
+        startingLineNumber={start + 1}
+        {lineCount}
+        class={THEME_MODULE_NAME}
+      />
+    </div>
+  </div>
+</div>

--- a/www/components/LineNumbers/Streaming.svelte
+++ b/www/components/LineNumbers/Streaming.svelte
@@ -47,8 +47,8 @@
   {lineCount.toLocaleString()}
   lines total. <code class="code">lines</code>
   only ever holds the scrolled-into-view window;
-  <code class="code">lineCount</code> keeps the gutter sized for the full
-  document.
+  <code class="code">lineCount</code>
+  keeps the gutter sized for the full document.
 </p>
 
 <div

--- a/www/components/LineNumbers/StyleProps.svelte
+++ b/www/components/LineNumbers/StyleProps.svelte
@@ -7,6 +7,7 @@
     --border-color="rgba(255, 255, 255, 0.1)"
     --padding-left="2em"
     --padding-right="1em"
+    --line-number-digit-width="0.75em"
   />`;
 </script>
 
@@ -16,4 +17,5 @@
   --border-color="rgba(255, 255, 255, 0.1)"
   --padding-left="2em"
   --padding-right="1em"
+  --line-number-digit-width="0.75em"
 />

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -30,6 +30,7 @@
   import HighlightedLinesCustomColor from "@components/LineNumbers/HighlightedLinesCustomColor.svelte";
   import Langtag from "@components/LineNumbers/Langtag.svelte";
   import StartingLineNumber from "@components/LineNumbers/StartingLineNumber.svelte";
+  import Streaming from "@components/LineNumbers/Streaming.svelte";
   import StyleProps from "@components/LineNumbers/StyleProps.svelte";
   import WrapLines from "@components/LineNumbers/WrapLines.svelte";
   import ScopedStyle from "@components/ScopedStyle.svelte";
@@ -406,6 +407,16 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <StartingLineNumber /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Pass a pre-split <code class="code">lines</code> array to render a window
+      of a larger document instead of the full
+      <code class="code">highlighted</code> string. Set
+      <code class="code">lineCount</code> so the gutter is sized for the whole
+      document, not just the window.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <Streaming /> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Use <code class="code">highlightedLines</code> to highlight specific

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -30,6 +30,7 @@
   import HighlightedLinesCustomColor from "@components/LineNumbers/HighlightedLinesCustomColor.svelte";
   import Langtag from "@components/LineNumbers/Langtag.svelte";
   import LineStates from "@components/LineNumbers/LineStates.svelte";
+  import Rtl from "@components/LineNumbers/Rtl.svelte";
   import StartingLineNumber from "@components/LineNumbers/StartingLineNumber.svelte";
   import Streaming from "@components/LineNumbers/Streaming.svelte";
   import StyleProps from "@components/LineNumbers/StyleProps.svelte";
@@ -446,8 +447,9 @@ export { add, mul };\`,
     <p class="mb-5">
       Use <code class="code">lineStates</code> for a per-line state map --
       <code class="code">"added"</code>, <code class="code">"removed"</code>, or
-      <code class="code">"focus"</code> -- so diff-style decorations can build
-      on the same primitive as <code class="code">highlightedLines</code>.
+      <code class="code">"focus"</code>
+      -- so diff-style decorations can build on the same primitive as
+      <code class="code">highlightedLines</code>.
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <LineStates /> </Column>
@@ -462,6 +464,13 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <Langtag /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      The gutter follows <code class="code">dir="rtl"</code> via logical CSS
+      properties.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <Rtl /> </Column>
 </Row>
 
 <Row class="mb-9">

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -29,6 +29,7 @@
   import HighlightedLines from "@components/LineNumbers/HighlightedLines.svelte";
   import HighlightedLinesCustomColor from "@components/LineNumbers/HighlightedLinesCustomColor.svelte";
   import Langtag from "@components/LineNumbers/Langtag.svelte";
+  import LineStates from "@components/LineNumbers/LineStates.svelte";
   import StartingLineNumber from "@components/LineNumbers/StartingLineNumber.svelte";
   import Streaming from "@components/LineNumbers/Streaming.svelte";
   import StyleProps from "@components/LineNumbers/StyleProps.svelte";
@@ -411,9 +412,10 @@ export { add, mul };\`,
     <p class="mb-5">
       Pass a pre-split <code class="code">lines</code> array to render a window
       of a larger document instead of the full
-      <code class="code">highlighted</code> string. Set
-      <code class="code">lineCount</code> so the gutter is sized for the whole
-      document, not just the window.
+      <code class="code">highlighted</code>
+      string. Set
+      <code class="code">lineCount</code>
+      so the gutter is sized for the whole document, not just the window.
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <Streaming /> </Column>
@@ -440,6 +442,15 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <HighlightedLinesCustomColor /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Use <code class="code">lineStates</code> for a per-line state map --
+      <code class="code">"added"</code>, <code class="code">"removed"</code>, or
+      <code class="code">"focus"</code> -- so diff-style decorations can build
+      on the same primitive as <code class="code">highlightedLines</code>.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <LineStates /> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       When using a custom slot, forward <code class="code">langtag</code> and


### PR DESCRIPTION
Bundles a set of LineNumbers improvements: a windowed lines/lineCount
input for pairing with HighlightStream and HighlightVirtual on large
documents, a lineStates prop that generalizes highlightedLines into
added/removed/focus decorations for diff-style views, RTL support via
logical CSS properties, and an em-based gutter width that scales with
font-size instead of a fixed pixel guess.

Render a window instead of re-splitting the whole document:

```svelte
<LineNumbers
  lines={doc.lineRange(start, end)}
  startingLineNumber={start + 1}
  lineCount={doc.lineCount()}
/>
```

Decorate lines like a diff:

```svelte
<LineNumbers
  {highlighted}
  lineStates={{ 1: "added", 2: "removed", 4: "focus" }}
/>
```

Both compose with the existing `highlighted` string, `hideBorder`,
`wrapLines`, and `highlightedLines` (which now merges into
`lineStates` as an implicit `"highlighted"` entry) without any
breaking changes.