### PR TITLE
docs(components): document Typewriter's speed={0} instant-reveal

### DIFF
--- a/README.md
+++ b/README.md
@@ -1652,6 +1652,8 @@ Control the pacing curve with `easing`: a function mapping elapsed-time fraction
 
 Named curves: `linear` (default), `easeInQuad`/`easeOutQuad`/`easeInOutQuad`, `easeInCubic`/`easeOutCubic`/`easeInOutCubic`, `easeInSine`/`easeOutSine`/`easeInOutSine`.
 
+Set `speed={0}` to reveal all content on the very first frame -- a documented "skip typing" escape hatch, useful for a "skip" button or for finishing an off-screen instance instantly.
+
 `Typewriter` doesn't gate itself on `prefers-reduced-motion` -- if you want to honor it, check `matchMedia("(prefers-reduced-motion: reduce)")` yourself and skip rendering `Typewriter` (or set a very low `speed`). Customize the caret with `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink`.
 
 

--- a/README.md
+++ b/README.md
@@ -1767,6 +1767,18 @@ doc.lineRange(50_000, 50_040); // 40 highlighted lines in O(window + interval)
 doc.append(moreCode); // streaming growth, no re-tokenization
 ```
 
+`Typewriter`'s tokenizer is available the same way, for a custom reveal UI or non-DOM use: `svelte-highlight/typewriter-units` exposes `tokenizeTypewriter`, `buildUnitMarkup`, `createTypewriterSplitter`, and `computeWordBoundaries` headlessly.
+
+```js
+import {
+  computeWordBoundaries,
+  tokenizeTypewriter,
+} from "svelte-highlight/typewriter-units";
+
+const units = tokenizeTypewriter(highlighted);
+const wordBoundaries = computeWordBoundaries(units); // for word-by-word reveal
+```
+
 `lineRange` tokenizes lazily and caches the most recently resolved window, so scrolling through even a huge document only ever pays for the lines actually requested. Its output matches `HighlightStream`'s live (non-canonicalized) parse: constructs needing multi-line lookahead across a window's edge can render slightly differently than `registry.highlight()`'s canonical output, the same tradeoff streaming already makes. `TokenizedDocument` doesn't support mid-document edits -- `append` and full `setCode` resets only. For a bounded, editable document (not a windowed/virtualized one), `HighlightEditable` solves mid-document editing, built on its own checkpoint-resume re-tokenizer (`src/incremental-tokenize.js`, not itself a public export). The two aren't unified today -- there's no single primitive yet for a document that's both editable and virtualized.
 
 ### Without virtualization

--- a/README.md
+++ b/README.md
@@ -1654,6 +1654,14 @@ Named curves: `linear` (default), `easeInQuad`/`easeOutQuad`/`easeInOutQuad`, `e
 
 Set `speed={0}` to reveal all content on the very first frame -- a documented "skip typing" escape hatch, useful for a "skip" button or for finishing an off-screen instance instantly.
 
+By default `granularity="char"` reveals one character at a time. Set `granularity="word"` to reveal a full word per step instead -- a ChatGPT-style token-by-token reveal. Total typing duration and `easing` are unaffected either way; only which character counts `revealed` may land on changes.
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <Typewriter {highlighted} granularity="word" />
+</Highlight>
+```
+
 Fire `on:progress` for a progress bar or "X% typed" indicator -- it dispatches `{ revealed, total }` (visible-character counts) whenever `revealed` advances. `revealed` and `total` are also exposed for `bind:revealed`/`bind:total`, though both are read-only in practice: the component overwrites them every frame.
 
 ```svelte
@@ -2248,6 +2256,7 @@ See [Large documents](#large-documents) above.
 | speed       | `number`                 | `30`          |
 | play        | `boolean`                | `true`        |
 | easing      | `(t: number) => number`  | `linear`      |
+| granularity | `"char" \| "word"`       | `"char"`      |
 | revealed    | `number`                 | `0`           |
 | total       | `number`                 | `0`           |
 

--- a/README.md
+++ b/README.md
@@ -1654,6 +1654,19 @@ Named curves: `linear` (default), `easeInQuad`/`easeOutQuad`/`easeInOutQuad`, `e
 
 Set `speed={0}` to reveal all content on the very first frame -- a documented "skip typing" escape hatch, useful for a "skip" button or for finishing an off-screen instance instantly.
 
+Fire `on:progress` for a progress bar or "X% typed" indicator -- it dispatches `{ revealed, total }` (visible-character counts) whenever `revealed` advances. `revealed` and `total` are also exposed for `bind:revealed`/`bind:total`, though both are read-only in practice: the component overwrites them every frame.
+
+```svelte
+<Highlight language={typescript} {code} let:highlighted>
+  <Typewriter
+    {highlighted}
+    bind:revealed
+    bind:total
+    on:progress={(e) => console.log(`${e.detail.revealed}/${e.detail.total}`)}
+  />
+</Highlight>
+```
+
 `Typewriter` doesn't gate itself on `prefers-reduced-motion` -- if you want to honor it, check `matchMedia("(prefers-reduced-motion: reduce)")` yourself and skip rendering `Typewriter` (or set a very low `speed`). Customize the caret with `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink`.
 
 
@@ -2235,12 +2248,15 @@ See [Large documents](#large-documents) above.
 | speed       | `number`                 | `30`          |
 | play        | `boolean`                | `true`        |
 | easing      | `(t: number) => number`  | `linear`      |
+| revealed    | `number`                 | `0`           |
+| total       | `number`                 | `0`           |
 
-`$$restProps` are forwarded to the top-level `pre` element.
+`$$restProps` are forwarded to the top-level `pre` element. `revealed`/`total` are read-only in practice (overwritten every frame) but exposed for `bind:revealed`/`bind:total`.
 
 #### Dispatched Events
 
 - **on:done**: fires when typing finishes
+- **on:progress**: fires whenever `revealed` advances, with `{ revealed, total }`
 
 ```svelte
 <Highlight language={typescript} {code} let:highlighted>

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -108,6 +108,14 @@ pkgJson.exports = {
     types: "./tokenized-document.d.ts",
     default: "./tokenized-document.js",
   },
+  "./typewriter-units": {
+    types: "./typewriter-units.d.ts",
+    default: "./typewriter-units.js",
+  },
+  "./typewriter-units.js": {
+    types: "./typewriter-units.d.ts",
+    default: "./typewriter-units.js",
+  },
   "./registry": {
     types: "./registry.d.ts",
     default: "./registry.js",

--- a/src/Typewriter.svelte
+++ b/src/Typewriter.svelte
@@ -49,8 +49,21 @@
   /** @type {boolean} */
   let doneFired = false;
 
-  /** Number of visible characters currently revealed. @type {number} */
-  let revealed = 0;
+  /**
+   * Number of visible characters currently revealed. Read-only in practice:
+   * overwritten every frame by the tick loop, but exported so `bind:revealed`
+   * can observe it (e.g. for a progress bar).
+   * @type {number}
+   */
+  export let revealed = 0;
+
+  /**
+   * Total number of visible characters in `highlighted`. Read-only in
+   * practice: overwritten every reactive flush from `units`, but exported so
+   * `bind:total` can observe it (e.g. for a progress bar).
+   * @type {number}
+   */
+  export let total = 0;
 
   /** @type {number | undefined} */
   let rafId;
@@ -148,7 +161,10 @@
     const t = duration > 0 ? Math.min(1, elapsedMs / duration) : 1;
     const target = Math.round(easing(t) * total);
     const next = Math.min(total, Math.max(0, target));
-    if (next > revealed) revealed = next;
+    if (next > revealed) {
+      revealed = next;
+      dispatch("progress", { revealed, total });
+    }
 
     if (useUnitReveal) syncUnitDom();
 

--- a/src/Typewriter.svelte
+++ b/src/Typewriter.svelte
@@ -21,6 +21,7 @@
   import { linear } from "./typewriter-easing.js";
   import {
     buildUnitMarkup,
+    computeWordBoundaries,
     createTypewriterSplitter,
     tokenizeTypewriter as tokenize,
   } from "./typewriter-units.js";
@@ -34,6 +35,15 @@
    * @type {(t: number) => number}
    */
   export let easing = linear;
+
+  /**
+   * Reveal granularity. `"char"` reveals one character at a time; `"word"`
+   * reveals a full word per step -- e.g. for a ChatGPT-style token-by-token
+   * reveal. Total duration and easing are unaffected -- only which
+   * character counts `revealed` may land on.
+   * @type {"char" | "word"}
+   */
+  export let granularity = "char";
 
   const dispatch = createEventDispatcher();
 
@@ -131,6 +141,29 @@
     }
   }
 
+  /**
+   * Largest value in sorted `boundaries` that is `<= target`, or `0` if none.
+   * @param {number} target
+   * @param {number[]} boundaries
+   * @returns {number}
+   */
+  function snapToWordBoundary(target, boundaries) {
+    let lo = 0;
+    let hi = boundaries.length - 1;
+    let result = 0;
+    while (lo <= hi) {
+      const mid = (lo + hi) >> 1;
+      const value = /** @type {number} */ (boundaries[mid]);
+      if (value <= target) {
+        result = value;
+        lo = mid + 1;
+      } else {
+        hi = mid - 1;
+      }
+    }
+    return result;
+  }
+
   function stopLoop() {
     if (rafId !== undefined) cancelAnimationFrame(rafId);
     rafId = undefined;
@@ -159,7 +192,9 @@
 
     const duration = Math.max(0, speed) * total;
     const t = duration > 0 ? Math.min(1, elapsedMs / duration) : 1;
-    const target = Math.round(easing(t) * total);
+    let target = Math.round(easing(t) * total);
+    if (granularity === "word" && wordBoundaries)
+      target = snapToWordBoundary(target, wordBoundaries);
     const next = Math.min(total, Math.max(0, target));
     if (next > revealed) {
       revealed = next;
@@ -201,6 +236,8 @@
   // together in the same reactive flush whenever `highlighted` changes.
   $: splitter = createTypewriterSplitter(units, highlighted);
   $: total = units.reduce((sum, unit) => sum + unit.visible, 0);
+  $: wordBoundaries =
+    granularity === "word" ? computeWordBoundaries(units) : null;
   $: bigInput = total > UNIT_THRESHOLD;
   $: useUnitReveal = mounted && !bigInput;
 

--- a/src/Typewriter.svelte.d.ts
+++ b/src/Typewriter.svelte.d.ts
@@ -32,6 +32,15 @@ export type TypewriterProps = HTMLAttributes<HTMLPreElement> & {
   easing?: (t: number) => number;
 
   /**
+   * Reveal granularity. `"char"` reveals one character at a time; `"word"`
+   * reveals a full word per step -- e.g. for a ChatGPT-style token-by-token
+   * reveal. Total duration and easing are unaffected -- only which
+   * character counts `revealed` may land on.
+   * @default "char"
+   */
+  granularity?: "char" | "word";
+
+  /**
    * Number of visible characters currently revealed. Read-only in practice
    * (overwritten every frame); exposed for `bind:revealed`.
    * @default 0

--- a/src/Typewriter.svelte.d.ts
+++ b/src/Typewriter.svelte.d.ts
@@ -9,7 +9,9 @@ export type TypewriterProps = HTMLAttributes<HTMLPreElement> & {
   highlighted?: string;
 
   /**
-   * Milliseconds between characters.
+   * Milliseconds between characters. `0` reveals all content on the first
+   * frame -- a "skip typing" escape hatch (e.g. a skip button, or finishing
+   * an off-screen instance instantly).
    * @default 30
    */
   speed?: number;

--- a/src/Typewriter.svelte.d.ts
+++ b/src/Typewriter.svelte.d.ts
@@ -32,6 +32,20 @@ export type TypewriterProps = HTMLAttributes<HTMLPreElement> & {
   easing?: (t: number) => number;
 
   /**
+   * Number of visible characters currently revealed. Read-only in practice
+   * (overwritten every frame); exposed for `bind:revealed`.
+   * @default 0
+   */
+  revealed?: number;
+
+  /**
+   * Total number of visible characters in `highlighted`. Read-only in
+   * practice (overwritten every reactive flush); exposed for `bind:total`.
+   * @default 0
+   */
+  total?: number;
+
+  /**
    * Width of the blinking caret.
    * @default "0.6em"
    */
@@ -67,6 +81,11 @@ export type TypewriterEvents = {
    * Fires when typing finishes.
    */
   done: CustomEvent<null>;
+
+  /**
+   * Fires whenever `revealed` advances, with the current `revealed`/`total`.
+   */
+  progress: CustomEvent<{ revealed: number; total: number }>;
 };
 
 export default class Typewriter extends SvelteComponentTyped<

--- a/src/typewriter-units.d.ts
+++ b/src/typewriter-units.d.ts
@@ -31,3 +31,16 @@ export declare function createTypewriterSplitter(
   units: TypewriterUnit[],
   html: string,
 ): TypewriterSplitter;
+
+/**
+ * Groups `units`' visible characters into words: a maximal run of
+ * consecutive non-whitespace visible units, plus any visible whitespace
+ * (` `, `\t`, `\r`, `\n`) immediately following it. A leading whitespace run
+ * (with no preceding word) is its own word. Tags (`visible: 0`) are skipped
+ * without resetting the current word. Returns the cumulative visible-unit
+ * count at the end of each word; the last entry always equals the total
+ * visible-unit count. Empty for zero visible units.
+ */
+export declare function computeWordBoundaries(
+  units: TypewriterUnit[],
+): number[];

--- a/src/typewriter-units.js
+++ b/src/typewriter-units.js
@@ -163,3 +163,39 @@ export function createTypewriterSplitter(units, html) {
 
   return { splitAt };
 }
+
+const WHITESPACE = new Set([" ", "\t", "\r", "\n"]);
+
+/**
+ * Groups `units`' visible characters into words: a maximal run of
+ * consecutive non-whitespace visible units, plus any visible whitespace
+ * (` `, `\t`, `\r`, `\n`) immediately following it. A leading whitespace run
+ * (with no preceding word) is its own word. Tags (`visible: 0`) are skipped
+ * without resetting the current word.
+ * @param {TypewriterUnit[]} units
+ * @returns {number[]} cumulative visible-unit count at the end of each word;
+ *   the last entry always equals the total visible-unit count. Empty for
+ *   zero visible units.
+ */
+export function computeWordBoundaries(units) {
+  /** @type {number[]} */
+  const boundaries = [];
+  let count = 0;
+  let inWhitespaceRun = false;
+
+  for (const unit of units) {
+    if (unit.visible === 0) continue;
+    count++;
+
+    if (WHITESPACE.has(unit.raw)) {
+      inWhitespaceRun = true;
+    } else if (inWhitespaceRun) {
+      boundaries.push(count - 1);
+      inWhitespaceRun = false;
+    }
+  }
+
+  if (count > 0) boundaries.push(count);
+
+  return boundaries;
+}

--- a/tests/e2e/Typewriter.test.svelte
+++ b/tests/e2e/Typewriter.test.svelte
@@ -4,6 +4,7 @@
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
 
   export let speed = 1;
+  export let granularity = "char";
 
   let code = "const add = (a: number, b: number) => a + b;";
   let play = true;
@@ -30,6 +31,7 @@
     {highlighted}
     {speed}
     {play}
+    {granularity}
     data-testid="tw"
     on:done={() => (done += 1)}
     on:progress={(e) => (progress = e.detail)}

--- a/tests/e2e/Typewriter.test.svelte
+++ b/tests/e2e/Typewriter.test.svelte
@@ -9,6 +9,7 @@
   let play = true;
 
   let done = 0;
+  let progress = { revealed: 0, total: 0 };
 </script>
 
 <svelte:head>{@html atomOneDark}</svelte:head>
@@ -31,7 +32,9 @@
     {play}
     data-testid="tw"
     on:done={() => (done += 1)}
+    on:progress={(e) => (progress = e.detail)}
   />
 </Highlight>
 
 <span data-testid="done">{done}</span>
+<span data-testid="progress">{progress.revealed}/{progress.total}</span>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -2252,6 +2252,22 @@ test("Typewriter - swapping `highlighted` mid-animation restarts cleanly", async
   expect(errors).toEqual([]);
 });
 
+test("Typewriter - dispatches progress and exposes bindable revealed/total", async ({
+  mount,
+  page,
+}) => {
+  await mount(Typewriter, { props: { speed: 15 } });
+
+  const progress = page.getByTestId("progress");
+
+  await expect.poll(async () => progress.textContent()).not.toMatch(/^0\//);
+
+  const total = await progress
+    .textContent()
+    .then((text) => text?.split("/")[1]);
+  await expect(progress).toHaveText(`${total}/${total}`, { timeout: 15_000 });
+});
+
 test("HighlightEditable - two instances share the same bound code", async ({
   mount,
   page,

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -2252,6 +2252,23 @@ test("Typewriter - swapping `highlighted` mid-animation restarts cleanly", async
   expect(errors).toEqual([]);
 });
 
+test('Typewriter - granularity="word" still completes and settles to the full content', async ({
+  mount,
+  page,
+}) => {
+  await mount(Typewriter, { props: { speed: 10, granularity: "word" } });
+
+  const tw = page.getByTestId("tw");
+
+  await expect(page.getByTestId("done")).toHaveText("1");
+
+  await expect(tw.locator(".hljs-keyword").first()).toHaveText("const");
+  await expect(tw.locator(".hljs-title.function_")).toHaveText("add");
+  await expect(tw).toContainText(
+    "const add = (a: number, b: number) => a + b;",
+  );
+});
+
 test("Typewriter - dispatches progress and exposes bindable revealed/total", async ({
   mount,
   page,

--- a/tests/typewriter-tokenize.test.ts
+++ b/tests/typewriter-tokenize.test.ts
@@ -1,4 +1,7 @@
-import { tokenizeTypewriter } from "../src/typewriter-units.js";
+import {
+  computeWordBoundaries,
+  tokenizeTypewriter,
+} from "../src/typewriter-units.js";
 
 describe("tokenizeTypewriter", () => {
   it("counts one visible unit per plain character", () => {
@@ -53,5 +56,29 @@ describe("tokenizeTypewriter", () => {
     ]);
     // The emoji unit must contain both surrogate halves together.
     expect(units[1]?.raw.length).toBe(2);
+  });
+});
+
+describe("computeWordBoundaries", () => {
+  it("groups plain words separated by whitespace", () => {
+    const units = tokenizeTypewriter("hello world");
+    expect(computeWordBoundaries(units)).toEqual([6, 11]);
+  });
+
+  it("treats a leading whitespace run as its own word", () => {
+    const units = tokenizeTypewriter("  go");
+    expect(computeWordBoundaries(units)).toEqual([2, 4]);
+  });
+
+  it("skips tags without resetting the current word", () => {
+    const units = tokenizeTypewriter(
+      '<span class="hljs-keyword">const</span> add',
+    );
+    expect(computeWordBoundaries(units)).toEqual([6, 9]);
+  });
+
+  it("is empty for zero visible units", () => {
+    expect(computeWordBoundaries(tokenizeTypewriter(""))).toEqual([]);
+    expect(computeWordBoundaries(tokenizeTypewriter("<br/>"))).toEqual([]);
   });
 });

--- a/www/components/Typewriter/Controls.svelte
+++ b/www/components/Typewriter/Controls.svelte
@@ -47,6 +47,10 @@
   let runId = 0;
   let easingName = "linear";
   let skippedSpeed;
+  let revealed = 0;
+  let total = 0;
+
+  $: percent = total > 0 ? Math.round((revealed / total) * 100) : 0;
 
   $: easing = EASINGS[easingName];
 
@@ -77,6 +81,8 @@
         class={THEME_MODULE_NAME}
         --caret-color="#2996cf"
         --caret-width="2px"
+        bind:revealed
+        bind:total
         on:done={() => (done = true)}
       />
     </Highlight>
@@ -107,6 +113,7 @@
   <Button size="small" kind="tertiary" on:click={skip}>Skip</Button>
   <Button size="small" kind="tertiary" on:click={replay}>Replay</Button>
   <p class="label-01" style="margin-bottom: 0.5rem">
-    Status: <code class="code">{done ? "done" : "revealing…"}</code>
+    Status:
+    <code class="code">{done ? "done" : "revealing…"}</code> ({percent}%)
   </p>
 </div>

--- a/www/components/Typewriter/Controls.svelte
+++ b/www/components/Typewriter/Controls.svelte
@@ -46,10 +46,20 @@
   let done = false;
   let runId = 0;
   let easingName = "linear";
+  let skippedSpeed;
 
   $: easing = EASINGS[easingName];
 
+  function skip() {
+    skippedSpeed = speed;
+    speed = 0;
+  }
+
   function replay() {
+    if (skippedSpeed !== undefined) {
+      speed = skippedSpeed;
+      skippedSpeed = undefined;
+    }
     done = false;
     play = true;
     runId += 1;
@@ -94,6 +104,7 @@
     labelA="Paused"
     labelB="Playing"
   />
+  <Button size="small" kind="tertiary" on:click={skip}>Skip</Button>
   <Button size="small" kind="tertiary" on:click={replay}>Replay</Button>
   <p class="label-01" style="margin-bottom: 0.5rem">
     Status: <code class="code">{done ? "done" : "revealing…"}</code>

--- a/www/components/Typewriter/Controls.svelte
+++ b/www/components/Typewriter/Controls.svelte
@@ -46,6 +46,7 @@
   let done = false;
   let runId = 0;
   let easingName = "linear";
+  let granularity = "char";
   let skippedSpeed;
   let revealed = 0;
   let total = 0;
@@ -78,6 +79,7 @@
         {speed}
         {play}
         {easing}
+        {granularity}
         class={THEME_MODULE_NAME}
         --caret-color="#2996cf"
         --caret-width="2px"
@@ -104,6 +106,10 @@
       <SelectItem value={name} />
     {/each}
   </Select>
+  <Select labelText="Granularity" bind:selected={granularity}>
+    <SelectItem value="char" />
+    <SelectItem value="word" />
+  </Select>
   <Toggle
     bind:toggled={play}
     labelText="Playback"
@@ -114,6 +120,7 @@
   <Button size="small" kind="tertiary" on:click={replay}>Replay</Button>
   <p class="label-01" style="margin-bottom: 0.5rem">
     Status:
-    <code class="code">{done ? "done" : "revealing…"}</code> ({percent}%)
+    <code class="code">{done ? "done" : "revealing…"}</code>
+    ({percent}%)
   </p>
 </div>


### PR DESCRIPTION
Also adds an on:progress event with bindable revealed/total, a
word-granularity reveal mode for token-by-token typing, and
publishes typewriter-units as a subpath export for headless use.