### PR TITLE
fix(theme): fall back to a plain light value under light-dark()

### DIFF
--- a/README.md
+++ b/README.md
@@ -388,6 +388,8 @@ Under a `style-src` CSP that requires a nonce, pass `nonce` and it's attached to
 
 A single `ThemePalette` (`theme` as an object, not a `light`/`dark` pair) never injects a `<style>` tag at all — only inline vars on the wrapper — so it's unaffected by a `style-src` nonce requirement in the first place; that's a reason to prefer it under a strict CSP.
 
+**Known limitation:** on the CSS-string path, server-side rendering emits one `<style>` tag per `HighlightStyle` instance, even when several instances on the page share the exact same theme — the client-side dedupe only kicks in after hydration. This is harmless (CSS is idempotent), but adds extra bytes on pages with many repeated identical-theme instances. The `ThemePalette` object path has no such concern for a single theme, since it never injects a `<style>` tag to begin with.
+
 ### Dark mode
 
 `HighlightStyle` can emit a light and a dark theme together and switch between them. Pass `light` and `dark` instead of `theme`:

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ This renders SSR-identical output — no `<svelte:head>`, no `<style>` tag, just
 </HighlightStyle>
 ```
 
-This renders `--shl-keyword: light-dark(#a626a4, #c678dd)` (etc.) plus `color-scheme: light dark`. `mode="light"` / `mode="dark"` force `color-scheme: light` / `dark`. Any other `mode` string (the legacy "CSS selector" mode) omits `color-scheme` inline — set it on your own selector for app-controlled switching, e.g. `[data-theme="dark"] { color-scheme: dark }`.
+The wrapper's inline style carries the plain light value for each var (e.g. `--shl-keyword:#a626a4`) — a baseline every browser can render. A scoped, deduped `<style>` tag (gated behind `@supports (color: light-dark(...))`) overrides it with `--shl-keyword: light-dark(#a626a4, #c678dd)` (etc.) plus `color-scheme: light dark` on browsers that support `light-dark()`. `mode="light"` / `mode="dark"` force `color-scheme: light` / `dark`. Any other `mode` string (the legacy "CSS selector" mode) omits `color-scheme` inline — set it on your own selector for app-controlled switching, e.g. `[data-theme="dark"] { color-scheme: dark }`.
 
 **One-line customization — any token, no theme forking:**
 
@@ -170,6 +170,8 @@ Variable names are derived mechanically from the selectors found in `highlight.j
 `themes/base.css` wraps a multi-scope (compound/descendant) variable in a fallback to its subject scope's variable — e.g. `.hljs-meta .hljs-string { color: var(--shl-meta-string, var(--shl-string)); }` — so a theme that never styles that specific combination still falls through to the plain scope color instead of rendering unstyled. Declarations that don't fit the var contract (gradients, borders, `::selection`, etc.) ship as an opaque `extras` string on the palette, applied only via the `.css` artifact.
 
 `base.css` assumes the default `hljs-` class prefix; projects using a custom `classPrefix` should stay on the legacy string path below.
+
+`HighlightStyle` also inlines `color-scheme` from the palette(s) it's given — `palette.colorScheme` for a single `theme`, or a value derived from `mode` for a `light`/`dark` pair — so native form controls and scrollbars inside a themed block follow the theme too.
 
 ### Creating themes
 
@@ -418,6 +420,8 @@ The `mode` prop controls how the two themes are switched (default `"auto"`):
 ```
 
 Both themes are scoped to the wrapper, so different blocks can use different theme pairs on the same page. When `light` and `dark` are both set they take precedence over `theme`; passing only `theme` keeps the existing single-theme behavior unchanged.
+
+The `ThemePalette` object pair path (`light`/`dark` as [`ThemePalette`s](#theming) rather than CSS strings) works the same way, but resolves the pair via `light-dark()` instead of `prefers-color-scheme`/selector gating. On a browser that predates `light-dark()` support, it now falls back to the light theme instead of rendering broken (unset) colors: a scoped, deduped `<style>` tag applies the `light-dark()` values behind `@supports (color: light-dark(...))`, and the wrapper's own inline style carries the plain light value as the pre-`@supports` baseline. Single-theme (`theme` alone, no pair) SSR-identical guarantees are unaffected either way.
 
 ## Styling with CSS variables
 

--- a/README.md
+++ b/README.md
@@ -376,6 +376,16 @@ The component prefixes each selector with a scope class on the wrapper, so the t
 
 For a page-wide theme, use `{@html theme}` as shown above.
 
+Under a `style-src` CSP that requires a nonce, pass `nonce` and it's attached to the `<style>` tag `HighlightStyle` injects into `<svelte:head>`:
+
+```svelte
+<HighlightStyle theme={a11yDark} nonce={cspNonce}>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>
+```
+
+A single `ThemePalette` (`theme` as an object, not a `light`/`dark` pair) never injects a `<style>` tag at all — only inline vars on the wrapper — so it's unaffected by a `style-src` nonce requirement in the first place; that's a reason to prefer it under a strict CSP.
+
 ### Dark mode
 
 `HighlightStyle` can emit a light and a dark theme together and switch between them. Pass `light` and `dark` instead of `theme`:
@@ -1949,6 +1959,7 @@ The active tab's `--tab-active-color` and `--tab-active-background` are resolved
 | dark       | `string \| ThemePalette` | N/A                       |
 | mode       | `"auto" \| "light" \| "dark" \| string` | `"auto"`   |
 | scopeClass | `string`                | hash of `theme`           |
+| nonce      | `string`                | N/A                       |
 
 The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the top-level `div` element.
 

--- a/README.md
+++ b/README.md
@@ -122,6 +122,8 @@ This renders SSR-identical output — no `<svelte:head>`, no `<style>` tag, just
 
 The wrapper's inline style carries the plain light value for each var (e.g. `--shl-keyword:#a626a4`) — a baseline every browser can render. A scoped, deduped `<style>` tag (gated behind `@supports (color: light-dark(...))`) overrides it with `--shl-keyword: light-dark(#a626a4, #c678dd)` (etc.) plus `color-scheme: light dark` on browsers that support `light-dark()`. `mode="light"` / `mode="dark"` force `color-scheme: light` / `dark`. Any other `mode` string (the legacy "CSS selector" mode) omits `color-scheme` inline — set it on your own selector for app-controlled switching, e.g. `[data-theme="dark"] { color-scheme: dark }`.
 
+See it live, with a mode toggle, on the [dual-palette preview page](https://svhe.onrender.com/preview-dual-palette).
+
 **One-line customization — any token, no theme forking:**
 
 ```css
@@ -172,6 +174,8 @@ Variable names are derived mechanically from the selectors found in `highlight.j
 `base.css` assumes the default `hljs-` class prefix; projects using a custom `classPrefix` should stay on the legacy string path below.
 
 `HighlightStyle` also inlines `color-scheme` from the palette(s) it's given — `palette.colorScheme` for a single `theme`, or a value derived from `mode` for a `light`/`dark` pair — so native form controls and scrollbars inside a themed block follow the theme too.
+
+`extras` isn't a corner case for every theme — e.g. the `3024` theme's `extras` covers 7 declarations, including `.hljs ::selection`, `.hljs::selection`, `.hljs-operator`, and `.ruby .hljs-property`, all silently dropped when that theme is imported as a `ThemePalette` object (`svelte-highlight/themes/3024`) instead of its `.css` artifact. There's no per-theme fidelity indicator today; [SUPPORTED_THEMES.md](SUPPORTED_THEMES.md) is where one could eventually live.
 
 ### Creating themes
 

--- a/src/HighlightStyle.svelte
+++ b/src/HighlightStyle.svelte
@@ -72,6 +72,15 @@
    * `<style>` tag to match against. */
   export let scopeClass = undefined;
 
+  /**
+   * CSP nonce attached to the injected `<style>` tag, for a `style-src`
+   * policy that requires one. Unneeded (and has no effect) on a single
+   * `ThemePalette` (`theme`, no `light`/`dark` pair): that path only ever
+   * sets inline vars on the wrapper, never injects a `<style>` tag.
+   * @type {string | undefined}
+   */
+  export let nonce = undefined;
+
   // Captured once: a consumer-supplied scopeClass is honored for the
   // lifetime of the instance instead of being overwritten by the hash below.
   const hasOwnScopeClass = scopeClass !== undefined && scopeClass !== "";
@@ -99,12 +108,12 @@
   // pairs dedupe their tag too.
   $: style = hasTheme
     ? usingObjectPair
-      ? dualPaletteSupportsStyle(scopeClass, light, dark, mode)
+      ? dualPaletteSupportsStyle(scopeClass, light, dark, mode, nonce)
       : usingObjectTheme
         ? ""
         : usingPair
-          ? dualStyle(light, dark, scopeClass, mode)
-          : scopeStyle(theme, scopeClass)
+          ? dualStyle(light, dark, scopeClass, mode, nonce)
+          : scopeStyle(theme, scopeClass, nonce)
     : "";
 
   // Inline vars applied to the wrapper element; undefined (no `style`

--- a/src/HighlightStyle.svelte
+++ b/src/HighlightStyle.svelte
@@ -25,7 +25,11 @@
 <script>
   import { onDestroy } from "svelte";
   import { dualStyle, scopeClassFor, scopeStyle } from "./scoped.js";
-  import { dualPaletteStyle, paletteStyle } from "./theme-style.js";
+  import {
+    dualPaletteSupportsStyle,
+    lightFallbackStyle,
+    paletteStyle,
+  } from "./theme-style.js";
 
   /**
    * Theme CSS from `svelte-highlight/styles/<theme>`, or a `ThemePalette`
@@ -77,7 +81,6 @@
     usingPair && typeof light === "object" && typeof dark === "object";
   $: usingObjectTheme =
     !usingPair && theme !== undefined && typeof theme === "object";
-  $: usingObjectPalette = usingObjectPair || usingObjectTheme;
 
   $: hasTheme = theme !== undefined || usingPair;
 
@@ -89,19 +92,27 @@
         : scopeClassFor(theme ?? `${light}${dark}`);
   }
 
-  // The scoped-<style> path's content; empty (nothing rendered) on the
-  // object path, which never touches <svelte:head> or the ownership store.
-  $: style =
-    hasTheme && !usingObjectPalette
-      ? usingPair
-        ? dualStyle(light, dark, scopeClass, mode)
-        : scopeStyle(theme, scopeClass)
-      : "";
+  // The <svelte:head>-injected <style> content. Empty for a single
+  // ThemePalette (inline vars only, no light-dark() to fall back from). For
+  // an object pair it's a light-dark()-gated @supports override, keyed into
+  // the same ownership registry as the legacy string path so identical
+  // pairs dedupe their tag too.
+  $: style = hasTheme
+    ? usingObjectPair
+      ? dualPaletteSupportsStyle(scopeClass, light, dark, mode)
+      : usingObjectTheme
+        ? ""
+        : usingPair
+          ? dualStyle(light, dark, scopeClass, mode)
+          : scopeStyle(theme, scopeClass)
+    : "";
 
   // Inline vars applied to the wrapper element; undefined (no `style`
-  // attribute) on the legacy scoped-<style> path.
+  // attribute) on the legacy scoped-<style> path. For an object pair this
+  // is the plain light-only baseline — light-dark() support upgrades it via
+  // the `style` tag above.
   $: inlineStyle = usingObjectPair
-    ? dualPaletteStyle(light, dark, mode)
+    ? lightFallbackStyle(light, dark)
     : usingObjectTheme
       ? paletteStyle(theme)
       : undefined;

--- a/src/HighlightStyle.svelte.d.ts
+++ b/src/HighlightStyle.svelte.d.ts
@@ -49,6 +49,14 @@ export type HighlightStyleProps = HTMLAttributes<HTMLDivElement> & {
    * @default hash of `theme`
    */
   scopeClass?: string;
+
+  /**
+   * CSP nonce attached to the injected `<style>` tag, for a `style-src`
+   * policy that requires one. Unneeded (and has no effect) on a single
+   * `ThemePalette` (`theme`, no `light`/`dark` pair): that path only ever
+   * sets inline vars on the wrapper, never injects a `<style>` tag.
+   */
+  nonce?: string;
 };
 
 export type HighlightStyleSlots = {

--- a/src/scoped.d.ts
+++ b/src/scoped.d.ts
@@ -1,5 +1,10 @@
-/** Prefix theme selectors with `.<scope> `. Keeps a `<style>` wrapper when present. */
-export declare function scopeStyle(style: string, scope: string): string;
+/** Prefix theme selectors with `.<scope> `. Keeps a `<style>` wrapper when
+ * present; `nonce` is attached to it (ignored when there's no wrapper). */
+export declare function scopeStyle(
+  style: string,
+  scope: string,
+  nonce?: string,
+): string;
 
 /** Walk CSS and rewrite each selector with `transform`. */
 export declare function scopeSelectors(
@@ -10,13 +15,15 @@ export declare function scopeSelectors(
 /**
  * Build a combined light/dark stylesheet scoped under `.scope`. `mode` is
  * `"auto"` (prefers-color-scheme media queries), `"light"`/`"dark"` (single
- * theme), or any CSS selector that gates the dark block.
+ * theme), or any CSS selector that gates the dark block. `nonce` is attached
+ * to the emitted `<style>` tag.
  */
 export declare function dualStyle(
   light: string,
   dark: string,
   scope: string,
   mode?: string,
+  nonce?: string,
 ): string;
 
 /** Hash of the theme string. Same theme gives the same class (SSR-safe). */

--- a/src/scoped.js
+++ b/src/scoped.js
@@ -165,13 +165,17 @@ export function scopeSelectors(css, transform) {
  *
  * @param {string} style Theme CSS (optionally `<style>`-wrapped).
  * @param {string} scope Scope class name without a leading `.`.
+ * @param {string} [nonce] CSP nonce for the `<style>` tag. Ignored when
+ *   `style` has no `<style>` wrapper to attach it to.
  * @returns {string}
  */
-export function scopeStyle(style, scope) {
+export function scopeStyle(style, scope, nonce) {
   warnIfInvalidScope(scope);
   const body = scopedBody(style, scope);
   const match = STYLE_TAG.exec(style);
-  return match ? `${match[1] ?? ""}${body}${match[3] ?? ""}` : body;
+  if (!match) return body;
+  if (nonce) return `<style nonce="${nonce}">${body}</style>`;
+  return `${match[1] ?? ""}${body}${match[3] ?? ""}`;
 }
 
 /**
@@ -202,9 +206,16 @@ function scopedBody(style, scope, prefix = "") {
  * @param {string} dark Dark theme CSS (optionally `<style>`-wrapped).
  * @param {string} scope Scope class name without a leading `.`.
  * @param {string} [mode] `"auto"` | `"light"` | `"dark"` | a CSS selector.
+ * @param {string} [nonce] CSP nonce for the `<style>` tag.
  * @returns {string}
  */
-export function dualStyle(light, dark, scope, mode = "auto") {
+export function dualStyle(
+  light,
+  dark,
+  scope,
+  mode = "auto",
+  nonce = undefined,
+) {
   warnIfInvalidScope(scope);
   let css;
   if (mode === "light") {
@@ -218,7 +229,8 @@ export function dualStyle(light, dark, scope, mode = "auto") {
   } else {
     css = scopedBody(light, scope) + scopedBody(dark, scope, mode);
   }
-  return `<style>${css}</style>`;
+  const openTag = nonce ? `<style nonce="${nonce}">` : "<style>";
+  return `${openTag}${css}</style>`;
 }
 
 /**

--- a/src/theme-style.js
+++ b/src/theme-style.js
@@ -61,10 +61,14 @@ export function mergeLightDarkVars(lightVars, darkVars, fallbacks) {
   return merged;
 }
 
-/** @param {Record<string, string>} vars */
-export function varsToStyle(vars) {
+/**
+ * @param {Record<string, string>} vars
+ * @param {{ important?: boolean }} [options]
+ */
+export function varsToStyle(vars, { important = false } = {}) {
+  const suffix = important ? " !important" : "";
   return Object.entries(vars)
-    .map(([key, value]) => `${key}:${value}`)
+    .map(([key, value]) => `${key}:${value}${suffix}`)
     .join(";");
 }
 
@@ -90,4 +94,45 @@ export function dualPaletteStyle(light, dark, mode) {
   const varsStyle = varsToStyle(merged);
   const colorScheme = COLOR_SCHEME_BY_MODE[mode];
   return colorScheme ? `${varsStyle};color-scheme:${colorScheme}` : varsStyle;
+}
+
+/**
+ * Plain-declaration baseline for a light/dark palette pair: the light
+ * side's resolved value for every key either palette declares, with no
+ * `light-dark()` — safe on any browser, including ones that don't support
+ * it. A key resolvable only via the dark side is omitted, same as
+ * `mergeLightDarkVars`.
+ * @param {import("./theme.d.ts").ThemePalette} light
+ * @param {import("./theme.d.ts").ThemePalette} dark
+ * @returns {string}
+ */
+export function lightFallbackStyle(light, dark) {
+  const keys = new Set([...Object.keys(light.vars), ...Object.keys(dark.vars)]);
+  /** @type {Record<string, string>} */
+  const vars = {};
+  for (const key of keys) {
+    const value = resolveThemeVar(light.vars, key, SHL_FALLBACKS);
+    if (value !== undefined) vars[key] = value;
+  }
+  return varsToStyle(vars);
+}
+
+/**
+ * A scoped `<style>` tag, gated behind `@supports (color: light-dark(#000,
+ * #000))`, that overrides `lightFallbackStyle`'s plain baseline with the
+ * `light-dark()` merge (and `color-scheme`) on browsers that support it.
+ * Paired with `lightFallbackStyle` as `HighlightStyle`'s inline style for a
+ * light/dark palette pair.
+ * @param {string} scopeClass
+ * @param {import("./theme.d.ts").ThemePalette} light
+ * @param {import("./theme.d.ts").ThemePalette} dark
+ * @param {string} mode
+ * @returns {string}
+ */
+export function dualPaletteSupportsStyle(scopeClass, light, dark, mode) {
+  const merged = mergeLightDarkVars(light.vars, dark.vars, SHL_FALLBACKS);
+  const colorScheme = COLOR_SCHEME_BY_MODE[mode];
+  if (colorScheme) merged["color-scheme"] = colorScheme;
+  const decls = varsToStyle(merged, { important: true });
+  return `<style>@supports (color: light-dark(#000, #000)){.${scopeClass}{${decls}}}</style>`;
 }

--- a/src/theme-style.js
+++ b/src/theme-style.js
@@ -79,9 +79,13 @@ const COLOR_SCHEME_BY_MODE = {
   dark: "dark",
 };
 
-/** @param {import("./theme.d.ts").ThemePalette} palette */
+/**
+ * Serialize a single palette's vars plus its own `color-scheme`, so native
+ * form controls/scrollbars inside a themed block follow the theme too.
+ * @param {import("./theme.d.ts").ThemePalette} palette
+ */
 export function paletteStyle(palette) {
-  return varsToStyle(palette.vars);
+  return `${varsToStyle(palette.vars)};color-scheme:${palette.colorScheme}`;
 }
 
 /**

--- a/src/theme-style.js
+++ b/src/theme-style.js
@@ -127,12 +127,14 @@ export function lightFallbackStyle(light, dark) {
  * @param {import("./theme.d.ts").ThemePalette} light
  * @param {import("./theme.d.ts").ThemePalette} dark
  * @param {string} mode
+ * @param {string} [nonce] CSP nonce for the `<style>` tag.
  * @returns {string}
  */
-export function dualPaletteSupportsStyle(scopeClass, light, dark, mode) {
+export function dualPaletteSupportsStyle(scopeClass, light, dark, mode, nonce) {
   const merged = mergeLightDarkVars(light.vars, dark.vars, SHL_FALLBACKS);
   const colorScheme = COLOR_SCHEME_BY_MODE[mode];
   if (colorScheme) merged["color-scheme"] = colorScheme;
   const decls = varsToStyle(merged, { important: true });
-  return `<style>@supports (color: light-dark(#000, #000)){.${scopeClass}{${decls}}}</style>`;
+  const openTag = nonce ? `<style nonce="${nonce}">` : "<style>";
+  return `${openTag}@supports (color: light-dark(#000, #000)){.${scopeClass}{${decls}}}</style>`;
 }

--- a/tests/e2e/HighlightStyle.nonce.test.svelte
+++ b/tests/e2e/HighlightStyle.nonce.test.svelte
@@ -1,0 +1,11 @@
+<script>
+  import Highlight, { HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import a11yDark from "svelte-highlight/styles/a11y-dark";
+
+  const code = "const add = (a, b) => a + b;";
+</script>
+
+<HighlightStyle theme={a11yDark} nonce="test-nonce">
+  <Highlight language={typescript} {code} />
+</HighlightStyle>

--- a/tests/e2e/HighlightStyle.themeSwitch.test.svelte
+++ b/tests/e2e/HighlightStyle.themeSwitch.test.svelte
@@ -3,6 +3,9 @@
   import typescript from "svelte-highlight/languages/typescript";
   import a11yDark from "svelte-highlight/styles/a11y-dark";
   import github from "svelte-highlight/styles/github";
+  import atomOneDark from "svelte-highlight/themes/atom-one-dark";
+  import atomOneLight from "svelte-highlight/themes/atom-one-light";
+  import "svelte-highlight/themes/base.css";
 
   const code = "const add = (a, b) => a + b;";
 
@@ -24,5 +27,14 @@
 
 <HighlightStyle theme={themeB} data-testid="b" let:scopeClass>
   <span data-testid="b-scope">{scopeClass}</span>
+  <Highlight language={typescript} {code} />
+</HighlightStyle>
+
+<HighlightStyle
+  light={atomOneLight}
+  dark={atomOneDark}
+  mode="dark"
+  data-testid="palette-pair"
+>
   <Highlight language={typescript} {code} />
 </HighlightStyle>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -102,6 +102,22 @@ test("HighlightStyle - recomputes scope class when theme changes at runtime", as
   await expect(b).toHaveCSS("background-color", "rgb(255, 255, 255)");
 });
 
+test("HighlightStyle - applies the light-dark() @supports override for a light/dark palette pair", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStyleThemeSwitch);
+
+  const pair = page.getByTestId("palette-pair").locator(".hljs").first();
+
+  // atom-one-dark background is #282c34, resolved via light-dark() under
+  // mode="dark" — Chromium supports light-dark(), so the @supports override
+  // applies and matches the same value dualPaletteStyle would have resolved
+  // pre-fallback, not the plain light baseline (#fafafa) inlined as a
+  // fallback for unsupporting browsers.
+  await expect(pair).toHaveCSS("background-color", "rgb(40, 44, 52)");
+});
+
 test("HighlightStyle - dedupes head injection for instances sharing a theme", async ({
   mount,
   page,

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -36,6 +36,7 @@ import HighlightStream from "./HighlightStream.test.svelte";
 import HighlightStreamVirtualize from "./HighlightStream.virtualize.test.svelte";
 import HighlightStyleDedupe from "./HighlightStyle.dedupe.test.svelte";
 import HighlightStyleEmptyScopeClass from "./HighlightStyle.emptyScopeClass.test.svelte";
+import HighlightStyleNonce from "./HighlightStyle.nonce.test.svelte";
 import HighlightStyleNoTheme from "./HighlightStyle.noTheme.test.svelte";
 import HighlightStyleThemeSwitch from "./HighlightStyle.themeSwitch.test.svelte";
 import HighlightSvelteDispatchOnce from "./HighlightSvelte.dispatchOnce.test.svelte";
@@ -129,6 +130,15 @@ test("HighlightStyle - dedupes head injection for instances sharing a theme", as
   await component.unmount();
 
   await expect(page.locator("style")).toHaveCount(0);
+});
+
+test("HighlightStyle - attaches a CSP nonce to the injected <style> tag", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStyleNonce);
+
+  await expect(page.locator("style[nonce='test-nonce']")).toHaveCount(1);
 });
 
 test("HighlightStyle - renders nothing when no theme is provided", async ({

--- a/tests/highlight-style-dual.test.ts
+++ b/tests/highlight-style-dual.test.ts
@@ -63,6 +63,13 @@ describe("dualStyle", () => {
     );
   });
 
+  it("attaches a CSP nonce to the <style> tag", () => {
+    const out = dualStyle(light, dark, "scope", "light", "abc");
+    expect(out).toBe(
+      '<style nonce="abc">.scope .hljs{color:black;background:white}</style>',
+    );
+  });
+
   it("handles themes without a <style> wrapper", () => {
     const out = dualStyle(
       ".hljs{color:black}",

--- a/tests/highlight-style-ssr.test.ts
+++ b/tests/highlight-style-ssr.test.ts
@@ -62,16 +62,18 @@ describe("HighlightStyle SSR", () => {
     expect(body).toContain("--shl-bg:#ffffff");
   });
 
-  it("merges a light/dark palette pair via light-dark() with color-scheme", async () => {
+  it("merges a light/dark palette pair via an @supports light-dark() override, with a plain light baseline inline", async () => {
     const { default: HighlightStyle } = await compileForServer();
 
     const { head, body } = render(HighlightStyle, {
       props: { light: lightPalette, dark: darkPalette, mode: "auto" },
     });
 
-    expect(head).not.toContain("<style>");
-    expect(body).toContain("light-dark(#000000, #ffffff)");
-    expect(body).toContain("color-scheme:light dark");
+    expect(head).toContain("<style>");
+    expect(head).toContain("@supports");
+    expect(head).toContain("light-dark(#000000, #ffffff) !important");
+    expect(body).toContain("--shl-fg:#000000");
+    expect(body).not.toContain("light-dark(");
   });
 
   it("keeps the legacy string path unchanged: scoped <style> in head, no inline vars", async () => {

--- a/tests/highlight-style-ssr.test.ts
+++ b/tests/highlight-style-ssr.test.ts
@@ -60,6 +60,7 @@ describe("HighlightStyle SSR", () => {
     expect(body).not.toContain("<style>");
     expect(body).toContain("--shl-fg:#000000");
     expect(body).toContain("--shl-bg:#ffffff");
+    expect(body).toContain("color-scheme:light");
   });
 
   it("merges a light/dark palette pair via an @supports light-dark() override, with a plain light baseline inline", async () => {

--- a/tests/scoped.test.ts
+++ b/tests/scoped.test.ts
@@ -28,6 +28,16 @@ describe("scopeStyle", () => {
     expect(out).toBe("<style>.scope .hljs{color:red}</style>");
   });
 
+  it("attaches a CSP nonce to the <style> tag", () => {
+    const out = scopeStyle("<style>.hljs{color:red}</style>", "scope", "abc");
+    expect(out).toBe('<style nonce="abc">.scope .hljs{color:red}</style>');
+  });
+
+  it("ignores a nonce when there's no <style> wrapper to attach it to", () => {
+    const out = scopeStyle(".hljs{color:red}", "scope", "abc");
+    expect(out).toBe(".scope .hljs{color:red}");
+  });
+
   it("leaves leading license comments in place", () => {
     const out = scopeStyle("/*! License */.hljs{color:red}", "scope");
     expect(out).toBe("/*! License */.scope .hljs{color:red}");

--- a/tests/theme-style.test.ts
+++ b/tests/theme-style.test.ts
@@ -1,5 +1,7 @@
 import {
   dualPaletteStyle,
+  dualPaletteSupportsStyle,
+  lightFallbackStyle,
   mergeLightDarkVars,
   paletteStyle,
   resolveThemeVar,
@@ -137,6 +139,87 @@ describe("dualPaletteStyle", () => {
 
   it("omits color-scheme for an app-controlled selector mode", () => {
     const style = dualPaletteStyle(light, dark, '[data-theme="dark"]');
+    expect(style).not.toContain("color-scheme");
+  });
+});
+
+describe("lightFallbackStyle", () => {
+  it("emits the light side's plain value for keys both sides declare", () => {
+    const style = lightFallbackStyle(
+      {
+        name: "light",
+        colorScheme: "light",
+        vars: { "--shl-keyword": "purple" },
+      },
+      {
+        name: "dark",
+        colorScheme: "dark",
+        vars: { "--shl-keyword": "violet" },
+      },
+    );
+    expect(style).toBe("--shl-keyword:purple");
+  });
+
+  it("resolves a one-sided key via the fallback chain (light only)", () => {
+    const style = lightFallbackStyle(
+      { name: "light", colorScheme: "light", vars: { "--shl-title": "navy" } },
+      {
+        name: "dark",
+        colorScheme: "dark",
+        vars: { "--shl-title-class_": "gold" },
+      },
+    );
+    expect(style).toContain("--shl-title-class_:navy");
+  });
+
+  it("omits a key resolvable only via the dark side", () => {
+    const style = lightFallbackStyle(
+      { name: "light", colorScheme: "light", vars: {} },
+      {
+        name: "dark",
+        colorScheme: "dark",
+        vars: { "--shl-keyword": "violet" },
+      },
+    );
+    expect(style).not.toContain("--shl-keyword");
+  });
+});
+
+describe("dualPaletteSupportsStyle", () => {
+  const light = {
+    name: "light",
+    colorScheme: "light" as const,
+    vars: { "--shl-fg": "#000", "--shl-bg": "#fff" },
+  };
+  const dark = {
+    name: "dark",
+    colorScheme: "dark" as const,
+    vars: { "--shl-fg": "#fff", "--shl-bg": "#000" },
+  };
+
+  it("wraps light-dark() declarations in an @supports block with !important", () => {
+    const style = dualPaletteSupportsStyle("svh-scope-1", light, dark, "auto");
+    expect(style).toContain(
+      "@supports (color: light-dark(#000, #000)){.svh-scope-1{",
+    );
+    expect(style).toContain("--shl-fg:light-dark(#000, #fff) !important");
+    expect(style).toContain("--shl-bg:light-dark(#fff, #000) !important");
+    expect(style.startsWith("<style>")).toBe(true);
+    expect(style.endsWith("</style>")).toBe(true);
+  });
+
+  it("includes color-scheme with !important for a resolved mode", () => {
+    const style = dualPaletteSupportsStyle("svh-scope-1", light, dark, "auto");
+    expect(style).toContain("color-scheme:light dark !important");
+  });
+
+  it("omits color-scheme for an app-controlled selector mode", () => {
+    const style = dualPaletteSupportsStyle(
+      "svh-scope-1",
+      light,
+      dark,
+      '[data-theme="dark"]',
+    );
     expect(style).not.toContain("color-scheme");
   });
 });

--- a/tests/theme-style.test.ts
+++ b/tests/theme-style.test.ts
@@ -222,4 +222,15 @@ describe("dualPaletteSupportsStyle", () => {
     );
     expect(style).not.toContain("color-scheme");
   });
+
+  it("attaches a CSP nonce to the <style> tag", () => {
+    const style = dualPaletteSupportsStyle(
+      "svh-scope-1",
+      light,
+      dark,
+      "auto",
+      "abc",
+    );
+    expect(style.startsWith('<style nonce="abc">')).toBe(true);
+  });
 });

--- a/tests/theme-style.test.ts
+++ b/tests/theme-style.test.ts
@@ -96,13 +96,15 @@ describe("varsToStyle", () => {
 });
 
 describe("paletteStyle", () => {
-  it("serializes a single palette's vars", () => {
+  it("serializes a single palette's vars plus its color-scheme", () => {
     const palette = {
       name: "test",
       colorScheme: "dark" as const,
       vars: { "--shl-fg": "#fff", "--shl-bg": "#000" },
     };
-    expect(paletteStyle(palette)).toBe("--shl-fg:#fff;--shl-bg:#000");
+    expect(paletteStyle(palette)).toBe(
+      "--shl-fg:#fff;--shl-bg:#000;color-scheme:dark",
+    );
   });
 });
 

--- a/www/components/DualPalettePreview.svelte
+++ b/www/components/DualPalettePreview.svelte
@@ -1,0 +1,127 @@
+<script>
+  import { Toggle } from "carbon-components-svelte";
+  import Highlight, { HighlightStyle } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/themes/atom-one-dark";
+  import atomOneLight from "svelte-highlight/themes/atom-one-light";
+  import "svelte-highlight/themes/base.css";
+
+  const code = `interface User {
+  id: number;
+  name: string;
+}
+
+const greet = (user: User): string => {
+  return \`Hello, \${user.name}!\`;
+};`;
+
+  const modes = ["auto", "light", "dark", "selector"];
+
+  /** @type {"auto" | "light" | "dark" | "selector"} */
+  let mode = "auto";
+
+  // "selector" mode gates dark styles on `[data-theme="dark"]`.
+  let darkSelectorOn = false;
+
+  const selector = '[data-theme="dark"]';
+
+  $: resolvedMode = mode === "selector" ? selector : mode;
+  $: dataTheme = mode === "selector" && darkSelectorOn ? "dark" : undefined;
+</script>
+
+<div class="controls">
+  <fieldset>
+    <legend>mode</legend>
+    {#each modes as value}
+      <button
+        type="button"
+        class="mode-button"
+        class:selected={mode === value}
+        on:click={() => (mode = value)}
+      >
+        {value}
+      </button>
+    {/each}
+  </fieldset>
+
+  {#if mode === "selector"}
+    <Toggle
+      bind:toggled={darkSelectorOn}
+      labelText={`apply ${selector}`}
+      labelA="Off"
+      labelB="On"
+      size="sm"
+    />
+  {/if}
+</div>
+
+<p class="hint">
+  {#if mode === "auto"}
+    Following your OS / browser <code>prefers-color-scheme</code>, resolved via
+    <code>light-dark()</code>. Switch your system theme to see it flip.
+  {:else if mode === "light" || mode === "dark"}
+    Forcing the <strong>{mode}</strong> theme.
+  {:else}
+    Dark block is gated behind <code>{selector}</code> on an ancestor — toggle
+    the checkbox above.
+  {/if}
+</p>
+
+<div data-theme={dataTheme}>
+  <HighlightStyle light={atomOneLight} dark={atomOneDark} mode={resolvedMode}>
+    <Highlight language={typescript} {code} />
+  </HighlightStyle>
+</div>
+
+<style>
+  .controls {
+    display: flex;
+    flex-wrap: wrap;
+    gap: 1rem;
+    align-items: center;
+    margin-bottom: 1rem;
+  }
+
+  fieldset {
+    display: flex;
+    gap: 0.75rem;
+    align-items: center;
+    border: 1px solid var(--cds-ui-04, #8d8d8d);
+    border-radius: 4px;
+    padding: 0.25rem 0.75rem;
+  }
+
+  legend {
+    padding: 0 0.25rem;
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+
+  .mode-button {
+    cursor: pointer;
+    border: 1px solid var(--cds-ui-04, #8d8d8d);
+    border-radius: 4px;
+    background: transparent;
+    color: inherit;
+    padding: 0.25rem 0.625rem;
+    font: inherit;
+    font-size: 0.875rem;
+  }
+
+  .mode-button.selected {
+    background: var(--cds-interactive-01, #0f62fe);
+    border-color: var(--cds-interactive-01, #0f62fe);
+    color: var(--cds-text-04, #ffffff);
+  }
+
+  .hint {
+    margin-bottom: 1rem;
+    font-size: 0.875rem;
+    opacity: 0.8;
+  }
+
+  code {
+    font-family: var(--cds-code-02-font-family, monospace);
+  }
+</style>

--- a/www/pages/preview-dual-palette.astro
+++ b/www/pages/preview-dual-palette.astro
@@ -1,0 +1,9 @@
+---
+import DualPalettePreview from "@components/DualPalettePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Dual light/dark ThemePalette preview">
+  <h1 class="mb-5">Dual light/dark ThemePalette</h1>
+  <DualPalettePreview client:idle />
+</Layout>


### PR DESCRIPTION
Adds a light-only fallback and @supports override for HighlightStyle's
light/dark ThemePalette path, a nonce prop for CSP style-src policies,
and color-scheme inlining on the single-palette path, plus docs and a
live dual-palette preview page.