### PR TITLE
feat(engine): add StreamSession#replace for headless mid-stream edits

### DIFF
--- a/README.md
+++ b/README.md
@@ -1691,6 +1691,8 @@ Append to `code` as chunks come in; set `done` once the stream ends.
 
 Multiple chunks appended within the same animation frame coalesce into a single highlight pass. Already-rendered lines are diffed and left untouched in the DOM; only lines whose content actually changed are repainted, so a fast-scrolling response only touches its changed suffix (typically the last line). A multi-line construct left open mid-stream -- an unterminated template literal or block comment -- re-tokenizes the lines it spans once the closing delimiter arrives, with no special-casing needed: it falls out of re-highlighting the full buffer on every update.
 
+`code` doesn't have to only grow by appending -- an edit to already-streamed text (an LLM regenerating an earlier paragraph, say) is handled incrementally too, via `StreamSession#replace()` under the hood, instead of discarding the session and re-tokenizing the whole buffer from scratch.
+
 A blinking caret marks the end of output while `!done`; setting `done` hides it and performs one final full highlight, so the finished output matches what `Highlight` would render for the same code. `on:done` fires right after that final highlight. Customize the caret with the same `--caret-width`, `--caret-height`, `--caret-gap`, `--caret-color`, and `--caret-blink` variables as `Typewriter`.
 
 A blinking caret is a purely visual cue, so the root element also carries `aria-busy` while `!done`, and a visually-hidden, polite live region announces `doneText` (default `"Code finished streaming"`) once `done` flips to `true` -- screen reader users get the same "still streaming" / "finished" signal sighted users get from the caret. Set `doneText` to `""` to disable the announcement.
@@ -2293,6 +2295,7 @@ import { registry } from "svelte-highlight/registry";
 
 const session = registry.createSession("typescript");
 session.append(chunk); // repeat as chunks arrive
+session.replace(from, to, text); // patch an earlier range without restarting
 const snapshot = session.snapshot(); // JSON-serializable checkpoint
 const { value } = session.finish();
 ```

--- a/src/HighlightStream.svelte
+++ b/src/HighlightStream.svelte
@@ -177,6 +177,49 @@
       return;
     }
     ensureRegistered(language);
+    if (session && sessionLanguageName === language.name) {
+      // Not a pure append (an LLM "regenerate the last paragraph", say):
+      // patch just the changed middle region instead of restarting the
+      // whole session and losing every sealed chunk.
+      const common = Math.min(code.length, fedCode.length);
+      let prefixLen = 0;
+      while (
+        prefixLen < common &&
+        code.charCodeAt(prefixLen) === fedCode.charCodeAt(prefixLen)
+      ) {
+        prefixLen++;
+      }
+      let suffixLen = 0;
+      const maxSuffix = common - prefixLen;
+      while (
+        suffixLen < maxSuffix &&
+        code.charCodeAt(code.length - 1 - suffixLen) ===
+          fedCode.charCodeAt(fedCode.length - 1 - suffixLen)
+      ) {
+        suffixLen++;
+      }
+      session.replace(
+        prefixLen,
+        fedCode.length - suffixLen,
+        code.slice(prefixLen, code.length - suffixLen),
+      );
+      fedCode = code;
+      previewCache = undefined;
+
+      const events = session.events();
+      const result = extendLines(events, [], "");
+      finalizedPendingHtml = result.pendingHtml;
+      finalizedOpenScopes = result.openScopes;
+      renderedCommittedCount = events.length;
+      completedHtml.reset();
+      completedHtml.appendLines(result.completedLines);
+      sealedChunks = [];
+      sealedLineCount = 0;
+      unsealedLines = result.completedLines;
+      while (unsealedLines.length >= SEAL_CHUNK_LINES) sealChunk();
+      tailLines = unsealedLines;
+      return;
+    }
     session = registry.createSession(language.name);
     sessionLanguageName = language.name;
     fedCode = "";

--- a/src/engine.d.ts
+++ b/src/engine.d.ts
@@ -178,6 +178,12 @@ export interface StreamSession {
   /** Tokenizes text loaded via `createSession`'s `from.code` up to (not
    * including) the first lexeme starting at or past `stopAt`. */
   advance(stopAt: number): void;
+  /** Replaces `[from, to)` in the session's fed text with `text`, reusing
+   * unaffected tokenized regions where state reconverges (see
+   * `incremental-tokenize.js`). The resulting `events()` are always
+   * identical to a fresh session fed the resulting text from scratch,
+   * computed cheaper. Does not support replacing across a language change. */
+  replace(from: number, to: number, text: string): void;
   finish(options?: { canonicalize?: boolean }): HighlightResult;
   snapshot(): Snapshot;
   events(): ScopeEvent[];

--- a/src/engine.js
+++ b/src/engine.js
@@ -31,7 +31,13 @@
  * @typedef {import("./engine.d.ts").StreamSession} StreamSession
  * @typedef {import("./engine.d.ts").Registry} Registry
  * @typedef {import("./engine.d.ts").Snapshot} Snapshot
+ * @typedef {import("./incremental-tokenize.js").IncrementalParse} IncrementalParse
  */
+
+import {
+  parseIncremental,
+  reparseIncremental,
+} from "./incremental-tokenize.js";
 
 /**
  * A grammar plus its transitive `subLanguage` dependencies, as passed to
@@ -1311,7 +1317,7 @@ export function createRegistry() {
     createSession(language, { from } = {}) {
       const program = this.get(language);
       if (!program) throw new Error(`Unknown language: "${language}"`);
-      const tokenizer = new Tokenizer(this, program);
+      let tokenizer = new Tokenizer(this, program);
       const registry = this;
       let staged = "";
       let fed = from ? from.code : "";
@@ -1319,6 +1325,12 @@ export function createRegistry() {
         tokenizer.code = from.code;
         if (from.snapshot) tokenizer.restore(from.snapshot);
       }
+      /**
+       * Lazily built on the first `replace()` call; stays null for sessions
+       * that only ever `append()`/`advance()` so they pay no extra cost.
+       * @type {IncrementalParse | null}
+       */
+      let incremental = null;
       return {
         /** @param {string} text */
         append(text) {
@@ -1340,6 +1352,57 @@ export function createRegistry() {
          */
         advance(stopAt) {
           tokenizer.run(stopAt);
+        },
+        /**
+         * Replaces the fed text's `[from, to)` range with `text`, as if the
+         * session had been fed the resulting string from the start.
+         * Built on `incremental-tokenize.js`'s diff-and-resume re-parsing: an
+         * `IncrementalParse` record is built once (lazily, on first call)
+         * and then re-parsed only for the affected region on each call,
+         * reusing the unaffected suffix when tokenizer state reconverges.
+         * Does not support a `replace()` across a language change; create a
+         * new session for that instead.
+         * @param {number} from
+         * @param {number} to
+         * @param {string} text
+         */
+        replace(from, to, text) {
+          if (!incremental) {
+            incremental = parseIncremental(
+              /** @type {Registry} */ (registry),
+              language,
+              fed,
+            );
+          }
+          const newCode = fed.slice(0, from) + text + fed.slice(to);
+          incremental = reparseIncremental(
+            /** @type {Registry} */ (registry),
+            language,
+            incremental,
+            newCode,
+          );
+          fed = newCode;
+          const lastCheckpoint = /** @type {Snapshot} */ (
+            incremental.checkpoints.at(-1)
+          );
+          tokenizer = new Tokenizer(registry, program);
+          tokenizer.code = fed.slice(0, lastCheckpoint.pos);
+          tokenizer.restore(lastCheckpoint);
+          // `lastCheckpoint` is taken just *before* `parseIncremental`'s
+          // internal `finish()` - by design (see `run`'s `stopAt` doc
+          // comment), it defers any lexeme starting exactly at the
+          // checkpoint's position so a later `advance()` could still see
+          // more text. `incremental.events` already has that lexeme
+          // resolved (by the `finish()` that produced it), so restore only
+          // the events up to the checkpoint's own count, then run the live
+          // tokenizer once - exactly what `append()` does for newly fed
+          // complete lines - to resolve it the same way.
+          tokenizer.events = incremental.events.slice(
+            0,
+            lastCheckpoint.eventCount,
+          );
+          tokenizer.run();
+          staged = fed.slice(tokenizer.pos);
         },
         /**
          * Multi-line lookahead (e.g. ruby heredocs) may need the full text

--- a/tests/e2e/HighlightStream.regenerate.test.svelte
+++ b/tests/e2e/HighlightStream.regenerate.test.svelte
@@ -1,0 +1,66 @@
+<script>
+  import Highlight, { HighlightStream } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  let code = "";
+  let highlighted = "";
+  let referenceHighlighted = "";
+
+  function appendChunk1() {
+    code += "const a = 1;\n";
+  }
+  function appendChunk2() {
+    code += "const b = 2;\n";
+  }
+  function appendChunk3() {
+    code += "const c = 3;\n";
+  }
+
+  // Simulates an LLM "regenerate the last paragraph": edits a line that
+  // isn't at the current end, not just appends - the non-append path that
+  // forces HighlightStream to patch the session with `replace()` instead of
+  // restarting it.
+  function regenerateEarlierLine() {
+    code = code.replace("const b = 2;", "const b = 222;");
+  }
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<button type="button" data-testid="append-1" on:click={appendChunk1}>
+  Append 1
+</button>
+<button type="button" data-testid="append-2" on:click={appendChunk2}>
+  Append 2
+</button>
+<button type="button" data-testid="append-3" on:click={appendChunk3}>
+  Append 3
+</button>
+<button type="button" data-testid="regenerate" on:click={regenerateEarlierLine}>
+  Regenerate earlier line
+</button>
+
+<HighlightStream
+  language={javascript}
+  {code}
+  data-testid="stream"
+  on:highlight={(e) => {
+    highlighted = e.detail.highlighted;
+  }}
+/>
+
+<pre data-testid="highlighted-snapshot" style="display:none">{highlighted}</pre>
+<pre
+  data-testid="reference-highlighted-snapshot"
+  style="display:none"
+>{referenceHighlighted}</pre>
+
+<Highlight
+  language={javascript}
+  {code}
+  data-testid="reference"
+  on:highlight={(e) => {
+    referenceHighlighted = e.detail.highlighted;
+  }}
+/>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -29,6 +29,7 @@ import HighlightEditableCssHighlights from "./HighlightEditable.cssHighlights.te
 import HighlightEditableLanguageSwap from "./HighlightEditable.languageSwap.test.svelte";
 import HighlightEditable from "./HighlightEditable.test.svelte";
 import HighlightStreamMidLineHighlight from "./HighlightStream.midLineHighlight.test.svelte";
+import HighlightStreamRegenerate from "./HighlightStream.regenerate.test.svelte";
 import HighlightStreamSealing from "./HighlightStream.sealing.test.svelte";
 import HighlightStreamStability from "./HighlightStream.stability.test.svelte";
 import HighlightStreamTemplateLiteral from "./HighlightStream.templateLiteral.test.svelte";
@@ -1612,6 +1613,33 @@ test("HighlightStream - marks aria-busy while streaming and announces completion
   await page.getByTestId("finish").click();
   await expect(stream).toHaveAttribute("aria-busy", "false");
   await expect(status).toHaveText("Code finished streaming");
+});
+
+test("HighlightStream - a non-append edit reuses the session instead of restarting", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamRegenerate);
+
+  await page.getByTestId("append-1").click();
+  await page.getByTestId("append-2").click();
+  await page.getByTestId("append-3").click();
+  await expect(
+    page.getByTestId("stream").locator("[data-line='2']"),
+  ).toBeVisible();
+
+  await page.getByTestId("regenerate").click();
+  await expect(
+    page.getByTestId("stream").locator("[data-line='1']"),
+  ).toHaveText("const b = 222;");
+
+  const streamedHighlighted = await page
+    .getByTestId("highlighted-snapshot")
+    .textContent();
+  const referenceHighlighted = await page
+    .getByTestId("reference-highlighted-snapshot")
+    .textContent();
+  expect(streamedHighlighted).toBe(referenceHighlighted);
 });
 
 test("HighlightStream sealing - text content stays byte-correct across sealed chunk boundaries", async ({

--- a/tests/stream-session-replace.test.ts
+++ b/tests/stream-session-replace.test.ts
@@ -1,0 +1,145 @@
+import { createRegistry } from "../src/engine.js";
+import { CHECKPOINT_INTERVAL } from "../src/incremental-tokenize.js";
+import javascript from "../src/languages/javascript.js";
+import ruby from "../src/languages/ruby.js";
+
+const registry = createRegistry();
+registry.register(javascript.register);
+registry.register(ruby.register);
+
+/** Asserts a session's current state matches a one-shot parse of `finalCode`. */
+function expectMatchesOneShot(
+  session: ReturnType<typeof registry.createSession>,
+  finalCode: string,
+  language: string,
+) {
+  const oneShot = registry.highlight(finalCode, { language });
+  expect(session.events()).toEqual(oneShot.events);
+  expect(session.finish({ canonicalize: true }).value).toBe(oneShot.value);
+}
+
+describe("StreamSession#replace", () => {
+  it("mid-document replace with no open construct", () => {
+    const code = "const a = 1;\nconst b = 2;\nconst c = 3;\n";
+    const session = registry.createSession("javascript");
+    session.append(code);
+
+    const from = code.indexOf("const b = 2;");
+    const to = from + "const b = 2;".length;
+    const finalCode = `${code.slice(0, from)}const b = 22;${code.slice(to)}`;
+    session.replace(from, to, "const b = 22;");
+
+    expectMatchesOneShot(session, finalCode, "javascript");
+  });
+
+  it("replace as the session's very first edit (code loaded via `from`, not append)", () => {
+    const code = "const a = 1;\nconst b = 2;\n";
+    const session = registry.createSession("javascript", { from: { code } });
+
+    const finalCode = code.replace("const a = 1;", "const a = 100;");
+    session.replace(0, "const a = 1;".length, "const a = 100;");
+
+    expectMatchesOneShot(session, finalCode, "javascript");
+  });
+
+  it("replace spanning into a still-open multi-line template literal (reconverges)", () => {
+    const code = `const msg = \`line one
+line two
+line three\`;
+const after = 1;
+`;
+    const session = registry.createSession("javascript");
+    session.append(code);
+
+    const from = code.indexOf("line one");
+    const to = from + "line one".length;
+    const finalCode = `${code.slice(0, from)}line ONE${code.slice(to)}`;
+    session.replace(from, to, "line ONE");
+
+    expectMatchesOneShot(session, finalCode, "javascript");
+  });
+
+  it("replace spanning into a still-open ruby heredoc (full-reparse fallback)", () => {
+    const code = `def render
+  <<~HTML
+    <p>#{@title}</p>
+  HTML
+end
+`;
+    const session = registry.createSession("ruby");
+    session.append(code);
+
+    const from = code.indexOf("<<~HTML");
+    const to = from + "<<~HTML".length;
+    const finalCode = `${code.slice(0, from)}<<~HTML_EDITED${code.slice(to)}`;
+    session.replace(from, to, "<<~HTML_EDITED");
+
+    // A heredoc's terminator needs lookahead past what's tokenized so far,
+    // same pre-existing limitation the plain append()-based session has
+    // (see "ruby heredocs ... canonicalize on finish" in
+    // engine-streaming.test.ts): session.events() mid-stream doesn't yet
+    // reflect text past the still-open heredoc, only the canonical
+    // finish() pass does.
+    const oneShot = registry.highlight(finalCode, { language: "ruby" });
+    expect(session.finish({ canonicalize: true }).value).toBe(oneShot.value);
+  });
+
+  it("two replace() calls in a row", () => {
+    const code = "const a = 1;\nconst b = 2;\nconst c = 3;\n";
+    const session = registry.createSession("javascript");
+    session.append(code);
+
+    session.replace(
+      code.indexOf("const a = 1;"),
+      code.indexOf("const a = 1;") + "const a = 1;".length,
+      "const a = 100;",
+    );
+    let finalCode = code.replace("const a = 1;", "const a = 100;");
+
+    session.replace(
+      finalCode.indexOf("const c = 3;"),
+      finalCode.indexOf("const c = 3;") + "const c = 3;".length,
+      "const c = 300;",
+    );
+    finalCode = finalCode.replace("const c = 3;", "const c = 300;");
+
+    expectMatchesOneShot(session, finalCode, "javascript");
+  });
+
+  it("replace() followed by further append()", () => {
+    const code = "const a = 1;\nconst b = 2;\n";
+    const session = registry.createSession("javascript");
+    session.append(code);
+
+    session.replace(
+      code.indexOf("const a = 1;"),
+      code.indexOf("const a = 1;") + "const a = 1;".length,
+      "const a = 100;",
+    );
+    const afterReplace = code.replace("const a = 1;", "const a = 100;");
+
+    const more = "const d = 4;\n";
+    session.append(more);
+    const finalCode = afterReplace + more;
+
+    expectMatchesOneShot(session, finalCode, "javascript");
+  });
+
+  it("replace() landing exactly on a CHECKPOINT_INTERVAL boundary", () => {
+    let code = "";
+    for (let i = 0; i < CHECKPOINT_INTERVAL * 2; i++) {
+      code += `const v${i} = ${i};\n`;
+    }
+    const session = registry.createSession("javascript");
+    session.append(code);
+
+    const target = `const v${CHECKPOINT_INTERVAL} = ${CHECKPOINT_INTERVAL};`;
+    const from = code.indexOf(target);
+    const to = from + target.length;
+    const replacement = `const v${CHECKPOINT_INTERVAL} = 999;`;
+    const finalCode = `${code.slice(0, from)}${replacement}${code.slice(to)}`;
+    session.replace(from, to, replacement);
+
+    expectMatchesOneShot(session, finalCode, "javascript");
+  });
+});


### PR DESCRIPTION
Adds a replace(from, to, text) method to StreamSession so headless
streaming consumers (not just HighlightEditable) can patch an earlier
range without discarding the whole session. HighlightStream now uses
it for any non-append code change, reusing sealed chunks and
incremental tokenization instead of restarting from scratch.