### PR TITLE
feat(components): add `MarkdownStream` for multi-fence chat output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1846,7 +1846,89 @@ Per-chunk work is O(tail), not O(stream length so far): finished output is seale
 {/each}
 ```
 
-Every segment's `id` is stable across both `append` (growing the buffer) and a full `set` (a regenerated buffer, keyed by common prefix) for everything before the first change, so the keyed `{#each}` never re-mounts a fence's `HighlightStream` just because more text arrived elsewhere in the document -- only the segment that actually changed gets a new instance. A `MarkdownStream` component that wraps this pattern is a separate deliverable; `createFenceSplitter` is the headless primitive underneath it.
+Every segment's `id` is stable across both `append` (growing the buffer) and a full `set` (a regenerated buffer, keyed by common prefix) for everything before the first change, so the keyed `{#each}` never re-mounts a fence's `HighlightStream` just because more text arrived elsewhere in the document -- only the segment that actually changed gets a new instance.
+
+### `MarkdownStream`
+
+`MarkdownStream` wraps the pattern above: pass it a growing Markdown `text` buffer and it drives one `HighlightStream` per fence for you, keyed by the splitter's stable ids. Prose renders as plain text by default -- it's not a Markdown renderer, just a router for fenced code.
+
+```svelte
+<script>
+  import { MarkdownStream } from "svelte-highlight";
+  import github from "svelte-highlight/styles/github";
+
+  let text = "";
+  let done = false;
+
+  // Wire this up to your streaming source (fetch, WebSocket, SSE, ...).
+  async function stream() {
+    for (const chunk of chunks) {
+      text += chunk;
+      await new Promise((r) => setTimeout(r, 30));
+    }
+    done = true;
+  }
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<MarkdownStream {text} {done} />
+```
+
+`done` is forwarded to every fence's `HighlightStream` as `done || !segment.open`, so a trailing fence still open when the overall stream ends is treated as closed. The caret only ever renders on the last open fence, and `doneText`'s completion announcement fires once, from the last fence, rather than once per fence.
+
+Override the `text` slot to render real Markdown prose (headings, lists, inline code) with a library of your choice, leaving fences to `MarkdownStream`:
+
+```svelte
+<script>
+  import { MarkdownStream } from "svelte-highlight";
+  import { renderInlineMarkdown } from "./your-markdown-renderer.js";
+</script>
+
+<MarkdownStream {text} {done}>
+  <div slot="text" let:segment>{@html renderInlineMarkdown(segment.text)}</div>
+</MarkdownStream>
+```
+
+By default, `resolveLanguage` dynamically imports one grammar per language seen via `loadLanguage`, falling back to plaintext while loading and for an unrecognized fence language. Pass your own `resolveLanguage` to restrict resolution to a fixed set of languages -- for example, everything else falls back to plaintext instead of fetching an arbitrary grammar chunk:
+
+```svelte
+<script>
+  import { MarkdownStream, loadLanguage } from "svelte-highlight";
+
+  const ALLOWED = new Set(["typescript", "javascript", "bash", "json"]);
+
+  function resolveLanguage(lang) {
+    return lang && ALLOWED.has(lang) ? loadLanguage(lang) : undefined;
+  }
+</script>
+
+<MarkdownStream {text} {done} {resolveLanguage} />
+```
+
+That still dynamically imports each allowed language's grammar on first use. For an app that wants no dynamic chunks at all -- everything bundled up front, same tradeoff as [Loading a language by name](#loading-a-language-by-name) -- map the allowlist to statically imported grammars instead:
+
+```svelte
+<script>
+  import { MarkdownStream } from "svelte-highlight";
+  import bash from "svelte-highlight/languages/bash";
+  import javascript from "svelte-highlight/languages/javascript";
+  import json from "svelte-highlight/languages/json";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const GRAMMARS = { typescript, javascript, bash, json };
+
+  function resolveLanguage(lang) {
+    return lang ? GRAMMARS[lang] : undefined;
+  }
+</script>
+
+<MarkdownStream {text} {done} {resolveLanguage} />
+```
+
+See [Code-splitting](#code-splitting) for the tradeoffs between a static import (bundled up front, no request-time latency) and `loadLanguage` (smaller initial bundle, one chunk fetched per language actually seen).
 
 ## Large documents
 
@@ -2421,6 +2503,44 @@ Use `bind:this`, then call `scrollToLine(line)` -- works in both `virtualize` an
   on:highlight={(e) => console.log(e.detail.highlighted)}
   on:done={() => console.log("stream finished")}
 />
+```
+
+### `MarkdownStream`
+
+#### Props
+
+| Name            | Type                                                                     | Default value                       |
+| :-------------- | :------------------------------------------------------------------------ | :----------------------------------- |
+| text            | `string`                                                                   | `""`                                  |
+| done            | `boolean`                                                                  | `false`                               |
+| resolveLanguage | `(lang: string \| undefined, segment: FenceSegment) => LanguageType \| Promise<LanguageType> \| undefined` | resolves via `loadLanguage`, falling back to plaintext |
+| caret           | `boolean`                                                                  | `true`                                |
+| autoScroll      | `boolean`                                                                  | `true`                                |
+| doneText        | `string`                                                                   | `"Code finished streaming"`           |
+
+`$$restProps` are forwarded to the top-level `div` element. `resolveLanguage` results are cached per canonical language name for the component's lifetime. `doneText` is announced once, by the last fence only, once `done` becomes `true`; set it to `""` to disable the announcement.
+
+#### Slots
+
+| Name | Props                | Fallback                                                          |
+| :--- | :-------------------- | :----------------------------------------------------------------- |
+| text | `segment`             | `<div class="shl-md-text">{segment.text}</div>`                    |
+| fence | `segment`, `language` | `<HighlightStream code={segment.code} {language} done={done \|\| !segment.open} caret={...} autoScroll={autoScroll} doneText={...} />` |
+
+#### Dispatched Events
+
+- **on:fence**: fired once, the first time a fence segment appears, with `{ id, lang }`
+- **on:done**: fired once when `done` becomes `true`
+
+#### CSS Variables
+
+| Variable                | Description                          | Default value |
+| :----------------------- | :------------------------------------ | :------------- |
+| --md-gap                 | Gap between prose and fence segments  | `1em`           |
+| --md-text-white-space    | `white-space` of the default prose block | `pre-wrap`   |
+
+```svelte
+<MarkdownStream {text} {done} on:fence={(e) => console.log(e.detail.lang)} />
 ```
 
 ### `HighlightVirtual`

--- a/src/MarkdownStream.svelte
+++ b/src/MarkdownStream.svelte
@@ -1,0 +1,202 @@
+<script>
+  /**
+   * Growing Markdown buffer. On change, `splitter.append` is used when the
+   * new value starts with the previous one; otherwise the whole buffer is
+   * replaced via `splitter.set`.
+   * @type {string}
+   */
+  export let text = "";
+
+  /**
+   * Stream finished: forwarded to every fence's `HighlightStream` as
+   * `done || !segment.open`.
+   * @type {boolean}
+   */
+  export let done = false;
+
+  /**
+   * Resolves a fence's language. Cached per canonical name for the
+   * component's lifetime.
+   * @type {(lang: string | undefined, segment: import("./fence.d.ts").FenceSegment) => import("./languages").LanguageType<string> | Promise<import("./languages").LanguageType<string>> | undefined}
+   */
+  export let resolveLanguage = defaultResolveLanguage;
+
+  /** @type {boolean} */
+  export let caret = true;
+
+  /** @type {boolean} */
+  export let autoScroll = true;
+
+  /**
+   * Announced once, by the last fence only, when `done` becomes `true`.
+   * @type {string}
+   */
+  export let doneText = "Code finished streaming";
+
+  import { createEventDispatcher } from "svelte";
+  import { createFenceSplitter } from "./fence.js";
+  import HighlightStream from "./HighlightStream.svelte";
+  import plaintext from "./languages/plaintext.js";
+  import { loadLanguage } from "./load-language.js";
+
+  /**
+   * @param {string | undefined} lang
+   * @returns {Promise<import("./languages").LanguageType<string> | undefined>}
+   */
+  async function defaultResolveLanguage(lang) {
+    if (!lang) return undefined;
+    try {
+      return await loadLanguage(
+        /** @type {import("./languages").LanguageName} */ (lang),
+      );
+    } catch {
+      return undefined;
+    }
+  }
+
+  const dispatch = createEventDispatcher();
+  const splitter = createFenceSplitter();
+
+  let previousText = "";
+  /** @type {readonly import("./fence.d.ts").MarkdownSegment[]} */
+  let segments = splitter.segments();
+
+  // Fence ids already reported via the `fence` event -- an id is only ever
+  // seen once, even if the splitter later rebuilds the segment object (a
+  // regenerated buffer keeps the id per the splitter's contract).
+  /** @type {Set<number>} */
+  const seenFenceIds = new Set();
+
+  // Resolved languages by canonical name, plus in-flight names so a second
+  // fence sharing a language doesn't re-invoke `resolveLanguage`.
+  /** @type {Record<string, import("./languages").LanguageType<string>>} */
+  let resolvedLanguages = {};
+  /** @type {Set<string>} */
+  const pendingLanguages = new Set();
+
+  /** @param {string | undefined} lang */
+  function cacheKey(lang) {
+    return lang === undefined ? "\0" : lang;
+  }
+
+  /** @param {import("./fence.d.ts").FenceSegment} segment */
+  function ensureLanguage(segment) {
+    const key = cacheKey(segment.lang);
+    if (pendingLanguages.has(key)) return;
+    pendingLanguages.add(key);
+    Promise.resolve(resolveLanguage(segment.lang, segment))
+      .then((language) => {
+        resolvedLanguages = {
+          ...resolvedLanguages,
+          [key]: language ?? plaintext,
+        };
+      })
+      .catch(() => {
+        resolvedLanguages = { ...resolvedLanguages, [key]: plaintext };
+      });
+  }
+
+  /**
+   * `languages` is passed in so the template tracks the cache. A helper
+   * that only closed over `resolvedLanguages` would not re-run when a
+   * grammar finished loading (Svelte 3/4, and Svelte 5's `untrack` of
+   * helper bodies).
+   * @param {Record<string, import("./languages").LanguageType<string>>} languages
+   * @param {import("./fence.d.ts").FenceSegment} segment
+   */
+  function languageFor(languages, segment) {
+    return languages[cacheKey(segment.lang)] ?? plaintext;
+  }
+
+  // Feed the splitter, then re-read its (identity-stable) segment list.
+  $: {
+    if (text !== previousText) {
+      if (text.startsWith(previousText)) {
+        splitter.append(text.slice(previousText.length));
+      } else {
+        splitter.set(text);
+      }
+      previousText = text;
+      segments = splitter.segments();
+    }
+  }
+
+  $: for (const segment of segments) {
+    if (segment.kind !== "fence") continue;
+    if (!seenFenceIds.has(segment.id)) {
+      seenFenceIds.add(segment.id);
+      dispatch("fence", { id: segment.id, lang: segment.lang });
+    }
+    ensureLanguage(segment);
+  }
+
+  let doneDispatched = false;
+  $: if (done) {
+    if (!doneDispatched) {
+      doneDispatched = true;
+      dispatch("done");
+    }
+  } else {
+    doneDispatched = false;
+  }
+
+  // Only the trailing segment can be an open fence (the parser is still
+  // inside it), so caret placement never needs to scan the whole document.
+  $: lastSegment = segments[segments.length - 1];
+  $: lastOpenFenceId =
+    lastSegment !== undefined &&
+    lastSegment.kind === "fence" &&
+    lastSegment.open
+      ? lastSegment.id
+      : undefined;
+
+  $: lastFenceId = findLastFenceId(segments);
+
+  /** @param {readonly import("./fence.d.ts").MarkdownSegment[]} list */
+  function findLastFenceId(list) {
+    for (let i = list.length - 1; i >= 0; i -= 1) {
+      const segment = /** @type {import("./fence.d.ts").MarkdownSegment} */ (
+        list[i]
+      );
+      if (segment.kind === "fence") return segment.id;
+    }
+    return undefined;
+  }
+</script>
+
+<div class="shl-md" aria-busy={!done} {...$$restProps}>
+  {#each segments as segment (segment.id)}
+    {#if segment.kind === "text"}
+      <slot name="text" {segment}>
+        <div class="shl-md-text">{segment.text}</div>
+      </slot>
+    {:else}
+      <slot
+        name="fence"
+        {segment}
+        language={languageFor(resolvedLanguages, segment)}
+      >
+        <HighlightStream
+          code={segment.code}
+          language={languageFor(resolvedLanguages, segment)}
+          done={done || !segment.open}
+          caret={caret && segment.id === lastOpenFenceId}
+          {autoScroll}
+          doneText={segment.id === lastFenceId ? doneText : ""}
+        />
+      </slot>
+    {/if}
+  {/each}
+</div>
+
+<style>
+  .shl-md {
+    display: flex;
+    flex-direction: column;
+    gap: var(--md-gap, 1em);
+  }
+
+  .shl-md-text {
+    white-space: var(--md-text-white-space, pre-wrap);
+  }
+</style>

--- a/src/MarkdownStream.svelte.d.ts
+++ b/src/MarkdownStream.svelte.d.ts
@@ -1,0 +1,100 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+import type { FenceSegment, MarkdownSegment } from "./fence";
+import type { LanguageType } from "./languages";
+
+export type MarkdownStreamProps = HTMLAttributes<HTMLDivElement> & {
+  /**
+   * Growing Markdown buffer. On change, `splitter.append` is used when the
+   * new value starts with the previous one; otherwise the whole buffer is
+   * replaced via `splitter.set` (a regenerated reply, say).
+   * @default ""
+   */
+  text?: string;
+
+  /**
+   * Stream finished. Forwarded to every fence's `HighlightStream` as
+   * `done || !segment.open`, so a trailing open fence is treated as closed
+   * once the overall stream ends.
+   * @default false
+   */
+  done?: boolean;
+
+  /**
+   * Resolves a fence's language. The default dynamically imports the
+   * grammar via `loadLanguage`, falling back to plaintext while loading and
+   * whenever `lang` is `undefined`, unrecognized, or the returned promise
+   * rejects -- it never throws. Results are cached per canonical name for
+   * the component's lifetime.
+   * @default resolves via `loadLanguage`, falling back to plaintext
+   */
+  resolveLanguage?: (
+    lang: string | undefined,
+    segment: FenceSegment,
+  ) => LanguageType<string> | Promise<LanguageType<string>> | undefined;
+
+  /**
+   * Show a blinking caret at the end of the last open fence while streaming.
+   * @default true
+   */
+  caret?: boolean;
+
+  /**
+   * Keep each streaming fence scrolled to the bottom, unless the user has
+   * scrolled away from it.
+   * @default true
+   */
+  autoScroll?: boolean;
+
+  /**
+   * Announced by the last fence's visually-hidden live region once `done`
+   * becomes `true` -- every other fence gets `""` so completion is
+   * announced only once. Set to `""` to disable the announcement.
+   * @default "Code finished streaming"
+   */
+  doneText?: string;
+
+  /**
+   * Space between prose and fence segments.
+   * @default "1em"
+   */
+  "--md-gap"?: string;
+
+  /**
+   * `white-space` of the default prose block.
+   * @default "pre-wrap"
+   */
+  "--md-text-white-space"?: string;
+};
+
+export type MarkdownStreamEvents = {
+  /**
+   * Fires once, the first time a fence segment appears.
+   */
+  fence: CustomEvent<{
+    id: number;
+    lang: string | undefined;
+  }>;
+
+  /**
+   * Fires once when `done` becomes `true`.
+   */
+  done: CustomEvent<null>;
+};
+
+export type MarkdownStreamSlots = {
+  text: {
+    segment: MarkdownSegment & { kind: "text" };
+  };
+  fence: {
+    segment: FenceSegment;
+    /** The resolved language, or plaintext while loading/unknown. */
+    language: LanguageType<string>;
+  };
+};
+
+export default class MarkdownStream extends SvelteComponentTyped<
+  MarkdownStreamProps,
+  MarkdownStreamEvents,
+  MarkdownStreamSlots
+> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -17,6 +17,7 @@ export { default as HighlightVirtual } from "./HighlightVirtual.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export type { LanguageName, LanguageType } from "./languages";
 export { LanguageLoadError, loadLanguage } from "./load-language";
+export { default as MarkdownStream } from "./MarkdownStream.svelte";
 export {
   dualStyle,
   scopeClassFor,

--- a/src/index.js
+++ b/src/index.js
@@ -14,6 +14,7 @@ export { default as HighlightSvelte } from "./HighlightSvelte.svelte";
 export { default as HighlightVirtual } from "./HighlightVirtual.svelte";
 export { default as LineNumbers } from "./LineNumbers.svelte";
 export { LanguageLoadError, loadLanguage } from "./load-language.js";
+export { default as MarkdownStream } from "./MarkdownStream.svelte";
 export {
   dualStyle,
   scopeClassFor,

--- a/tests/e2e/MarkdownStream.test.svelte
+++ b/tests/e2e/MarkdownStream.test.svelte
@@ -1,0 +1,92 @@
+<script>
+  import { MarkdownStream } from "svelte-highlight";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  // Chunk boundaries land mid-fence and mid-line, exercising the same
+  // arbitrary-boundary handling as HighlightStream itself.
+  const CHUNKS = [
+    "Here is a reply.\n\n```ts\nconst a: number = 1;\n```\n\n",
+    "And a script.\n\n```py\n",
+    'print("hi")\n```\n',
+  ];
+
+  let text = "";
+  let done = false;
+  let chunksSent = 0;
+  let fenceCount = 0;
+  let doneCount = 0;
+
+  function appendChunk() {
+    if (chunksSent >= CHUNKS.length) return;
+    text += CHUNKS[chunksSent];
+    chunksSent += 1;
+  }
+
+  // Simulates an LLM "regenerate the last fence": edits only the trailing
+  // fence's code, not a pure append - the splitter's `set` path.
+  function regenerateLastFence() {
+    text = text.replace('print("hi")', 'print("hello, world")');
+  }
+
+  function finish() {
+    done = true;
+  }
+
+  function startUnknownLanguage() {
+    text = "```nope\ncustom text\n```\n";
+    done = false;
+    chunksSent = CHUNKS.length;
+  }
+
+  // A finished buffer in one assignment -- no later `text` change to
+  // accidentally re-evaluate the fence language after the grammar loads.
+  function startCompleteFence() {
+    text = [
+      "Here's a helper that adds two numbers:",
+      "",
+      "```javascript",
+      "function add(a, b) {",
+      "  return a + b;",
+      "}",
+      "```",
+      "",
+    ].join("\n");
+    done = true;
+    chunksSent = CHUNKS.length;
+  }
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<button type="button" data-testid="append-chunk" on:click={appendChunk}>
+  Append chunk
+</button>
+<button type="button" data-testid="regenerate" on:click={regenerateLastFence}>
+  Regenerate last fence
+</button>
+<button type="button" data-testid="finish" on:click={finish}>Finish</button>
+<button
+  type="button"
+  data-testid="start-unknown"
+  on:click={startUnknownLanguage}
+>
+  Start unknown language
+</button>
+<button
+  type="button"
+  data-testid="start-complete"
+  on:click={startCompleteFence}
+>
+  Start complete fence
+</button>
+
+<MarkdownStream
+  {text}
+  {done}
+  data-testid="markdown-stream"
+  on:fence={() => (fenceCount += 1)}
+  on:done={() => (doneCount += 1)}
+/>
+
+<span data-testid="fence-count">{fenceCount}</span>
+<span data-testid="done-count">{doneCount}</span>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -61,6 +61,7 @@ import LineNumbersMultilineSpan from "./LineNumbers.multilineSpan.test.svelte";
 import LineNumbersRtl from "./LineNumbers.rtl.test.svelte";
 import LineNumbers from "./LineNumbers.test.svelte";
 import LineNumbersWrapLines from "./LineNumbers.wrapLines.test.svelte";
+import MarkdownStream from "./MarkdownStream.test.svelte";
 import ScopedStyle from "./ScopedStyle.test.svelte";
 import SvelteHighlight from "./SvelteHighlight.test.svelte";
 import Typewriter from "./Typewriter.test.svelte";
@@ -2653,4 +2654,105 @@ test("FileTabs - the active tab scrolls into view when set programmatically", as
   expect(tabBox.x + tabBox.width).toBeLessThanOrEqual(
     tablistBox.x + tablistBox.width + 1,
   );
+});
+
+test("MarkdownStream - streams prose and two fences with the right languages", async ({
+  mount,
+  page,
+}) => {
+  await mount(MarkdownStream);
+
+  await page.getByTestId("append-chunk").click();
+  await page.getByTestId("append-chunk").click();
+  await page.getByTestId("append-chunk").click();
+
+  const container = page.getByTestId("markdown-stream");
+  const fences = container.locator("pre");
+  await expect(fences).toHaveCount(2);
+
+  // typescript resolved for the first fence, not plaintext.
+  await expect(fences.nth(0).locator(".hljs-keyword").first()).toHaveText(
+    "const",
+  );
+  // python resolved for the second fence, not plaintext.
+  await expect(fences.nth(1).locator(".hljs-string").first()).toHaveText(
+    '"hi"',
+  );
+
+  const prose = container.locator(".shl-md-text");
+  await expect(prose).toHaveCount(2);
+  await expect(prose.nth(0)).toHaveText("Here is a reply.");
+  await expect(prose.nth(1)).toHaveText("And a script.");
+});
+
+test("MarkdownStream - regeneration keeps earlier fence elements", async ({
+  mount,
+  page,
+}) => {
+  await mount(MarkdownStream);
+
+  await page.getByTestId("append-chunk").click();
+  await page.getByTestId("append-chunk").click();
+  await page.getByTestId("append-chunk").click();
+
+  const container = page.getByTestId("markdown-stream");
+  const firstFenceHandle = await container
+    .locator("pre")
+    .nth(0)
+    .elementHandle();
+
+  await page.getByTestId("regenerate").click();
+
+  expect(await firstFenceHandle?.evaluate((el) => el.isConnected)).toBe(true);
+  await expect(container.locator("pre").nth(1)).toContainText('"hello, world"');
+});
+
+test("MarkdownStream - a complete done buffer highlights without a later text change", async ({
+  mount,
+  page,
+}) => {
+  await mount(MarkdownStream);
+  await page.getByTestId("start-complete").click();
+
+  const container = page.getByTestId("markdown-stream");
+  await expect(container.locator("pre")).toHaveCount(1);
+  await expect(container.locator(".hljs-keyword").first()).toHaveText(
+    "function",
+  );
+});
+
+test("MarkdownStream - unknown language falls back to plaintext without errors", async ({
+  mount,
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  await mount(MarkdownStream);
+  await page.getByTestId("start-unknown").click();
+
+  const container = page.getByTestId("markdown-stream");
+  await expect(container.locator("pre")).toHaveCount(1);
+  await expect(container.locator("pre code")).toHaveText("custom text");
+  expect(errors).toEqual([]);
+});
+
+test("MarkdownStream - caret only on the last open fence", async ({
+  mount,
+  page,
+}) => {
+  await mount(MarkdownStream);
+
+  // First fence (ts) opens and closes within a single chunk; the second
+  // (py) fence's closing fence hasn't arrived yet, so it's the only open
+  // fence while streaming.
+  await page.getByTestId("append-chunk").click();
+  await page.getByTestId("append-chunk").click();
+
+  const container = page.getByTestId("markdown-stream");
+  await expect(container.locator("pre")).toHaveCount(2);
+  await expect(container.locator(".highlight-stream-caret")).toHaveCount(1);
+  await expect(
+    container.locator("pre").nth(1).locator(".highlight-stream-caret"),
+  ).toHaveCount(1);
 });

--- a/tests/markdown-stream-ssr.test.ts
+++ b/tests/markdown-stream-ssr.test.ts
@@ -1,0 +1,83 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+
+const componentPath = path.join(
+  import.meta.dir,
+  "../src/MarkdownStream.svelte",
+);
+
+async function compileForServer() {
+  // Bun's default `.svelte` loader compiles for the client, so `import
+  // HighlightStream from "./HighlightStream.svelte"` inside the generated
+  // output would resolve to a mount function, not the `($$renderer, props)`
+  // shape `svelte/server` expects. Server-compile it too and rewrite the
+  // specifier to point at that copy.
+  const highlightStreamPath = path.join(
+    import.meta.dir,
+    "../src/HighlightStream.svelte",
+  );
+  const highlightStreamJs = compile(
+    fs.readFileSync(highlightStreamPath, "utf-8"),
+    { generate: "server", filename: "HighlightStream.svelte" },
+  ).js.code;
+  const highlightStreamOutPath = path.join(
+    import.meta.dir,
+    "../src/.tmp-highlight-stream.server.js",
+  );
+
+  const source = fs.readFileSync(componentPath, "utf-8");
+  const { js } = compile(source, {
+    generate: "server",
+    filename: "MarkdownStream.svelte",
+  });
+  const code = js.code.replace(
+    'from "./HighlightStream.svelte"',
+    'from "./.tmp-highlight-stream.server.js"',
+  );
+
+  // Written alongside the component (not in tests/) so its relative imports
+  // (e.g. "./fence.js") resolve.
+  const outPath = path.join(
+    import.meta.dir,
+    "../src/.tmp-markdown-stream.server.js",
+  );
+  fs.writeFileSync(highlightStreamOutPath, highlightStreamJs);
+  fs.writeFileSync(outPath, code);
+  try {
+    return await import(pathToFileURL(outPath).href);
+  } finally {
+    fs.unlinkSync(outPath);
+    fs.unlinkSync(highlightStreamOutPath);
+  }
+}
+
+describe("MarkdownStream SSR", () => {
+  it("server-renders two fences and one prose block, with no undefined in the markup", async () => {
+    const { default: MarkdownStream } = await compileForServer();
+
+    const text = [
+      "Here is some intro text.",
+      "",
+      "```ts",
+      "const a: number = 1;",
+      "```",
+      "",
+      "```py",
+      'print("hi")',
+      "```",
+    ].join("\n");
+
+    const { body } = render(MarkdownStream, {
+      props: { text, done: true },
+    });
+
+    const preCount = (body.match(/<pre/g) ?? []).length;
+    expect(preCount).toBe(2);
+    expect(body).toContain("shl-md-text");
+    expect(body).toContain("Here is some intro text.");
+    expect(body).not.toContain("undefined");
+  });
+});

--- a/www/components/HighlightStream/stream-demo.js
+++ b/www/components/HighlightStream/stream-demo.js
@@ -45,3 +45,56 @@ export function simulateStream(
   };
   return stop;
 }
+
+// A line that could still grow into a fence delimiter (` ``` `/`~~~`,
+// optionally followed by a language word) or inline code -- anything
+// starting with a backtick or tilde.
+const FENCE_CANDIDATE_LINE_RE = /^ {0,3}[`~]/;
+// Bails out of holding a line back if it never gets a newline (so a
+// legitimately long line starting with a backtick/tilde still streams).
+const MAX_HELD_LINE_LENGTH = 80;
+
+/**
+ * Wraps a `simulateStream` `onChunk` callback so a line that could still be
+ * a Markdown fence opener isn't flushed mid-marker before it's complete,
+ * which would flash the raw syntax as plain text for a few frames before
+ * `createFenceSplitter` recognizes the completed line as a fence. Complete
+ * lines pass through immediately; a trailing, not-yet-terminated line is
+ * held back only while it still looks like a fence/inline-code candidate,
+ * and released whole once its newline arrives. Call `.flush()` once the
+ * source stream ends, in case its very last line was held back.
+ * @param {(chunk: string) => void} onFlush
+ * @returns {((chunk: string) => void) & { flush(): void }}
+ */
+export function createFenceAwareAppender(onFlush) {
+  /** @type {string} */
+  let buffer = "";
+
+  const release = () => {
+    if (buffer === "") return;
+    onFlush(buffer);
+    buffer = "";
+  };
+
+  /** @param {string} chunk */
+  const onChunk = (chunk) => {
+    buffer += chunk;
+
+    let newlineIndex = buffer.indexOf("\n");
+    while (newlineIndex !== -1) {
+      onFlush(buffer.slice(0, newlineIndex + 1));
+      buffer = buffer.slice(newlineIndex + 1);
+      newlineIndex = buffer.indexOf("\n");
+    }
+
+    if (
+      buffer.length > MAX_HELD_LINE_LENGTH ||
+      !FENCE_CANDIDATE_LINE_RE.test(buffer)
+    ) {
+      release();
+    }
+  };
+
+  onChunk.flush = release;
+  return onChunk;
+}

--- a/www/components/MarkdownStream/Basic.svelte
+++ b/www/components/MarkdownStream/Basic.svelte
@@ -1,0 +1,68 @@
+<script>
+  import {
+    createFenceAwareAppender,
+    simulateStream,
+  } from "@components/HighlightStream/stream-demo.js";
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import { onDestroy, onMount } from "svelte";
+  import { HighlightStream, MarkdownStream } from "svelte-highlight";
+
+  const full = `Here's a helper that adds two numbers:
+
+\`\`\`javascript
+function add(a, b) {
+  return a + b;
+}
+\`\`\`
+
+And a typed version, using the \`ts\` alias:
+
+\`\`\`ts
+function add(a: number, b: number): number {
+  return a + b;
+}
+\`\`\`
+
+Let me know if you'd like more examples!`;
+
+  let text = "";
+  let done = false;
+  let stop = () => {};
+
+  function run() {
+    stop();
+    text = "";
+    done = false;
+    const appendChunk = createFenceAwareAppender((chunk) => (text += chunk));
+    stop = simulateStream(full, {
+      onChunk: appendChunk,
+      onDone: () => {
+        appendChunk.flush();
+        done = true;
+      },
+    });
+  }
+
+  onMount(run);
+  onDestroy(() => stop());
+</script>
+
+<MarkdownStream {text} {done}>
+  <svelte:fragment slot="fence" let:segment let:language>
+    {#if segment.code}
+      <HighlightStream
+        code={segment.code}
+        {language}
+        done={done || !segment.open}
+        caret={!done && segment.open}
+        autoScroll
+        class={THEME_MODULE_NAME}
+      />
+    {/if}
+  </svelte:fragment>
+</MarkdownStream>
+
+<Button size="small" kind="tertiary" style="margin-top: 0.75rem" on:click={run}>
+  Replay
+</Button>

--- a/www/components/MarkdownStream/Regenerate.svelte
+++ b/www/components/MarkdownStream/Regenerate.svelte
@@ -1,0 +1,58 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button } from "carbon-components-svelte";
+  import { HighlightStream, MarkdownStream } from "svelte-highlight";
+
+  const VARIANTS = [
+    `function add(a, b) {
+  return a + b;
+}`,
+    `function add(a, b) {
+  return Number(a) + Number(b);
+}`,
+    "const add = (a, b) => a + b;",
+  ];
+
+  function build(variant) {
+    return [
+      "Here's a helper that adds two numbers:",
+      "",
+      "```javascript",
+      variant,
+      "```",
+      "",
+      "Let me know if you'd like a different version!",
+    ].join("\n");
+  }
+
+  let variantIndex = 0;
+  let text = build(VARIANTS[variantIndex]);
+
+  // Only the fenced code changes -- the surrounding prose (and its DOM
+  // node) never gets re-created, since the splitter keeps the fence's id
+  // stable across a `set` whenever its info string is unchanged.
+  function regenerate() {
+    variantIndex = (variantIndex + 1) % VARIANTS.length;
+    text = build(VARIANTS[variantIndex]);
+  }
+</script>
+
+<MarkdownStream {text} done>
+  <svelte:fragment slot="fence" let:segment let:language>
+    <HighlightStream
+      code={segment.code}
+      {language}
+      done
+      class={THEME_MODULE_NAME}
+    />
+  </svelte:fragment>
+</MarkdownStream>
+
+<Button
+  size="small"
+  kind="tertiary"
+  style="margin-top: 0.75rem"
+  on:click={regenerate}
+>
+  Regenerate
+</Button>

--- a/www/components/MarkdownStreamPreview.svelte
+++ b/www/components/MarkdownStreamPreview.svelte
@@ -1,0 +1,15 @@
+<script>
+  import Basic from "@components/MarkdownStream/Basic.svelte";
+  import Regenerate from "@components/MarkdownStream/Regenerate.svelte";
+  import { Column, Row } from "carbon-components-svelte";
+</script>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Basic</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Basic /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Regenerating a fence</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Regenerate /> </Column>
+</Row>

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -72,6 +72,7 @@
     "/preview-dual-theme": "Dual light/dark HighlightStyle preview",
     "/preview-editable": "Editable highlight preview",
     "/preview-highlight-stream": "HighlightStream preview",
+    "/preview-markdown-stream": "MarkdownStream preview",
     "/preview-virtual": "HighlightVirtual preview",
     "/preview-engine": "Headless engine preview",
     "/preview-jq": "jq language preview",

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -38,6 +38,8 @@
   import Streaming from "@components/LineNumbers/Streaming.svelte";
   import StyleProps from "@components/LineNumbers/StyleProps.svelte";
   import WrapLines from "@components/LineNumbers/WrapLines.svelte";
+  import MarkdownStreamBasic from "@components/MarkdownStream/Basic.svelte";
+  import MarkdownStreamRegenerate from "@components/MarkdownStream/Regenerate.svelte";
   import ScopedStyle from "@components/ScopedStyle.svelte";
   import ScopedStyleAuto from "@components/ScopedStyleAuto.svelte";
   import ScopedStyleSvelte from "@components/ScopedStyleSvelte.svelte";
@@ -769,10 +771,40 @@ export { add, mul };\`,
       hideCloseButton
       kind="info"
       title="Note:"
-      subtitle="Headless: createFenceSplitter has no Svelte dependency. A MarkdownStream component wrapping this pattern is a separate deliverable."
+      subtitle="Headless: createFenceSplitter has no Svelte dependency. MarkdownStream, below, wraps this exact pattern into a component."
     />
   </Column>
   <Column xlg={10} lg={10} md={12}> <HighlightStreamMarkdownFences /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">MarkdownStream</code>
+      wraps the pattern above: pass it a growing <code class="code">text</code>
+      buffer and it drives one <code class="code">HighlightStream</code> per
+      fence for you, keyed by the splitter's stable ids. Prose renders as plain
+      text by default -- it's not a Markdown renderer, just a router for fenced
+      code.
+    </p>
+    <InlineNotification
+      lowContrast
+      hideCloseButton
+      kind="info"
+      title="Note:"
+      subtitle="done is forwarded to every fence as done || !segment.open, the caret only ever renders on the last open fence, and doneText's completion announcement fires once, from the last fence."
+    />
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <MarkdownStreamBasic /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      A non-append change to <code class="code">text</code>—an LLM regenerating
+      the last fence, say—is handled by the splitter's
+      <code class="code">set</code>, not just <code class="code">append</code>.
+      Earlier segments keep their id (and DOM node); only the fence that
+      actually changed gets a new
+      <code class="code">HighlightStream</code>
+      instance.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <MarkdownStreamRegenerate /> </Column>
 </Row>
 
 <Row class="mb-9">

--- a/www/pages/preview-markdown-stream.astro
+++ b/www/pages/preview-markdown-stream.astro
@@ -1,0 +1,8 @@
+---
+import MarkdownStreamPreview from "@components/MarkdownStreamPreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="MarkdownStream preview">
+  <MarkdownStreamPreview client:idle />
+</Layout>


### PR DESCRIPTION
Composes createFenceSplitter with one HighlightStream per fence, keyed
by the splitter's stable ids so appends and regenerated buffers keep
existing blocks mounted. Languages resolve through a resolveLanguage
prop with a plaintext fallback, and prose stays plain text unless a
slot overrides it. Includes README docs, homepage demos, and a
full-page preview.