### PR TITLE
feat(theme): extend the TextMate starter table with 4 common scopes

### DIFF
--- a/README.md
+++ b/README.md
@@ -257,7 +257,7 @@ import nightOwl from "./night-owl-color-theme.json" with { type: "json" };
 const palette = fromTextMate(nightOwl);
 ```
 
-`fromTextMate` accepts a **parsed object** only — VS Code themes are often JSONC, so parsing is the caller's job. The scope mapping is best-effort: TextMate scope selectors are matched against a starter table by segment-prefix (`"entity.name.function"` matches `"entity.name.function.method.ts"`), with the most specific (longest) match winning ties broken by the later `tokenColors` entry — the same specificity semantics VS Code itself uses. Entries that don't map to anything are never silently dropped; pass `onWarn` to observe them:
+`fromTextMate` accepts a **parsed object** only — VS Code themes are often JSONC, so parsing is the caller's job. The scope mapping is best-effort: TextMate scope selectors are matched against a starter table by segment-prefix (`"entity.name.function"` matches `"entity.name.function.method.ts"`), with the most specific (longest) match winning ties broken by the later `tokenColors` entry — the same specificity semantics VS Code itself uses. The starter table covers common scopes, including Markdown code spans/fences and invalid/illegal markers; because matching generalizes by prefix, a row like `"keyword"` already resolves any more-specific scope sharing that prefix, so `"keyword.control"` and `"keyword.operator"` resolve differently without needing a dedicated row for each. Entries that don't map to anything are never silently dropped; pass `onWarn` to observe them:
 
 ```js
 const palette = fromTextMate(nightOwl, {

--- a/README.md
+++ b/README.md
@@ -265,6 +265,8 @@ const palette = fromTextMate(nightOwl, {
 });
 ```
 
+When present, `theme.semanticTokenColors` is read as a higher-priority overlay on top of `tokenColors` — matching VS Code's own precedence when semantic highlighting is enabled. It's resolved against a starter table of VS Code's default semantic token types (`namespace`, `class`, `interface`, `enum`, `struct`, `typeParameter`, `type`, `parameter`, `variable`, `enumMember`, `property`, `event`, `decorator`, `label`, `function`, `method`, `macro`, `comment`, `string`, `keyword`, `number`, `regexp`, `operator`); modifiers (`"variable.readonly"`) and language scoping (`"variable:typescript"`) are not resolved — only the base type before the first `.` or `:` is matched.
+
 ## Styling
 
 Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility. Legacy styles are stable and will not be removed. One concrete reason to pick this path over `ThemePalette`: `base.css` assumes the default `hljs-` class prefix, so projects using a custom `classPrefix` should stay here.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,12 @@ When present, `theme.semanticTokenColors` is read as a higher-priority overlay o
 
 `fromTextMate` never populates `ThemePalette.extras` — `editor.background` is always read as a single solid color assigned straight to `--shl-bg`. This matches VS Code's own model (VS Code doesn't support gradients for `editor.background` either), so it's a deliberate, low-risk scope cut rather than a gap to fix.
 
+Real VS Code theme files are usually JSONC (comments, trailing commas), which `fromTextMate` doesn't accept directly. `scripts/import-textmate-theme.ts` is a local dev recipe — not an installed CLI — that strips comments/trailing commas and writes the resulting `ThemePalette` as JSON; copy it into your own project and adapt as needed:
+
+```sh
+bun scripts/import-textmate-theme.ts ./night-owl-color-theme.json ./night-owl.palette.json
+```
+
 ## Styling
 
 Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility. Legacy styles are stable and will not be removed. One concrete reason to pick this path over `ThemePalette`: `base.css` assumes the default `hljs-` class prefix, so projects using a custom `classPrefix` should stay here.

--- a/README.md
+++ b/README.md
@@ -265,6 +265,15 @@ const palette = fromTextMate(nightOwl, {
 });
 ```
 
+To count unmapped entries instead of observing each one as it happens, use `fromTextMateWithWarnings`, which aggregates every `onWarn` call:
+
+```js
+import { fromTextMateWithWarnings } from "svelte-highlight/theme/textmate";
+
+const { palette, warnings } = fromTextMateWithWarnings(nightOwl);
+// warnings.length is the number of unmapped tokenColors entries
+```
+
 When present, `theme.semanticTokenColors` is read as a higher-priority overlay on top of `tokenColors` — matching VS Code's own precedence when semantic highlighting is enabled. It's resolved against a starter table of VS Code's default semantic token types (`namespace`, `class`, `interface`, `enum`, `struct`, `typeParameter`, `type`, `parameter`, `variable`, `enumMember`, `property`, `event`, `decorator`, `label`, `function`, `method`, `macro`, `comment`, `string`, `keyword`, `number`, `regexp`, `operator`); modifiers (`"variable.readonly"`) and language scoping (`"variable:typescript"`) are not resolved — only the base type before the first `.` or `:` is matched.
 
 ## Styling

--- a/README.md
+++ b/README.md
@@ -276,6 +276,8 @@ const { palette, warnings } = fromTextMateWithWarnings(nightOwl);
 
 When present, `theme.semanticTokenColors` is read as a higher-priority overlay on top of `tokenColors` — matching VS Code's own precedence when semantic highlighting is enabled. It's resolved against a starter table of VS Code's default semantic token types (`namespace`, `class`, `interface`, `enum`, `struct`, `typeParameter`, `type`, `parameter`, `variable`, `enumMember`, `property`, `event`, `decorator`, `label`, `function`, `method`, `macro`, `comment`, `string`, `keyword`, `number`, `regexp`, `operator`); modifiers (`"variable.readonly"`) and language scoping (`"variable:typescript"`) are not resolved — only the base type before the first `.` or `:` is matched.
 
+`fromTextMate` never populates `ThemePalette.extras` — `editor.background` is always read as a single solid color assigned straight to `--shl-bg`. This matches VS Code's own model (VS Code doesn't support gradients for `editor.background` either), so it's a deliberate, low-risk scope cut rather than a gap to fix.
+
 ## Styling
 
 Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility. Legacy styles are stable and will not be removed. One concrete reason to pick this path over `ThemePalette`: `base.css` assumes the default `hljs-` class prefix, so projects using a custom `classPrefix` should stay here.

--- a/scripts/import-textmate-theme.ts
+++ b/scripts/import-textmate-theme.ts
@@ -1,0 +1,23 @@
+import { fromTextMate } from "../src/textmate-theme.js";
+import { stripJsonComments } from "./strip-jsonc.ts";
+
+const inputPath = process.argv[2];
+const outputPath = process.argv[3];
+
+if (!inputPath) {
+  console.error(
+    "usage: bun scripts/import-textmate-theme.ts <theme.jsonc> [out.json]",
+  );
+  process.exit(1);
+}
+
+const raw = await Bun.file(inputPath).text();
+const parsed = JSON.parse(stripJsonComments(raw));
+const palette = fromTextMate(parsed, { onWarn: console.warn });
+const output = JSON.stringify(palette, null, 2);
+
+if (outputPath) {
+  await Bun.write(outputPath, output);
+} else {
+  console.log(output);
+}

--- a/scripts/strip-jsonc.ts
+++ b/scripts/strip-jsonc.ts
@@ -1,0 +1,15 @@
+const STRING_OR_COMMENT = /("(?:\\.|[^"\\])*")|\/\/.*|\/\*[\s\S]*?\*\//g;
+const TRAILING_COMMA = /,(\s*[}\]])/g;
+
+/**
+ * Strip `//` line comments, `/* *\/` block comments, and trailing commas
+ * from JSONC text so it can be `JSON.parse`d. String literals are left
+ * untouched even when they contain `//` or `/*`.
+ */
+export function stripJsonComments(text: string): string {
+  const withoutComments = text.replace(
+    STRING_OR_COMMENT,
+    (_match, str) => str ?? "",
+  );
+  return withoutComments.replace(TRAILING_COMMA, "$1");
+}

--- a/src/textmate-theme.d.ts
+++ b/src/textmate-theme.d.ts
@@ -52,3 +52,13 @@ export function fromTextMate(
   theme: TextMateTheme,
   options?: FromTextMateOptions,
 ): ThemePalette;
+
+/**
+ * Convenience wrapper around `fromTextMate` that aggregates every `onWarn`
+ * call into a returned `warnings` array, for the common "how many entries
+ * mapped" question.
+ */
+export function fromTextMateWithWarnings(theme: TextMateTheme): {
+  palette: ThemePalette;
+  warnings: string[];
+};

--- a/src/textmate-theme.d.ts
+++ b/src/textmate-theme.d.ts
@@ -9,6 +9,16 @@ export interface TextMateTokenColor {
   };
 }
 
+/** One `semanticTokenColors` entry's value, VS Code's actual shape —
+ * distinct fields from `tokenColors`' `settings.fontStyle` string. */
+export interface TextMateSemanticTokenStyle {
+  foreground?: string;
+  bold?: boolean;
+  italic?: boolean;
+  underline?: boolean;
+  strikethrough?: boolean;
+}
+
 /** A parsed VS Code / TextMate theme JSON object. JSONC parsing (comments,
  * trailing commas) is the caller's job — `fromTextMate` accepts plain
  * objects only. */
@@ -18,6 +28,9 @@ export interface TextMateTheme {
   /** VS Code workbench colors, e.g. `"editor.foreground"`. */
   colors?: Record<string, string>;
   tokenColors?: TextMateTokenColor[];
+  /** Semantic highlighting overlay, keyed `"<type>[.modifier...][:language]"`
+   * (e.g. `"variable.readonly:typescript"`) — resolved by base type only. */
+  semanticTokenColors?: Record<string, string | TextMateSemanticTokenStyle>;
 }
 
 export interface FromTextMateOptions {

--- a/src/textmate-theme.js
+++ b/src/textmate-theme.js
@@ -4,6 +4,7 @@
  *
  * @typedef {import("./textmate-theme.d.ts").TextMateTheme} TextMateTheme
  * @typedef {import("./textmate-theme.d.ts").TextMateTokenColor} TextMateTokenColor
+ * @typedef {import("./textmate-theme.d.ts").TextMateSemanticTokenStyle} TextMateSemanticTokenStyle
  * @typedef {import("./textmate-theme.d.ts").FromTextMateOptions} FromTextMateOptions
  * @typedef {import("./theme.d.ts").ThemePalette} ThemePalette
  * @typedef {import("./theme.d.ts").TokenStyle} TokenStyle
@@ -74,6 +75,39 @@ const STARTER_ROWS = STARTER_TABLE.map(([prefix, target]) => ({
 }));
 
 /**
+ * VS Code semantic token type -> hljs target scope key. Covers VS Code's
+ * default semantic token types (`semanticTokenTypes`); modifiers and
+ * language scoping are not resolved — a `semanticTokenColors` key matches
+ * by base type only.
+ * @type {Record<string, string>}
+ */
+const SEMANTIC_STARTER_TABLE = {
+  namespace: "title.class_",
+  class: "title.class_",
+  interface: "title.class_",
+  enum: "title.class_",
+  struct: "title.class_",
+  typeParameter: "type",
+  type: "type",
+  parameter: "params",
+  variable: "variable",
+  enumMember: "variable",
+  property: "property",
+  event: "property",
+  decorator: "meta",
+  label: "meta",
+  function: "title.function_",
+  method: "title.function_",
+  macro: "title.function_",
+  comment: "comment",
+  string: "string",
+  keyword: "keyword",
+  number: "literal",
+  regexp: "regexp",
+  operator: "operator",
+};
+
+/**
  * The most specific (longest segment-prefix) starter-table row matching
  * `scope`, or `null` if none does.
  * @param {string} scope
@@ -115,6 +149,23 @@ function styleFromSettings(settings) {
     if (tokens.includes("bold")) style.fontWeight = "bold";
     if (tokens.includes("underline")) style.textDecoration = "underline";
   }
+  return style;
+}
+
+/**
+ * @param {string | TextMateSemanticTokenStyle} settings
+ * @returns {TokenStyle}
+ */
+function styleFromSemanticSettings(settings) {
+  if (typeof settings === "string") return { color: settings };
+
+  /** @type {TokenStyle} */
+  const style = {};
+  if (settings.foreground !== undefined) style.color = settings.foreground;
+  if (settings.italic) style.fontStyle = "italic";
+  if (settings.bold) style.fontWeight = "bold";
+  if (settings.underline) style.textDecoration = "underline";
+  else if (settings.strikethrough) style.textDecoration = "line-through";
   return style;
 }
 
@@ -202,6 +253,25 @@ export function fromTextMate(theme, options = {}) {
 
   for (const [target, style] of winnerStyle) {
     applyTokenStyle(vars, parseScopeKey(target), style);
+  }
+
+  // Second pass: semanticTokenColors overlays tokenColors, matching VS
+  // Code's own precedence when semantic highlighting is enabled.
+  const semanticTokenColors = theme.semanticTokenColors ?? {};
+  for (const [key, settings] of Object.entries(semanticTokenColors)) {
+    const baseType = key.split(":")[0]?.split(".")[0] ?? "";
+    const target = SEMANTIC_STARTER_TABLE[baseType];
+    if (!target) {
+      onWarn(
+        `fromTextMate(): no hljs mapping for semantic token type "${baseType}".`,
+      );
+      continue;
+    }
+    applyTokenStyle(
+      vars,
+      parseScopeKey(target),
+      styleFromSemanticSettings(settings),
+    );
   }
 
   const colorScheme =

--- a/src/textmate-theme.js
+++ b/src/textmate-theme.js
@@ -285,3 +285,16 @@ export function fromTextMate(theme, options = {}) {
     vars,
   };
 }
+
+/**
+ * Convenience wrapper around `fromTextMate` that aggregates every `onWarn`
+ * call instead of requiring the caller to collect them manually.
+ * @param {TextMateTheme} theme
+ * @returns {{ palette: ThemePalette, warnings: string[] }}
+ */
+export function fromTextMateWithWarnings(theme) {
+  /** @type {string[]} */
+  const warnings = [];
+  const palette = fromTextMate(theme, { onWarn: (m) => warnings.push(m) });
+  return { palette, warnings };
+}

--- a/src/textmate-theme.js
+++ b/src/textmate-theme.js
@@ -60,6 +60,12 @@ const STARTER_TABLE = [
   ["markup.underline.link", "link"],
   ["markup.inserted", "addition"],
   ["markup.deleted", "deletion"],
+  // "deletion" is the closest visual analog hljs offers for invalid/illegal
+  // syntax — an approximation, not a semantic match.
+  ["invalid", "deletion"],
+  ["markup.raw", "code"],
+  ["markup.fenced_code", "code"],
+  ["meta.embedded", "meta"],
 ];
 
 const STARTER_ROWS = STARTER_TABLE.map(([prefix, target]) => ({

--- a/tests/strip-jsonc.test.ts
+++ b/tests/strip-jsonc.test.ts
@@ -1,0 +1,25 @@
+import { stripJsonComments } from "../scripts/strip-jsonc.ts";
+
+describe("stripJsonComments", () => {
+  it("removes a // line comment", () => {
+    const input = '{\n  "a": 1 // comment\n}';
+    expect(JSON.parse(stripJsonComments(input))).toEqual({ a: 1 });
+  });
+
+  it("removes a /* */ block comment", () => {
+    const input = '{\n  /* comment */\n  "a": 1\n}';
+    expect(JSON.parse(stripJsonComments(input))).toEqual({ a: 1 });
+  });
+
+  it("removes a trailing comma before } and before ]", () => {
+    const input = '{\n  "a": [1, 2,],\n  "b": 2,\n}';
+    expect(JSON.parse(stripJsonComments(input))).toEqual({ a: [1, 2], b: 2 });
+  });
+
+  it("leaves // and /* sequences inside a quoted string value untouched", () => {
+    const input = '{ "a": "http://example.com /* not a comment */" }';
+    expect(JSON.parse(stripJsonComments(input))).toEqual({
+      a: "http://example.com /* not a comment */",
+    });
+  });
+});

--- a/tests/textmate-theme.test.ts
+++ b/tests/textmate-theme.test.ts
@@ -1,4 +1,7 @@
-import { fromTextMate } from "../src/textmate-theme.js";
+import {
+  fromTextMate,
+  fromTextMateWithWarnings,
+} from "../src/textmate-theme.js";
 
 describe("fromTextMate", () => {
   it("resolves fg/bg from colors[editor.foreground/background]", () => {
@@ -349,5 +352,31 @@ describe("fromTextMate", () => {
     });
     expect(() => JSON.stringify(palette)).not.toThrow();
     expect(JSON.parse(JSON.stringify(palette))).toEqual(palette);
+  });
+});
+
+describe("fromTextMateWithWarnings", () => {
+  it("aggregates onWarn calls into a warnings array alongside the palette", () => {
+    const theme = {
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        { scope: "totally.unknown.scope", settings: { foreground: "#bad" } },
+        {
+          scope: "source.js entity.name.function",
+          settings: { foreground: "#bad" },
+        },
+      ],
+    };
+    const { palette, warnings } = fromTextMateWithWarnings(theme);
+    expect(warnings).toHaveLength(2);
+    expect(palette).toEqual(fromTextMate(theme));
+  });
+
+  it("returns an empty warnings array for a clean theme", () => {
+    const { warnings } = fromTextMateWithWarnings({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [{ scope: "keyword", settings: { foreground: "#f0f" } }],
+    });
+    expect(warnings).toEqual([]);
   });
 });

--- a/tests/textmate-theme.test.ts
+++ b/tests/textmate-theme.test.ts
@@ -270,6 +270,77 @@ describe("fromTextMate", () => {
     expect(palette.vars["--shl-string"]).toBe("#b4");
   });
 
+  it("maps a string-valued semanticTokenColors entry to foreground only", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [],
+      semanticTokenColors: { variable: "#c1c1c1" },
+    });
+    expect(palette.vars["--shl-variable"]).toBe("#c1c1c1");
+  });
+
+  it("maps an object-valued semanticTokenColors entry's bold/italic/underline/strikethrough", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [],
+      semanticTokenColors: {
+        function: {
+          foreground: "#d1d1d1",
+          bold: true,
+          italic: true,
+          underline: true,
+        },
+      },
+    });
+    expect(palette.vars["--shl-title-function_"]).toBe("#d1d1d1");
+    expect(palette.vars["--shl-title-function_-font-weight"]).toBe("bold");
+    expect(palette.vars["--shl-title-function_-font-style"]).toBe("italic");
+    expect(palette.vars["--shl-title-function_-text-decoration"]).toBe(
+      "underline",
+    );
+  });
+
+  it("maps strikethrough to line-through when underline is absent", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [],
+      semanticTokenColors: { comment: { strikethrough: true } },
+    });
+    expect(palette.vars["--shl-comment-text-decoration"]).toBe("line-through");
+  });
+
+  it("overrides a tokenColors match with a semanticTokenColors entry for the same target", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [{ scope: "variable", settings: { foreground: "#tok" } }],
+      semanticTokenColors: { variable: "#sem" },
+    });
+    expect(palette.vars["--shl-variable"]).toBe("#sem");
+  });
+
+  it("resolves a semanticTokenColors key with a modifier and language suffix via its base type", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [],
+      semanticTokenColors: { "variable.readonly:typescript": "#e1e1e1" },
+    });
+    expect(palette.vars["--shl-variable"]).toBe("#e1e1e1");
+  });
+
+  it("calls onWarn for an unmapped semantic token type", () => {
+    const warnings: string[] = [];
+    fromTextMate(
+      {
+        colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+        tokenColors: [],
+        semanticTokenColors: { unknownType: "#f1f1f1" },
+      },
+      { onWarn: (message) => warnings.push(message) },
+    );
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatch(/unknownType/);
+  });
+
   it("returns a plain, serializable ThemePalette", () => {
     const palette = fromTextMate({
       name: "night-owl",

--- a/tests/textmate-theme.test.ts
+++ b/tests/textmate-theme.test.ts
@@ -218,6 +218,58 @@ describe("fromTextMate", () => {
     expect(palette.name).toBe("night-owl");
   });
 
+  it("maps invalid(.illegal), markup.raw/fenced_code, and meta.embedded to their starter-table targets", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        { scope: "invalid", settings: { foreground: "#a1" } },
+        { scope: "markup.raw", settings: { foreground: "#a2" } },
+        { scope: "meta.embedded.block.html", settings: { foreground: "#a4" } },
+      ],
+    });
+    expect(palette.vars["--shl-deletion"]).toBe("#a1");
+    expect(palette.vars["--shl-code"]).toBe("#a2");
+    expect(palette.vars["--shl-meta"]).toBe("#a4");
+
+    const illegal = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        { scope: "invalid.illegal", settings: { foreground: "#a1" } },
+      ],
+    });
+    expect(illegal.vars["--shl-deletion"]).toBe("#a1");
+
+    const fenced = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        { scope: "markup.fenced_code", settings: { foreground: "#a3" } },
+      ],
+    });
+    expect(fenced.vars["--shl-code"]).toBe("#a3");
+  });
+
+  it("already generalizes starter-table prefixes to more specific scopes without dedicated rows", () => {
+    const palette = fromTextMate({
+      colors: { "editor.foreground": "#eee", "editor.background": "#111" },
+      tokenColors: [
+        {
+          scope: "keyword.control.conditional",
+          settings: { foreground: "#b1" },
+        },
+        { scope: "keyword.operator.new", settings: { foreground: "#b2" } },
+        {
+          scope: "entity.name.tag.support",
+          settings: { foreground: "#b3" },
+        },
+        { scope: "string.quoted.docstring", settings: { foreground: "#b4" } },
+      ],
+    });
+    expect(palette.vars["--shl-keyword"]).toBe("#b1");
+    expect(palette.vars["--shl-operator"]).toBe("#b2");
+    expect(palette.vars["--shl-tag"]).toBe("#b3");
+    expect(palette.vars["--shl-string"]).toBe("#b4");
+  });
+
   it("returns a plain, serializable ThemePalette", () => {
     const palette = fromTextMate({
       name: "night-owl",


### PR DESCRIPTION
Also layers semanticTokenColors on top of tokenColors so modern
themes that lean on semantic highlighting aren't under-colored, adds
fromTextMateWithWarnings for an aggregated unmapped-entry count, and
ships a local (unpublished) JSONC import recipe under scripts/. Docs
cover each addition plus the pre-existing extras limitation.