### PR TITLE
refactor(engine): export scopeToCssClass

### DIFF
--- a/README.md
+++ b/README.md
@@ -1224,7 +1224,7 @@ The static transform runs only when all of these are true:
 - `language` is a plain identifier from a static `import` of `svelte-highlight/languages/*`.
 - `code` is a string literal or a template literal with no `${...}` interpolation.
 - The element has no slot content, spread props, or directives (`bind:`, `on:`, etc.).
-- `langtag` is not set. Static output can't pull in `langtag.css`; that only happens when a runtime `LangTag` is in the bundle.
+- `langtag`, if set, is a bare flag or a static boolean literal (`langtag={true}`/`langtag={false}`) - not a variable or expression. Static output can't pull in `langtag.css` (that only happens when a runtime `LangTag` is in the bundle), so a truthy `langtag` renders the language badge as a plain inline-styled `<span>` instead, themed with the same `--langtag-*` custom properties `LangTag` reads - customization is limited to those variables, not `LangTag`'s slot content.
 
 Dynamic `code` or `language`, `loadLanguage`, `HighlightAuto`, `HighlightSvelte`, and `HighlightEditable` keep the runtime component. No warning. That's intentional.
 

--- a/README.md
+++ b/README.md
@@ -1238,6 +1238,20 @@ highlightStatic({
 });
 ```
 
+To measure how many `<Highlight>` usages a build actually converted to static markup, pass `onSummary`. It fires once per file with at least one shape-matched usage (files with none don't trigger it), so summing across calls gives a build-wide total:
+
+```js
+let matched = 0;
+let succeeded = 0;
+
+highlightStatic({
+  onSummary(summary) {
+    matched += summary.matched;
+    succeeded += summary.succeeded;
+  },
+});
+```
+
 Scope is small on purpose. Extra props on `<Highlight>` don't carry over to the emitted `<pre>`. Unused `Highlight` and language imports are left in place; bundlers drop them (`sideEffects` in `package.json` is narrow enough).
 
 ### Rendering Markdown/MDX fences

--- a/README.md
+++ b/README.md
@@ -1184,17 +1184,7 @@ Grammars with embedded sublanguages (`astro`, `svelte`, and others with a `depen
 
 > **Note:** Because the imported name is dynamic, the bundler cannot prune unused grammars and will emit a chunk for every language — all 279 shipped grammars. Prefer a static `import` when the language is known ahead of time, and reach for `loadLanguage` only when it is not.
 
-A practical case is rendering Markdown, where each fenced block declares its own language:
-
-```js
-import { loadLanguage } from "svelte-highlight";
-
-// e.g. from a Markdown fence: ```ts → "typescript"
-async function highlightFence(fenceLang, code) {
-  const grammar = await loadLanguage(fenceLang);
-  return { code, language: grammar };
-}
-```
+A practical case is rendering Markdown, where each fenced block declares its own language — see "[Rendering Markdown/MDX fences](#rendering-markdownmdx-fences)" below for a ready-made `highlightFence` helper built on top of `loadLanguage`.
 
 ## Static mode
 
@@ -1248,7 +1238,88 @@ highlightStatic({
 });
 ```
 
-Scope is small on purpose. Extra props on `<Highlight>` don't carry over to the emitted `<pre>`. Unused `Highlight` and language imports are left in place; bundlers drop them (`sideEffects` in `package.json` is narrow enough). No Astro/MDX fence hook yet.
+Scope is small on purpose. Extra props on `<Highlight>` don't carry over to the emitted `<pre>`. Unused `Highlight` and language imports are left in place; bundlers drop them (`sideEffects` in `package.json` is narrow enough).
+
+### Rendering Markdown/MDX fences
+
+`highlightStatic` only transforms literal `<Highlight>` usages in `.svelte` files. Markdown/MDX/mdsvex code fences never go through the Svelte compiler at all, so `svelte-highlight/fence` provides a separate, framework-agnostic building block: `parseMeta(meta)` and `highlightFence({ code, lang, meta })`, a plain async function with zero Svelte dependency.
+
+```js
+import { highlightFence } from "svelte-highlight/fence";
+
+const html = await highlightFence({
+  code: 'const add = (a, b) => a + b;\nconst sub = (a, b) => a - b;\nexport { add, sub };',
+  lang: "typescript",
+  meta: '{1,3-5} title="app.ts"',
+});
+```
+
+`lang` must be the grammar's canonical file name (see "[Loading a language by name](#loading-a-language-by-name)"); it rejects with `LanguageLoadError` for an unrecognized one. `meta` is the Expressive Code/Shiki-style vocabulary standardized on by tools like Astro, Starlight, and rehype-pretty-code: a bare `{1,3-5}` or `mark={1,3-5}` marks lines, `ins={...}`/`del={...}` mark insertions/deletions, `title="..."` sets a title, and `showLineNumbers` is a bare flag. The output wraps each line in `<span class="line" data-line-state="mark|ins|del">` (only when a state applies) inside a `<pre class="hljs" data-language="...">`, so a `mark`/`ins`/`del`-aware stylesheet can target `[data-line-state]` the same way it would target Expressive Code or Shiki output.
+
+**mdsvex.** Wire `highlightFence` into `highlight.highlighter`, whose signature is `(code, lang, meta) => string | Promise<string>`:
+
+```js
+// mdsvex.config.js
+import { highlightFence } from "svelte-highlight/fence";
+
+/** @type {import("mdsvex").MdsvexOptions} */
+const config = {
+  highlight: {
+    highlighter: (code, lang, meta) => highlightFence({ code, lang, meta }),
+  },
+};
+
+export default config;
+```
+
+**markdown-it.** Wire it into the `highlight` constructor option, whose signature is `(str, lang, attrs) => string` — markdown-it inserts the returned string verbatim (no further escaping), and `highlight` isn't allowed to be `async`, so pre-render fences you know about or fall back to a sync path for the rest:
+
+```js
+import MarkdownIt from "markdown-it";
+import { highlightFence } from "svelte-highlight/fence";
+
+const md = new MarkdownIt({
+  highlight(str, lang, attrs) {
+    // highlightFence is async; markdown-it's highlight isn't, so either
+    // pre-highlight fences in a separate async pass before render() and
+    // look the result up here, or fall back to escaped plain text.
+    return md.utils.escapeHtml(str);
+  },
+});
+```
+
+**rehype.** `rehype`/`unist-util-visit` are the consumer's dependencies, not this package's. A rehype plugin walks the hast tree *after* `remark-rehype` has already converted fenced code to `<pre><code class="language-*">` — the fence's `meta` string isn't part of that hast by default, only `lang` (via the `language-*` class), so pass `meta` through only if an earlier remark step attached it (e.g. `node.data.hProperties["data-meta"] = mdastNode.meta`):
+
+```js
+import { visit } from "unist-util-visit";
+import { highlightFence } from "svelte-highlight/fence";
+
+function rehypeHighlightFence() {
+  return async (tree) => {
+    const nodes = [];
+    visit(tree, "element", (node, index, parent) => {
+      if (node.tagName !== "pre" || parent === undefined || index === undefined) return;
+      const code = node.children.find((child) => child.tagName === "code");
+      if (code) nodes.push({ node, index, parent, code });
+    });
+
+    for (const { node, index, parent, code } of nodes) {
+      const lang = code.properties?.className
+        ?.map(String)
+        .find((c) => c.startsWith("language-"))
+        ?.slice("language-".length);
+      if (!lang) continue;
+
+      const html = await highlightFence({
+        code: code.children.map((c) => (c.type === "text" ? c.value : "")).join(""),
+        lang,
+        meta: code.properties?.["data-meta"],
+      });
+      parent.children[index] = { type: "raw", value: html };
+    }
+  };
+}
+```
 
 ## Action
 

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -30,6 +30,14 @@ pkgJson.exports = {
     types: "./static.d.ts",
     import: "./static.js",
   },
+  "./fence": {
+    types: "./fence.d.ts",
+    import: "./fence.js",
+  },
+  "./fence.js": {
+    types: "./fence.d.ts",
+    import: "./fence.js",
+  },
   "./*.svelte": {
     types: "./*.svelte.d.ts",
     import: "./*.svelte",

--- a/src/engine.d.ts
+++ b/src/engine.d.ts
@@ -3,7 +3,7 @@
  *
  * - **Stable (semver-governed):** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`,
  *   `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`,
- *   `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`,
+ *   `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `scopeToCssClass`,
  *   `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`,
  *   `Registry` and all its methods, `createRegistry`, `registerAll`,
  *   `StreamSession`, `Snapshot` (see its own doc comment for a narrower
@@ -75,6 +75,13 @@ export const OPEN: 1;
 export const CLOSE: 2;
 
 export function escapeHtml(value: string): string;
+
+/**
+ * `renderHtml`'s internal scope-name-to-class-name conversion: splits
+ * compound scopes (e.g. `"title.class_"` -> `"hljs-title class_"`) and maps
+ * the `language-*` embedded-language convention.
+ */
+export function scopeToCssClass(name: string, prefix: string): string;
 
 export interface TokenRange {
   start: number;

--- a/src/engine.js
+++ b/src/engine.js
@@ -869,7 +869,7 @@ class Tokenizer {
  * @param {string} name
  * @param {string} prefix
  */
-function scopeToCssClass(name, prefix) {
+export function scopeToCssClass(name, prefix) {
   if (name.startsWith(LANGUAGE_SCOPE_PREFIX)) {
     return name.replace(LANGUAGE_SCOPE_PREFIX, "language-");
   }

--- a/src/fence.d.ts
+++ b/src/fence.d.ts
@@ -17,3 +17,24 @@ export interface ParsedMeta {
  * directive appears later in the string. Unknown tokens are ignored.
  */
 export declare function parseMeta(meta: string): ParsedMeta;
+
+/**
+ * Highlights a single Markdown/MDX code fence into hljs-compatible HTML,
+ * for use from framework adapters (mdsvex, markdown-it, rehype, ...) that
+ * process fences outside the Svelte compiler.
+ *
+ * Renders each source line as `<span class="line">`, decorated with
+ * `data-line-state="mark" | "ins" | "del"` per `meta`'s directives (see
+ * `parseMeta`), wrapped in a `<pre class="hljs" data-language="...">` that
+ * carries `data-title`/`data-show-line-numbers` when `meta` sets them.
+ *
+ * `lang` must be the grammar's canonical file name (e.g. `"typescript"`,
+ * not `"ts"`) - alias resolution is the caller's job. Rejects with
+ * `LanguageLoadError` (`Unknown language: "<lang>"`) when `lang` doesn't
+ * resolve to a shipped grammar.
+ */
+export declare function highlightFence(options: {
+  code: string;
+  lang: string;
+  meta?: string;
+}): Promise<string>;

--- a/src/fence.d.ts
+++ b/src/fence.d.ts
@@ -1,0 +1,19 @@
+export interface ParsedMeta {
+  /** 1-indexed line number -> the last-applied state for that line. */
+  lines: Record<number, "mark" | "ins" | "del">;
+  title?: string;
+  showLineNumbers?: boolean;
+}
+
+/**
+ * Parses the Expressive Code / Shiki-style meta-string vocabulary from a
+ * Markdown/MDX code fence's info-string suffix, e.g. for
+ * ` ```ts title="app.ts" {1,3-5} ins={7} showLineNumbers `, `meta` is
+ * `title="app.ts" {1,3-5} ins={7} showLineNumbers`.
+ *
+ * Recognizes a bare `{<ranges>}` (state `"mark"`), `mark=`/`ins=`/`del=`
+ * (each combinable), `title="<text>"`, and the bare `showLineNumbers` flag.
+ * A line number named by more than one directive resolves to whichever
+ * directive appears later in the string. Unknown tokens are ignored.
+ */
+export declare function parseMeta(meta: string): ParsedMeta;

--- a/src/fence.js
+++ b/src/fence.js
@@ -1,3 +1,7 @@
+import { escapeHtml, scopeToCssClass, tokenLines } from "./engine.js";
+import { loadLanguage } from "./load-language.js";
+import { ensureRegistered, registry } from "./registry.js";
+
 /**
  * @typedef {import("./fence.d.ts").ParsedMeta} ParsedMeta
  */
@@ -37,7 +41,7 @@ export function parseMeta(meta) {
     const [, titleKey, titleValue, stateKey, stateRanges, bareRanges, bareWord] = match;
 
     if (titleKey !== undefined) {
-      if (titleKey === "title") result.title = titleValue;
+      if (titleKey === "title") result.title = titleValue ?? "";
       continue;
     }
 
@@ -56,4 +60,55 @@ export function parseMeta(meta) {
   }
 
   return result;
+}
+
+/** @param {string} value */
+function escapeAttribute(value) {
+  return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+/**
+ * @param {import("./engine.d.ts").LineToken} token
+ */
+function renderToken(token) {
+  let html = escapeHtml(token.text);
+  for (let i = token.scopes.length - 1; i >= 0; i -= 1) {
+    const scope = /** @type {string} */ (token.scopes[i]);
+    html = `<span class="${scopeToCssClass(scope, "hljs-")}">${html}</span>`;
+  }
+  return html;
+}
+
+/**
+ * @param {{ code: string; lang: string; meta?: string }} options
+ * @returns {Promise<string>}
+ */
+export async function highlightFence({ code, lang, meta }) {
+  const language = await loadLanguage(
+    /** @type {import("./languages").LanguageName} */ (lang),
+  );
+  ensureRegistered(language);
+  const { events } = registry.highlight(code, { language: lang });
+  const parsedMeta = meta !== undefined ? parseMeta(meta) : undefined;
+
+  const lines = tokenLines(events)
+    .map((tokens, index) => {
+      const state = parsedMeta?.lines[index + 1];
+      const stateAttr = state ? ` data-line-state="${state}"` : "";
+      return `<span class="line"${stateAttr}>${tokens.map(renderToken).join("")}</span>`;
+    })
+    .join("\n");
+
+  const titleAttr =
+    parsedMeta?.title !== undefined
+      ? ` data-title="${escapeAttribute(parsedMeta.title)}"`
+      : "";
+  const showLineNumbersAttr = parsedMeta?.showLineNumbers
+    ? ' data-show-line-numbers="true"'
+    : "";
+
+  return (
+    `<pre class="hljs" data-language="${escapeAttribute(lang)}"${titleAttr}${showLineNumbersAttr}>` +
+    `<code class="hljs">${lines}</code></pre>`
+  );
 }

--- a/src/fence.js
+++ b/src/fence.js
@@ -22,7 +22,7 @@ function parseRanges(ranges) {
     if (!trimmed) continue;
     const [startStr, endStr] = trimmed.split("-");
     const start = Number(startStr);
-    const end = endStr !== undefined ? Number(endStr) : start;
+    const end = endStr === undefined ? start : Number(endStr);
     if (!Number.isInteger(start) || !Number.isInteger(end)) continue;
     for (let line = start; line <= end; line += 1) lines.push(line);
   }
@@ -38,7 +38,15 @@ export function parseMeta(meta) {
   const result = { lines: {} };
 
   for (const match of meta.matchAll(TOKEN_RE)) {
-    const [, titleKey, titleValue, stateKey, stateRanges, bareRanges, bareWord] = match;
+    const [
+      ,
+      titleKey,
+      titleValue,
+      stateKey,
+      stateRanges,
+      bareRanges,
+      bareWord,
+    ] = match;
 
     if (titleKey !== undefined) {
       if (titleKey === "title") result.title = titleValue ?? "";
@@ -46,8 +54,10 @@ export function parseMeta(meta) {
     }
 
     if (stateKey !== undefined) {
-      if (stateKey !== "mark" && stateKey !== "ins" && stateKey !== "del") continue;
-      for (const line of parseRanges(stateRanges ?? "")) result.lines[line] = stateKey;
+      if (stateKey !== "mark" && stateKey !== "ins" && stateKey !== "del")
+        continue;
+      for (const line of parseRanges(stateRanges ?? ""))
+        result.lines[line] = stateKey;
       continue;
     }
 
@@ -89,7 +99,7 @@ export async function highlightFence({ code, lang, meta }) {
   );
   ensureRegistered(language);
   const { events } = registry.highlight(code, { language: lang });
-  const parsedMeta = meta !== undefined ? parseMeta(meta) : undefined;
+  const parsedMeta = meta === undefined ? undefined : parseMeta(meta);
 
   const lines = tokenLines(events)
     .map((tokens, index) => {
@@ -100,9 +110,9 @@ export async function highlightFence({ code, lang, meta }) {
     .join("\n");
 
   const titleAttr =
-    parsedMeta?.title !== undefined
-      ? ` data-title="${escapeAttribute(parsedMeta.title)}"`
-      : "";
+    parsedMeta?.title === undefined
+      ? ""
+      : ` data-title="${escapeAttribute(parsedMeta.title)}"`;
   const showLineNumbersAttr = parsedMeta?.showLineNumbers
     ? ' data-show-line-numbers="true"'
     : "";

--- a/src/fence.js
+++ b/src/fence.js
@@ -1,0 +1,59 @@
+/**
+ * @typedef {import("./fence.d.ts").ParsedMeta} ParsedMeta
+ */
+
+const TOKEN_RE = /(\w+)="([^"]*)"|(\w+)=\{([^}]*)\}|\{([^}]*)\}|(\w+)/g;
+
+/**
+ * Expands a comma-separated `1,3-5` range string into individual 1-indexed
+ * line numbers.
+ * @param {string} ranges
+ * @returns {number[]}
+ */
+function parseRanges(ranges) {
+  /** @type {number[]} */
+  const lines = [];
+  for (const part of ranges.split(",")) {
+    const trimmed = part.trim();
+    if (!trimmed) continue;
+    const [startStr, endStr] = trimmed.split("-");
+    const start = Number(startStr);
+    const end = endStr !== undefined ? Number(endStr) : start;
+    if (!Number.isInteger(start) || !Number.isInteger(end)) continue;
+    for (let line = start; line <= end; line += 1) lines.push(line);
+  }
+  return lines;
+}
+
+/**
+ * @param {string} meta
+ * @returns {ParsedMeta}
+ */
+export function parseMeta(meta) {
+  /** @type {ParsedMeta} */
+  const result = { lines: {} };
+
+  for (const match of meta.matchAll(TOKEN_RE)) {
+    const [, titleKey, titleValue, stateKey, stateRanges, bareRanges, bareWord] = match;
+
+    if (titleKey !== undefined) {
+      if (titleKey === "title") result.title = titleValue;
+      continue;
+    }
+
+    if (stateKey !== undefined) {
+      if (stateKey !== "mark" && stateKey !== "ins" && stateKey !== "del") continue;
+      for (const line of parseRanges(stateRanges ?? "")) result.lines[line] = stateKey;
+      continue;
+    }
+
+    if (bareRanges !== undefined) {
+      for (const line of parseRanges(bareRanges)) result.lines[line] = "mark";
+      continue;
+    }
+
+    if (bareWord === "showLineNumbers") result.showLineNumbers = true;
+  }
+
+  return result;
+}

--- a/src/preprocessor.js
+++ b/src/preprocessor.js
@@ -140,6 +140,22 @@ function getIdentifierAttribute(attribute) {
 }
 
 /**
+ * `null` unless the attribute is a bare flag (`langtag`) or a static
+ * boolean literal (`langtag={true}`/`langtag={false}`).
+ * @param {import("svelte/compiler").AST.Attribute} attribute
+ */
+function getStaticBooleanAttribute(attribute) {
+  if (attribute.value === true) return true;
+  const value = getSingleAttributeValue(attribute);
+  if (value?.type !== "ExpressionTag") return null;
+  const { expression } = value;
+  if (expression.type === "Literal" && typeof expression.value === "boolean") {
+    return expression.value;
+  }
+  return null;
+}
+
+/**
  * @param {import("svelte/compiler").AST.ElementLike} element
  * @param {Map<string, string>} imports
  */
@@ -156,9 +172,14 @@ function matchHighlightElement(element, imports) {
     // Reject spread attributes and any directive (bind:, on:, use:, class:, etc.) -
     // none of these can be safely replicated in static HTML.
     if (attribute.type !== "Attribute") return null;
-    // Reject any attribute outside the supported set (this also excludes `langtag`,
-    // which needs global CSS the static output can't guarantee is bundled - see README).
-    if (attribute.name !== "language" && attribute.name !== "code") return null;
+    // Reject any attribute outside the supported set.
+    if (
+      attribute.name !== "language" &&
+      attribute.name !== "code" &&
+      attribute.name !== "langtag"
+    ) {
+      return null;
+    }
     attrs.set(attribute.name, attribute);
   }
 
@@ -175,7 +196,17 @@ function matchHighlightElement(element, imports) {
   const languageSource = imports.get(languageLocalName);
   if (!languageSource || !isLanguageImportSource(languageSource)) return null;
 
-  return { code, languageSource };
+  // Bare `langtag` or a static boolean literal only - anything else (a
+  // variable, an expression) disqualifies the usage, same as `code`/`language`.
+  const langtagAttr = attrs.get("langtag");
+  let langtag = false;
+  if (langtagAttr) {
+    const value = getStaticBooleanAttribute(langtagAttr);
+    if (value === null) return null;
+    langtag = value;
+  }
+
+  return { code, languageSource, langtag };
 }
 
 /**
@@ -196,6 +227,14 @@ async function resolveLanguageModule(source, filename) {
 /** @param {string} value */
 function escapeAttribute(value) {
   return value.replace(/&/g, "&amp;").replace(/"/g, "&quot;");
+}
+
+/** @param {string} value */
+function escapeText(value) {
+  return value
+    .replace(/&/g, "&amp;")
+    .replace(/</g, "&lt;")
+    .replace(/>/g, "&gt;");
 }
 
 /**
@@ -240,18 +279,32 @@ function escapeSvelteBraces(html) {
   return html.replace(/[{}]/g, (char) => (char === "{" ? "{'{'}" : "{'}'}"));
 }
 
+// The same declarations `.langtag::after` uses (src/langtag.css), each backed by
+// the matching `--langtag-*` custom property, so a themed static usage needs no
+// stylesheet - see `matchHighlightElement`'s `langtag` handling.
+const LANGTAG_BADGE_STYLE =
+  "position:absolute;top:var(--langtag-top, 0);right:var(--langtag-right, 0);" +
+  "display:flex;align-items:center;justify-content:center;" +
+  "background:var(--langtag-background, inherit);color:var(--langtag-color, inherit);" +
+  "border-radius:var(--langtag-border-radius, 0);padding:var(--langtag-padding, 1em);" +
+  "font-size:var(--langtag-font-size, inherit);";
+
 /**
  * @param {import("./languages").LanguageType<string>} language
  * @param {string} code
+ * @param {boolean} langtag
  */
-function renderStatic(language, code) {
+function renderStatic(language, code, langtag) {
   ensureRegistered(language);
   const { value } = registry.highlight(code, { language: language.name });
+  const badge = langtag
+    ? `<span style="${LANGTAG_BADGE_STYLE}">${escapeText(language.name)}</span>`
+    : "";
   return escapeSvelteBraces(
     `<pre class="hljs" data-language="${escapeAttribute(language.name)}" ` +
-      `style="overflow-x:var(--overflow-x, auto);overflow-y:var(--overflow-y, auto);` +
+      `style="${langtag ? "position:relative;" : ""}overflow-x:var(--overflow-x, auto);overflow-y:var(--overflow-y, auto);` +
       `border-radius:var(--border-radius, 0);width:var(--width, auto);max-width:var(--max-width, none)">` +
-      `<code class="hljs">${value}</code></pre>`,
+      `<code class="hljs">${value}</code>${badge}</pre>`,
   );
 }
 
@@ -483,7 +536,7 @@ export function highlightStatic(options = {}) {
           }
 
           try {
-            return renderStatic(language, match.code);
+            return renderStatic(language, match.code, match.langtag);
           } catch (cause) {
             warn(
               `highlight.js failed to highlight the code (language "${language.name}")`,

--- a/src/preprocessor.js
+++ b/src/preprocessor.js
@@ -403,6 +403,7 @@ function applyEdits(content, edits) {
 /**
  * @typedef {{
  *   onWarn?: (message: string, details: { filename?: string | undefined; line: number; cause: unknown }) => void;
+ *   onSummary?: (summary: { filename?: string | undefined; matched: number; succeeded: number; failed: number }) => void;
  * }} HighlightStaticOptions
  */
 
@@ -419,6 +420,7 @@ function applyEdits(content, edits) {
  */
 export function highlightStatic(options = {}) {
   const warn = options.onWarn ?? defaultWarn;
+  const onSummary = options.onSummary;
 
   return {
     name: "svelte-highlight-static",
@@ -521,6 +523,13 @@ export function highlightStatic(options = {}) {
 
         edits.push({ start, end, replacement: html });
       }
+
+      onSummary?.({
+        filename,
+        matched: matches.length,
+        succeeded: edits.length,
+        failed: matches.length - edits.length,
+      });
 
       if (edits.length === 0) return;
       return applyEdits(content, edits);

--- a/src/static.d.ts
+++ b/src/static.d.ts
@@ -12,6 +12,20 @@ export interface HighlightStaticOptions {
     message: string,
     details: { filename?: string; line: number; cause: unknown },
   ) => void;
+
+  /**
+   * Called once per file with at least one shape-matched `<Highlight>` usage,
+   * after all of that file's usages have been resolved - the escape hatch for
+   * "how many usages actually went static," with aggregation across files
+   * left to the caller. A file with no `<Highlight>`-shaped usages doesn't
+   * trigger this at all.
+   */
+  onSummary?: (summary: {
+    filename?: string;
+    matched: number;
+    succeeded: number;
+    failed: number;
+  }) => void;
 }
 
 /**

--- a/tests/fence-meta.test.ts
+++ b/tests/fence-meta.test.ts
@@ -1,0 +1,76 @@
+import { parseMeta } from "../src/fence.js";
+
+describe("parseMeta", () => {
+  it("parses a bare {ranges} as mark state", () => {
+    expect(parseMeta("{1,3-5}")).toEqual({
+      lines: { 1: "mark", 3: "mark", 4: "mark", 5: "mark" },
+    });
+  });
+
+  it("parses ins={ranges}", () => {
+    expect(parseMeta("ins={2,4}")).toEqual({
+      lines: { 2: "ins", 4: "ins" },
+    });
+  });
+
+  it("parses del={ranges}", () => {
+    expect(parseMeta("del={6-7}")).toEqual({
+      lines: { 6: "del", 7: "del" },
+    });
+  });
+
+  it("parses mark={ranges} (explicit alias of bare {ranges})", () => {
+    expect(parseMeta("mark={1}")).toEqual({
+      lines: { 1: "mark" },
+    });
+  });
+
+  it("combines mark=, ins=, and del= directives", () => {
+    expect(parseMeta("mark={1} ins={2} del={3}")).toEqual({
+      lines: { 1: "mark", 2: "ins", 3: "del" },
+    });
+  });
+
+  it("parses title=", () => {
+    expect(parseMeta('title="app.ts"')).toEqual({
+      lines: {},
+      title: "app.ts",
+    });
+  });
+
+  it("parses the bare showLineNumbers flag", () => {
+    expect(parseMeta("showLineNumbers")).toEqual({
+      lines: {},
+      showLineNumbers: true,
+    });
+  });
+
+  it("parses a realistic string combining every directive", () => {
+    expect(
+      parseMeta('title="app.ts" {1,3-5} ins={7} showLineNumbers'),
+    ).toEqual({
+      lines: { 1: "mark", 3: "mark", 4: "mark", 5: "mark", 7: "ins" },
+      title: "app.ts",
+      showLineNumbers: true,
+    });
+  });
+
+  it("resolves a line named by multiple directives to whichever appears later", () => {
+    expect(parseMeta("{1} del={1}")).toEqual({
+      lines: { 1: "del" },
+    });
+    expect(parseMeta("del={1} {1}")).toEqual({
+      lines: { 1: "mark" },
+    });
+  });
+
+  it("returns an empty result for an empty string", () => {
+    expect(parseMeta("")).toEqual({ lines: {} });
+  });
+
+  it("ignores unrelated/unknown tokens interspersed with recognized ones", () => {
+    expect(parseMeta('foo={1} bar {2} baz="qux" ins={3}')).toEqual({
+      lines: { 2: "mark", 3: "ins" },
+    });
+  });
+});

--- a/tests/fence-meta.test.ts
+++ b/tests/fence-meta.test.ts
@@ -46,13 +46,13 @@ describe("parseMeta", () => {
   });
 
   it("parses a realistic string combining every directive", () => {
-    expect(
-      parseMeta('title="app.ts" {1,3-5} ins={7} showLineNumbers'),
-    ).toEqual({
-      lines: { 1: "mark", 3: "mark", 4: "mark", 5: "mark", 7: "ins" },
-      title: "app.ts",
-      showLineNumbers: true,
-    });
+    expect(parseMeta('title="app.ts" {1,3-5} ins={7} showLineNumbers')).toEqual(
+      {
+        lines: { 1: "mark", 3: "mark", 4: "mark", 5: "mark", 7: "ins" },
+        title: "app.ts",
+        showLineNumbers: true,
+      },
+    );
   });
 
   it("resolves a line named by multiple directives to whichever appears later", () => {

--- a/tests/fence.test.ts
+++ b/tests/fence.test.ts
@@ -1,0 +1,81 @@
+import { highlightFence } from "../src/fence.js";
+
+describe("highlightFence", () => {
+  it("wraps every line in <span class=\"line\"> when no meta is given", async () => {
+    const html = await highlightFence({
+      code: "const a = 1;\nconst b = 2;",
+      lang: "javascript",
+    });
+
+    expect(html.match(/<span class="line">/g)).toHaveLength(2);
+    expect(html).not.toContain("data-line-state");
+    expect(html).toContain('<pre class="hljs" data-language="javascript">');
+    expect(html).toContain('<code class="hljs">');
+  });
+
+  it("marks only the targeted line for a bare {n} range", async () => {
+    const html = await highlightFence({
+      code: "const a = 1;\nconst b = 2;\nconst c = 3;",
+      lang: "javascript",
+      meta: "{2}",
+    });
+
+    const lines = html.match(/<span class="line"[^>]*>/g) ?? [];
+    expect(lines).toEqual([
+      '<span class="line">',
+      '<span class="line" data-line-state="mark">',
+      '<span class="line">',
+    ]);
+  });
+
+  it("supports ins= and del= together", async () => {
+    const html = await highlightFence({
+      code: "const a = 1;\nconst b = 2;",
+      lang: "javascript",
+      meta: "ins={1} del={2}",
+    });
+
+    const lines = html.match(/<span class="line"[^>]*>/g) ?? [];
+    expect(lines).toEqual([
+      '<span class="line" data-line-state="ins">',
+      '<span class="line" data-line-state="del">',
+    ]);
+  });
+
+  it("adds data-title from title=", async () => {
+    const html = await highlightFence({
+      code: "const a = 1;",
+      lang: "javascript",
+      meta: 'title="x.ts"',
+    });
+
+    expect(html).toContain('data-title="x.ts"');
+  });
+
+  it("adds the data-show-line-numbers attribute for showLineNumbers", async () => {
+    const html = await highlightFence({
+      code: "const a = 1;",
+      lang: "javascript",
+      meta: "showLineNumbers",
+    });
+
+    expect(html).toContain('data-show-line-numbers="true"');
+  });
+
+  it("rejects with Unknown language for an unresolvable lang", async () => {
+    await expect(
+      highlightFence({ code: "x", lang: "not-a-real-language" }),
+    ).rejects.toThrow('Unknown language: "not-a-real-language"');
+  });
+
+  it("preserves a multi-token, multi-scope line's text when tags are stripped", async () => {
+    const line = "const x: number = 1 + 2; // a comment";
+    const html = await highlightFence({
+      code: line,
+      lang: "typescript",
+    });
+
+    const stripped = html.replace(/<[^>]+>/g, "");
+    expect(stripped).toBe(line);
+  });
+});

--- a/tests/fence.test.ts
+++ b/tests/fence.test.ts
@@ -1,7 +1,7 @@
 import { highlightFence } from "../src/fence.js";
 
 describe("highlightFence", () => {
-  it("wraps every line in <span class=\"line\"> when no meta is given", async () => {
+  it('wraps every line in <span class="line"> when no meta is given', async () => {
     const html = await highlightFence({
       code: "const a = 1;\nconst b = 2;",
       lang: "javascript",

--- a/tests/static-preprocessor.test.ts
+++ b/tests/static-preprocessor.test.ts
@@ -68,13 +68,47 @@ describe("highlightStatic", () => {
     expect(output).toBe(source);
   });
 
-  it("leaves usages with the langtag prop untouched", async () => {
+  it("transforms a bare langtag into a position:relative pre plus an inline badge span", async () => {
     const source = `<script>
   import Highlight from "../src/Highlight.svelte";
   import javascript from "../src/languages/javascript.js";
 </script>
 
 <Highlight language={javascript} code="const x = 1;" langtag />
+`;
+    const output = await transform(source);
+
+    expect(output).not.toContain("<Highlight");
+    expect(output).toContain("position:relative;");
+    expect(output).toContain(
+      '<span style="position:absolute;top:var(--langtag-top, 0);',
+    );
+    expect(output).toContain(">javascript</span>");
+  });
+
+  it("transforms langtag={false} without the badge span", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+</script>
+
+<Highlight language={javascript} code="const x = 1;" langtag={false} />
+`;
+    const output = await transform(source);
+
+    expect(output).not.toContain("<Highlight");
+    expect(output).not.toContain("position:relative;");
+    expect(output).not.toContain("position:absolute;top:var(--langtag-top");
+  });
+
+  it("leaves usages with a non-literal langtag untouched", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+  let showLangtag = true;
+</script>
+
+<Highlight language={javascript} code="const x = 1;" langtag={showLangtag} />
 `;
     const output = await transform(source);
     expect(output).toBe(source);

--- a/tests/static-preprocessor.test.ts
+++ b/tests/static-preprocessor.test.ts
@@ -173,4 +173,57 @@ describe("highlightStatic", () => {
       console.warn = originalWarn;
     }
   });
+
+  it("fires onSummary once per file with counts for eligible and matched-but-failing usages", async () => {
+    const source = `<script>
+  import Highlight from "../src/Highlight.svelte";
+  import javascript from "../src/languages/javascript.js";
+  import doesNotExist from "svelte-highlight/languages/does-not-exist";
+</script>
+
+<Highlight language={javascript} code="const x = 1;" />
+<Highlight language={doesNotExist} code="const y = 2;" />
+`;
+    const summaries: Array<{
+      filename?: string;
+      matched: number;
+      succeeded: number;
+      failed: number;
+    }> = [];
+
+    await preprocess(
+      source,
+      highlightStatic({
+        onWarn: () => {},
+        onSummary: (summary) => summaries.push(summary),
+      }),
+      { filename },
+    );
+
+    expect(summaries).toHaveLength(1);
+    expect(summaries[0]).toEqual({
+      filename,
+      matched: 2,
+      succeeded: 1,
+      failed: 1,
+    });
+  });
+
+  it("does not fire onSummary for a file with no <Highlight> usages", async () => {
+    const source = `<script>
+  const x = 1;
+</script>
+
+<p>{x}</p>
+`;
+    const summaries: unknown[] = [];
+
+    await preprocess(
+      source,
+      highlightStatic({ onSummary: (summary) => summaries.push(summary) }),
+      { filename },
+    );
+
+    expect(summaries).toHaveLength(0);
+  });
 });

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -1080,11 +1080,34 @@ export { add, mul };\`,
         directives.
       </ListItem>
       <ListItem>
-        The <code class="code">langtag</code> prop is not used. Static output
-        can't pull in <code class="code">langtag.css</code>; that only happens
-        when a runtime <code class="code">LangTag</code> is in the bundle.
+        The <code class="code">langtag</code> prop, if set, is a bare flag or a
+        static boolean literal (<code class="code">langtag={"{true}"}</code
+        >/<code class="code">langtag={"{false}"}</code>) - not a variable or
+        expression.
       </ListItem>
     </UnorderedList>
+    <p class="mb-5">
+      A truthy <code class="code">langtag</code> can't pull in
+      <code class="code">langtag.css</code>
+      at build time, so it renders the language badge as a plain inline-styled
+      <code class="code">{"<span>"}</code>
+      instead, themed with the same
+      <code class="code">--langtag-*</code>
+      custom properties <code class="code">LangTag</code> reads:
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <Highlight
+      code={`<Highlight language={javascript} code="const x = 1;" langtag />`}
+      language={javascript}
+      class={THEME_MODULE_NAME}
+    />
+    <HighlightSvelte
+      code={`<pre class="hljs" data-language="javascript" style="position:relative;overflow-x:var(--overflow-x, auto);overflow-y:var(--overflow-y, auto);border-radius:var(--border-radius, 0);width:var(--width, auto);max-width:var(--max-width, none)"><code class="hljs"><span class="hljs-keyword">const</span> x = <span class="hljs-number">1</span>;</code><span style="position:absolute;top:var(--langtag-top, 0);right:var(--langtag-right, 0);display:flex;align-items:center;justify-content:center;background:var(--langtag-background, inherit);color:var(--langtag-color, inherit);border-radius:var(--langtag-border-radius, 0);padding:var(--langtag-padding, 1em);font-size:var(--langtag-font-size, inherit);">javascript</span></pre>`}
+      class={THEME_MODULE_NAME}
+    />
+  </Column>
+  <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Dynamic <code class="code">code</code> or
       <code class="code">language</code>,
@@ -1140,7 +1163,8 @@ export { add, mul };\`,
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       ...renders per-line markup driven by <code class="code">meta</code>, with
-      <code class="code">data-line-state</code> on lines that
+      <code class="code">data-line-state</code>
+      on lines that
       <code class="code">mark</code>/<code class="code">ins</code>/
       <code class="code">del</code>
       target:

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -68,6 +68,22 @@ export default {
     // defaults to a console.warn with the filename, line, and message
   },
 });`;
+
+  const highlightFenceCallSnippet = `import { highlightFence } from "svelte-highlight/fence";
+
+const html = await highlightFence({
+  code: \`const add = (a, b) => a + b;
+const mul = (a, b) => a * b;
+const oldSub = (a, b) => a - b;
+export { add, mul };\`,
+  lang: "typescript",
+  meta: '{1} ins={2} del={3} title="app.ts"',
+});`;
+
+  const highlightFenceOutputSnippet = `<pre class="hljs" data-language="typescript" data-title="app.ts"><code class="hljs"><span class="line" data-line-state="mark"><span class="hljs-keyword">const</span> <span class="hljs-title function_">add</span> = (<span class="hljs-params">a, b</span>) =&gt; a + b;</span>
+<span class="line" data-line-state="ins"><span class="hljs-keyword">const</span> <span class="hljs-title function_">mul</span> = (<span class="hljs-params">a, b</span>) =&gt; a * b;</span>
+<span class="line" data-line-state="del"><span class="hljs-keyword">const</span> <span class="hljs-title function_">oldSub</span> = (<span class="hljs-params">a, b</span>) =&gt; a - b;</span>
+<span class="line"><span class="hljs-keyword">export</span> { add, mul };</span></code></pre>`;
 </script>
 
 <Row>
@@ -1094,7 +1110,46 @@ export default {
       hideCloseButton
       kind="info"
       title="Note:"
-      subtitle="Scope is small on purpose: extra props on Highlight don't carry over to the emitted &lt;pre&gt;, unused imports are left for bundlers to drop, and there's no Astro/MDX fence hook yet."
+      subtitle="Scope is small on purpose: extra props on Highlight don't carry over to the emitted &lt;pre&gt;, and unused imports are left for bundlers to drop."
+    />
+  </Column>
+  <Column xlg={12}> <h4>Rendering Markdown/MDX Fences</h4> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">highlightStatic</code>
+      only transforms literal <code class="code">Highlight</code>
+      usages, which never appear in Markdown/MDX/mdsvex code fences.
+      <code class="code">svelte-highlight/fence</code>
+      is a separate, zero-Svelte building block for that case:
+      <code class="code">highlightFence({"{"} code, lang, meta {"}"})</code>
+      highlights a single fence, and <code class="code">meta</code>
+      uses the Expressive Code/Shiki-style vocabulary (
+      <code class="code">{"{1,3-5}"}</code>, <code class="code">ins=</code>,
+      <code class="code">del=</code>, <code class="code">title=</code>,
+      <code class="code">showLineNumbers</code>) already standard across that
+      tooling.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <Highlight
+      code={highlightFenceCallSnippet}
+      language={javascript}
+      class={THEME_MODULE_NAME}
+    />
+  </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      ...renders per-line markup driven by <code class="code">meta</code>, with
+      <code class="code">data-line-state</code> on lines that
+      <code class="code">mark</code>/<code class="code">ins</code>/
+      <code class="code">del</code>
+      target:
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}>
+    <HighlightSvelte
+      code={highlightFenceOutputSnippet}
+      class={THEME_MODULE_NAME}
     />
   </Column>
 </Row>


### PR DESCRIPTION
Adds a new svelte-highlight/fence subpath with parseMeta and
highlightFence for pre-rendering Markdown/MDX code fences outside the
Svelte compiler (mdsvex, markdown-it, rehype), plus an onSummary
callback for highlightStatic and langtag support in its static
<Highlight> output.

```js
import { highlightFence } from "svelte-highlight/fence";

const html = await highlightFence({
  code: "const add = (a, b) => a + b;",
  lang: "typescript",
  meta: '{1} title="app.ts"',
});
```

```js
highlightStatic({
  onSummary({ filename, matched, succeeded, failed }) {
    // one call per file with at least one shape-matched usage
  },
});
```

```svelte
<Highlight language={javascript} code="const x = 1;" langtag />
```