### PR TITLE
test(styles): assert WCAG contrast floors for custom style pairs

### DIFF
--- a/README.md
+++ b/README.md
@@ -292,7 +292,7 @@ bun scripts/import-textmate-theme.ts ./night-owl-color-theme.json ./night-owl.pa
 
 ## Styling
 
-Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility. Legacy styles are stable and will not be removed. One concrete reason to pick this path over `ThemePalette`: `base.css` assumes the default `hljs-` class prefix, so projects using a custom `classPrefix` should stay here.
+Import styles from `svelte-highlight/styles`. See [SUPPORTED_STYLES.md](SUPPORTED_STYLES.md) for a list of supported styles. For new projects, prefer [Theming](#theming) above — this is the original, string-based theming path, kept fully supported for backward compatibility. Legacy styles are stable and will not be removed. One concrete reason to pick this path over `ThemePalette`: `base.css` assumes the default `hljs-` class prefix, so projects using a custom `classPrefix` should stay here. 45 of the styles (90 dark/light files) are original pairs authored by svelte-highlight rather than ported from highlight.js, marked as custom in the gallery and in `SUPPORTED_STYLES.md`.
 
 There are two ways to apply `highlight.js` styles.
 

--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ This renders SSR-identical output — no `<svelte:head>`, no `<style>` tag, just
 **Dual light/dark via [`light-dark()`](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/light-dark):**
 
 ```svelte
-<HighlightStyle light={atomOneLight} dark={atomOneDark} mode="auto">
+<HighlightStyle light={cyanotypeLight} dark={cyanotypeDark} mode="auto">
   <Highlight language={typescript} {code} />
 </HighlightStyle>
 ```

--- a/scripts/build-styles.ts
+++ b/scripts/build-styles.ts
@@ -13,10 +13,23 @@ import {
 } from "./utils/regexes.ts";
 import { scopeStylesheet } from "./utils/scope-stylesheet.ts";
 import { buildGapFillProposals } from "./utils/similarity-map.ts";
+import { colorSchemeFor } from "./utils/theme-ir.ts";
 import { toCamelCase } from "./utils/to-camel-case.ts";
 import { writeTo } from "./utils/write-to.ts";
 
 export type ModuleNames = Array<{ name: string; moduleName: string }>;
+
+type StyleEntry = {
+  name: string;
+  moduleName: string;
+  description?: string;
+  custom?: boolean;
+  colorScheme: "light" | "dark";
+};
+
+const HLJS_BASE_RULE = /\n\.hljs\s*\{([^}]*)\}/;
+const BACKGROUND_DECLARATION = /background(?:-color)?:\s*([^;\n]+)/;
+const DESCRIPTION_COMMENT = /Description:\s*(.+)/;
 
 /** camelCase, prefixed with `_` when it can't be a bare identifier (`1c`, `default`). */
 function toStyleModuleName(name: string) {
@@ -39,7 +52,6 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
 
   let scopedStyles = "";
   const seenNames = new Set<string>();
-  let styles: ModuleNames = [];
 
   const glob = new Glob("**/*");
 
@@ -64,7 +76,6 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
       }
 
       seenNames.add(name);
-      styles.push({ name, moduleName });
       cssFiles.push({ file, absPath, name, dir, moduleName });
     }
   }
@@ -85,7 +96,6 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
       }
 
       seenNames.add(name);
-      styles.push({ name, moduleName });
       cssFiles.push({
         file,
         absPath,
@@ -145,6 +155,14 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
           ? { name, deadDeclarationsRemoved, gapsFilled }
           : null;
 
+      const bgValue = HLJS_BASE_RULE.exec(content)?.[1]?.match(
+        BACKGROUND_DECLARATION,
+      )?.[1];
+      const colorScheme = colorSchemeFor(bgValue?.trim());
+      const description = custom
+        ? DESCRIPTION_COMMENT.exec(content)?.[1]?.trim()
+        : undefined;
+
       return {
         writes: [
           writeTo(`src/styles/${name}.js`, exportee),
@@ -162,6 +180,13 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
           css: cssMinified,
           ...(custom ? { custom: true } : {}),
         },
+        styleEntry: {
+          name,
+          moduleName,
+          colorScheme,
+          ...(custom ? { custom: true } : {}),
+          ...(description ? { description } : {}),
+        } satisfies StyleEntry,
       };
     }),
   );
@@ -173,15 +198,23 @@ export async function buildStyles(): Promise<{ themeInputs: ThemeInput[] }> {
     gapsFilled: number;
   }> = [];
   const themeInputs: ThemeInput[] = [];
-  for (const { writes, scopedStyle, augmentation, themeInput } of fileWrites) {
+  const styles: StyleEntry[] = [];
+  for (const {
+    writes,
+    scopedStyle,
+    augmentation,
+    themeInput,
+    styleEntry,
+  } of fileWrites) {
     allWrites.push(...writes);
     scopedStyles += scopedStyle;
     if (augmentation) augmentations.push(augmentation);
     themeInputs.push(themeInput);
+    styles.push(styleEntry);
   }
   augmentations.sort((a, b) => a.name.localeCompare(b.name));
 
-  styles = styles.sort((a, b) => a.name.localeCompare(b.name));
+  styles.sort((a, b) => a.name.localeCompare(b.name));
 
   const customNames = new Set(
     cssFiles.filter((file) => file.custom).map((file) => file.name),

--- a/scripts/custom-styles/blacklight-dark.css
+++ b/scripts/custom-styles/blacklight-dark.css
@@ -18,7 +18,7 @@ code.hljs {
 }
 .hljs-comment,
 .hljs-quote {
-  color: #6a5088;
+  color: #745895;
   font-style: italic;
 }
 .hljs-doctag,

--- a/scripts/custom-styles/cyanotype-light.css
+++ b/scripts/custom-styles/cyanotype-light.css
@@ -18,7 +18,7 @@ code.hljs {
 }
 .hljs-comment,
 .hljs-quote {
-  color: #7a8a78;
+  color: #707f6e;
   font-style: italic;
 }
 .hljs-doctag,

--- a/scripts/custom-styles/dusk-dark.css
+++ b/scripts/custom-styles/dusk-dark.css
@@ -29,7 +29,7 @@ code.hljs {
 }
 .hljs-comment,
 .hljs-quote {
-  color: #9488ac;
+  color: #aca3bf;
   font-style: italic;
 }
 .hljs-doctag,

--- a/scripts/custom-styles/peat-dark.css
+++ b/scripts/custom-styles/peat-dark.css
@@ -18,7 +18,7 @@ code.hljs {
 }
 .hljs-comment,
 .hljs-quote {
-  color: #6a5a48;
+  color: #796752;
   font-style: italic;
 }
 .hljs-doctag,

--- a/scripts/custom-styles/thermal-dark.css
+++ b/scripts/custom-styles/thermal-dark.css
@@ -18,7 +18,7 @@ code.hljs {
 }
 .hljs-comment,
 .hljs-quote {
-  color: #5a4878;
+  color: #705995;
   font-style: italic;
 }
 .hljs-doctag,

--- a/scripts/custom-styles/wet-plate-dark.css
+++ b/scripts/custom-styles/wet-plate-dark.css
@@ -18,7 +18,7 @@ code.hljs {
 }
 .hljs-comment,
 .hljs-quote {
-  color: #5a5048;
+  color: #6e6258;
   font-style: italic;
 }
 .hljs-doctag,

--- a/tests/custom-styles.test.ts
+++ b/tests/custom-styles.test.ts
@@ -67,40 +67,43 @@ test("custom styles and themes are exported after build", async () => {
 
 describe("WCAG contrast", () => {
   function relativeLuminance(hex: string): number {
-    const [r, g, b] = [1, 3, 5].map(
-      (i) => parseInt(hex.slice(i, i + 2), 16) / 255,
-    );
+    const r = Number.parseInt(hex.slice(1, 3), 16) / 255;
+    const g = Number.parseInt(hex.slice(3, 5), 16) / 255;
+    const b = Number.parseInt(hex.slice(5, 7), 16) / 255;
     const lin = (c: number) =>
       c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
     return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
   }
 
   function contrastRatio(hexA: string, hexB: string): number {
-    const [l1, l2] = [relativeLuminance(hexA), relativeLuminance(hexB)].sort(
-      (a, b) => b - a,
-    );
+    const lA = relativeLuminance(hexA);
+    const lB = relativeLuminance(hexB);
+    const l1 = Math.max(lA, lB);
+    const l2 = Math.min(lA, lB);
     return (l1 + 0.05) / (l2 + 0.05);
   }
 
   test("custom style base palettes and comment colors clear WCAG contrast floors", async () => {
     const contents = await Promise.all(
-      customFiles.map(async (file) => ({
-        file,
-        css: await Bun.file(path.join(CUSTOM_DIR, file)).text(),
-      })),
+      customFiles.map((file) => Bun.file(path.join(CUSTOM_DIR, file)).text()),
     );
 
-    for (const { file, css } of contents) {
+    for (const css of contents) {
       const base = css.match(
         /\.hljs \{\s*color: (#[0-9a-fA-F]{6});\s*background: (#[0-9a-fA-F]{6});/,
       );
       const comment = css.match(
         /\.hljs-comment,\n\.hljs-quote \{\s*color: (#[0-9a-fA-F]{6});/,
       );
-      expect(base).not.toBeNull();
-      expect(comment).not.toBeNull();
-      const [, fg, bg] = base as RegExpMatchArray;
-      const [, commentColor] = comment as RegExpMatchArray;
+      if (!base) throw new Error("expected a .hljs base color/background rule");
+      if (!comment) throw new Error("expected a .hljs-comment color rule");
+      const [, fg, bg] = base;
+      const [, commentColor] = comment;
+      if (!fg || !bg || !commentColor) {
+        throw new Error(
+          "expected .hljs/.hljs-comment rules to capture hex colors",
+        );
+      }
 
       // WCAG AA body text floor; already passes for all 90 files.
       expect(contrastRatio(fg, bg)).toBeGreaterThanOrEqual(4.5);

--- a/tests/custom-styles.test.ts
+++ b/tests/custom-styles.test.ts
@@ -64,3 +64,49 @@ test("custom styles and themes are exported after build", async () => {
     if (name.endsWith("-light")) expect(palette.colorScheme).toBe("light");
   }
 });
+
+describe("WCAG contrast", () => {
+  function relativeLuminance(hex: string): number {
+    const [r, g, b] = [1, 3, 5].map(
+      (i) => parseInt(hex.slice(i, i + 2), 16) / 255,
+    );
+    const lin = (c: number) =>
+      c <= 0.04045 ? c / 12.92 : ((c + 0.055) / 1.055) ** 2.4;
+    return 0.2126 * lin(r) + 0.7152 * lin(g) + 0.0722 * lin(b);
+  }
+
+  function contrastRatio(hexA: string, hexB: string): number {
+    const [l1, l2] = [relativeLuminance(hexA), relativeLuminance(hexB)].sort(
+      (a, b) => b - a,
+    );
+    return (l1 + 0.05) / (l2 + 0.05);
+  }
+
+  test("custom style base palettes and comment colors clear WCAG contrast floors", async () => {
+    const contents = await Promise.all(
+      customFiles.map(async (file) => ({
+        file,
+        css: await Bun.file(path.join(CUSTOM_DIR, file)).text(),
+      })),
+    );
+
+    for (const { file, css } of contents) {
+      const base = css.match(
+        /\.hljs \{\s*color: (#[0-9a-fA-F]{6});\s*background: (#[0-9a-fA-F]{6});/,
+      );
+      const comment = css.match(
+        /\.hljs-comment,\n\.hljs-quote \{\s*color: (#[0-9a-fA-F]{6});/,
+      );
+      expect(base).not.toBeNull();
+      expect(comment).not.toBeNull();
+      const [, fg, bg] = base as RegExpMatchArray;
+      const [, commentColor] = comment as RegExpMatchArray;
+
+      // WCAG AA body text floor; already passes for all 90 files.
+      expect(contrastRatio(fg, bg)).toBeGreaterThanOrEqual(4.5);
+      // Comments are secondary/decorative text, so held to WCAG's large-text
+      // floor rather than body text; today's failures are fixed in Step 2.
+      expect(contrastRatio(commentColor, bg)).toBeGreaterThanOrEqual(3);
+    }
+  });
+});

--- a/www/components/DualThemePreview.svelte
+++ b/www/components/DualThemePreview.svelte
@@ -2,8 +2,8 @@
   import { Toggle } from "carbon-components-svelte";
   import Highlight, { HighlightStyle } from "svelte-highlight";
   import typescript from "svelte-highlight/languages/typescript";
-  import github from "svelte-highlight/styles/github";
-  import githubDark from "svelte-highlight/styles/github-dark";
+  import cyanotypeDark from "svelte-highlight/themes/cyanotype-dark";
+  import cyanotypeLight from "svelte-highlight/themes/cyanotype-light";
 
   const code = `interface User {
   id: number;
@@ -67,7 +67,11 @@ const greet = (user: User): string => {
 </p>
 
 <div data-theme={dataTheme}>
-  <HighlightStyle light={github} dark={githubDark} mode={resolvedMode}>
+  <HighlightStyle
+    light={cyanotypeLight}
+    dark={cyanotypeDark}
+    mode={resolvedMode}
+  >
     <Highlight language={typescript} {code} />
   </HighlightStyle>
 </div>

--- a/www/components/globals/Styles.svelte
+++ b/www/components/globals/Styles.svelte
@@ -15,6 +15,7 @@
   } from "carbon-components-svelte";
 
   let useCdnImport = false;
+  let customOnly = false;
 </script>
 
 <ListSearch
@@ -27,6 +28,15 @@
   let:filteredIds
 >
   {@const useInjectedStyles = currentLabel === "Injected styles"}
+  <Row>
+    <Column xlg={3} lg={12}>
+      <Toggle
+        size="sm"
+        labelText="Custom styles only"
+        bind:toggled={customOnly}
+      />
+    </Column>
+  </Row>
   {#if !useInjectedStyles}
     <Row>
       <Column xlg={3} lg={12}>
@@ -53,7 +63,10 @@
         <StructuredListBody>
           {#each styles as style (style.name)}
             <StructuredListRow
-              class={filteredIds.has(style.name) ? "" : "hidden"}
+              class={filteredIds.has(style.name) &&
+              (!customOnly || style.custom)
+                ? ""
+                : "hidden"}
               style="content-visibility: auto; contain-intrinsic-size: 0 360px;"
             >
               <StructuredListCell>
@@ -66,6 +79,13 @@
                   <div class="label-01 mb-3">Module name</div>
                   <CodeSnippet type="inline" code={style.moduleName} />
                 </div>
+
+                {#if style.description}
+                  <div class="mb-5">
+                    <div class="label-01 mb-3">Description</div>
+                    {style.description}
+                  </div>
+                {/if}
               </StructuredListCell>
               <StructuredListCell>
                 <ScopedStyle {...style} {useInjectedStyles} {useCdnImport} />


### PR DESCRIPTION
Adds a WCAG contrast floor to the custom style test suite, fixes the
six pairs that fell below it, and threads description/custom/
colorScheme metadata through the styles build so the gallery can show
descriptions and filter to custom pairs. Also swaps the light-dark()
demo (README and DualThemePreview.svelte) to a genuine custom
light/dark pair instead of two unrelated highlight.js themes.