### PR TITLE
feat(engine): add transformEvents, typed errors, CI perf budget

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -42,6 +42,9 @@ jobs:
       - name: Run typecheck
         run: bun test:types
 
+      - name: Run engine perf budget
+        run: bun scripts/benchmark-engine.ts
+
   e2e-tests:
     needs: [lint]
     runs-on: macos-15

--- a/README.md
+++ b/README.md
@@ -2384,6 +2384,25 @@ See [Large documents](#large-documents) above.
 
 The highlighting engine's output is a flat scope-event stream (`ScopeEvent[]`): a sequence of `TEXT`/`OPEN`/`CLOSE` events that `renderHtml`, `toRanges`, and `tokenLines` each render differently. Every `<Highlight>`-family component exposes this stream (as `events`, in the default slot and the `highlight` event detail — see [Component API](#component-api) above), and `svelte-highlight/engine` + `svelte-highlight/registry` expose it directly, so highlighting can be consumed headlessly: server routes, build pipelines, tests, or any non-component context. `svelte-highlight/engine` has zero Svelte dependency and works in any JS runtime.
 
+### Zero-bundler usage from a CDN
+
+`svelte-highlight/engine` has no `import` statements of its own, so it — and any generated language grammar — can be loaded straight from a CDN like [esm.sh](https://esm.sh), with no bundler, build step, or Svelte in the loop:
+
+```html
+<script type="module">
+  import { createRegistry, registerAll, renderHtml } from "https://esm.sh/svelte-highlight/engine";
+  import typescript from "https://esm.sh/svelte-highlight/languages/typescript";
+
+  const registry = createRegistry();
+  registerAll(registry, typescript);
+
+  const { events } = registry.tokenize("const greeting: string = 'hi';", "typescript");
+  document.querySelector("pre").innerHTML = renderHtml(events);
+</script>
+```
+
+See it as a complete page in [examples/cdn](examples/cdn).
+
 ### Stability tiers
 
 - **Stable, semver-governed:** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`, `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`, `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`, `Registry` and its methods, `createRegistry`, `registerAll`, `StreamSession`, `TokenizedDocument`, `createTokenizedDocument`, `TextSegment`, `FenceSegment`, `MarkdownSegment`, `FenceSplitter`, `createFenceSplitter`. `Snapshot` is a serializable format that round-trips within one library version, but is **not** guaranteed stable across versions — a snapshot from an older release may be rejected on resume. The same caveat applies to `TokenizedDocument`: its method surface (`setCode`/`append`/`lineCount`/`lineRange`/`tokenizedThrough`/`checkpointCount`) is stable and semver-governed, but internally it resumes from `Snapshot`s the same way `StreamSession` does, so anything that tried to serialize and later resume a `TokenizedDocument`'s internal state directly would hit the same cross-version instability -- the public API doesn't expose that today.

--- a/README.md
+++ b/README.md
@@ -2493,6 +2493,10 @@ const myRenderer = {
 
 Both are exported from `svelte-highlight/engine` and are distinct from `LanguageLoadError` (exported from `svelte-highlight` and `svelte-highlight/load-language`), which fires from a grammar module's *dynamic import* failure, not a registry lookup.
 
+### `illegal` is enforced only during auto-detection
+
+A grammar's `illegal` pattern only aborts `tokenizeAuto`/`highlightAuto`: a candidate whose text matches its own `illegal` pattern loses relevance scoring and is dropped from consideration. An explicit `tokenize`/`highlight`/`createSession` call never checks it, unlike hljs's own `ignoreIllegals: false` default, which throws on the same condition. This is deliberate: streamed or LLM-generated code is routinely "illegal" mid-stream — an unclosed string, a dangling `#` — and an explicit-language highlighter that could throw partway through a stream would be unusable for that case. For hljs-style strict validation, run `highlightAuto(code, [language])` instead.
+
 ## [Supported Languages](SUPPORTED_LANGUAGES.md)
 
 ## [Supported Styles](SUPPORTED_STYLES.md)

--- a/README.md
+++ b/README.md
@@ -2405,7 +2405,7 @@ See it as a complete page in [examples/cdn](examples/cdn).
 
 ### Stability tiers
 
-- **Stable, semver-governed:** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`, `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`, `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`, `Registry` and its methods, `createRegistry`, `registerAll`, `StreamSession`, `TokenizedDocument`, `createTokenizedDocument`, `TextSegment`, `FenceSegment`, `MarkdownSegment`, `FenceSplitter`, `createFenceSplitter`. `Snapshot` is a serializable format that round-trips within one library version, but is **not** guaranteed stable across versions — a snapshot from an older release may be rejected on resume. The same caveat applies to `TokenizedDocument`: its method surface (`setCode`/`append`/`lineCount`/`lineRange`/`tokenizedThrough`/`checkpointCount`) is stable and semver-governed, but internally it resumes from `Snapshot`s the same way `StreamSession` does, so anything that tried to serialize and later resume a `TokenizedDocument`'s internal state directly would hit the same cross-version instability -- the public API doesn't expose that today.
+- **Stable, semver-governed:** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`, `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`, `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`, `Registry` and its methods, `createRegistry`, `registerAll`, `StreamSession`, `TokenizedDocument`, `createTokenizedDocument`, `TextSegment`, `FenceSegment`, `MarkdownSegment`, `FenceSplitter`, `createFenceSplitter`, `UnknownLanguageError`, `TokenizerLoopError`. `Snapshot` is a serializable format that round-trips within one library version, but is **not** guaranteed stable across versions — a snapshot from an older release may be rejected on resume. The same caveat applies to `TokenizedDocument`: its method surface (`setCode`/`append`/`lineCount`/`lineRange`/`tokenizedThrough`/`checkpointCount`) is stable and semver-governed, but internally it resumes from `Snapshot`s the same way `StreamSession` does, so anything that tried to serialize and later resume a `TokenizedDocument`'s internal state directly would hit the same cross-version instability -- the public API doesn't expose that today.
 - **Generated data, versioned with the library:** `GrammarIR`/`GrammarState`. These come from the build pipeline and are consumed by `registerAll`; treat them as opaque payloads whose field-level structure may change in any minor release. Always load grammars from the same package version as the engine.
 
 ### Headless highlighting, isolated registry
@@ -2485,6 +2485,13 @@ const myRenderer = {
   },
 };
 ```
+
+### Errors
+
+- **`UnknownLanguageError`** (`{ language }`): thrown by `tokenize`, `highlight`, `tokenizeRanges`, and `createSession` when `language` isn't registered.
+- **`TokenizerLoopError`** (`{ grammarName, iterations }`): thrown once a parse exceeds 500,000 tokenizer iterations, guarding against a grammar bug that never advances position.
+
+Both are exported from `svelte-highlight/engine` and are distinct from `LanguageLoadError` (exported from `svelte-highlight` and `svelte-highlight/load-language`), which fires from a grammar module's *dynamic import* failure, not a registry lookup.
 
 ## [Supported Languages](SUPPORTED_LANGUAGES.md)
 

--- a/scripts/benchmark-engine.ts
+++ b/scripts/benchmark-engine.ts
@@ -97,3 +97,10 @@ for (const row of rows) {
 console.log(
   `\nworst-case ratio: ${worstRatio.toFixed(2)}x ${worstRatio <= 1.5 ? "(within 1.5x budget)" : "(OVER the 1.5x budget)"}`,
 );
+
+if (worstRatio > 1.5) {
+  console.error(
+    `\nengine benchmark FAILED: worst-case ratio ${worstRatio.toFixed(2)}x exceeds the 1.5x budget`,
+  );
+  process.exit(1);
+}

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -148,6 +148,14 @@ pkgJson.exports = {
     types: "./compat.d.ts",
     default: "./compat.js",
   },
+  "./transformers": {
+    types: "./transformers.d.ts",
+    default: "./transformers.js",
+  },
+  "./transformers.js": {
+    types: "./transformers.d.ts",
+    default: "./transformers.js",
+  },
   "./package.json": "./package.json",
 };
 

--- a/src/engine.d.ts
+++ b/src/engine.d.ts
@@ -7,7 +7,7 @@
  *   `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`,
  *   `Registry` and all its methods, `createRegistry`, `registerAll`,
  *   `StreamSession`, `Snapshot` (see its own doc comment for a narrower
- *   guarantee).
+ *   guarantee), `UnknownLanguageError`, `TokenizerLoopError`.
  * - **Generated data (structure versioned with the library):** `GrammarIR`,
  *   `GrammarState` (see their doc comment).
  *
@@ -192,6 +192,28 @@ export interface StreamSession {
 /** The compiled program `Registry#get` returns; opaque other than its source IR's identity. */
 export interface CompiledProgram {
   ir: GrammarIR;
+}
+
+/**
+ * Thrown by `tokenize`, `highlight`, `tokenizeRanges`, and `createSession`
+ * when `language` isn't registered. Distinct from `LanguageLoadError`
+ * (`svelte-highlight`/`svelte-highlight/load-language`), which fires from a
+ * grammar module's dynamic `import()` failure, not a registry lookup.
+ * `resume()` does not throw this - see its own doc comment.
+ */
+export class UnknownLanguageError extends Error {
+  constructor(language: string);
+  language: string;
+}
+
+/**
+ * Thrown by the tokenizer once a parse exceeds 500,000 iterations,
+ * guarding against a grammar bug that never advances position.
+ */
+export class TokenizerLoopError extends Error {
+  constructor(grammarName: string, iterations: number);
+  grammarName: string;
+  iterations: number;
 }
 
 export interface Registry {

--- a/src/engine.d.ts
+++ b/src/engine.d.ts
@@ -40,6 +40,12 @@ export interface GrammarState {
   returnBegin?: boolean;
   returnEnd?: boolean;
   subLanguage?: string | string[];
+  /**
+   * Only enforced during auto-detection (`tokenizeAuto`/`highlightAuto`);
+   * inert on an explicit-language `tokenize()`/`highlight()`/`createSession()`/
+   * `resume()` call, so mid-stream text that would trip `illegal` under hljs's
+   * `ignoreIllegals: false` default is never rejected once the language is named.
+   */
   illegal?: string;
   keywords?: Record<string, [string, number]>;
   keywordPattern?: string;

--- a/src/engine.js
+++ b/src/engine.js
@@ -131,6 +131,41 @@ export const TEXT = 0;
 export const OPEN = 1;
 export const CLOSE = 2;
 
+/**
+ * Thrown by `tokenize`, `highlight`, `tokenizeRanges`, and `createSession`
+ * when `language` isn't registered. Distinct from `LanguageLoadError`
+ * (src/load-language.js), which fires from a grammar module's dynamic
+ * `import()` failure, not a registry lookup. `resume()` does not throw
+ * this - see its own comment.
+ */
+export class UnknownLanguageError extends Error {
+  /**
+   * @param {string} language
+   */
+  constructor(language) {
+    super(`Unknown language: "${language}"`);
+    this.name = "UnknownLanguageError";
+    this.language = language;
+  }
+}
+
+/**
+ * Thrown by `Tokenizer#run` once a parse exceeds 500,000 iterations,
+ * guarding against a grammar bug that never advances `pos`.
+ */
+export class TokenizerLoopError extends Error {
+  /**
+   * @param {string} grammarName
+   * @param {number} iterations
+   */
+  constructor(grammarName, iterations) {
+    super(`potential infinite loop (${grammarName})`);
+    this.name = "TokenizerLoopError";
+    this.grammarName = grammarName;
+    this.iterations = iterations;
+  }
+}
+
 /** Scope name prefix marking a sub-language boundary (`language:css`). */
 const LANGUAGE_SCOPE_PREFIX = "language:";
 
@@ -752,7 +787,7 @@ class Tokenizer {
     for (;;) {
       this.iterations++;
       if (this.iterations > 500000) {
-        throw new Error(`potential infinite loop (${this.program.ir.name})`);
+        throw new TokenizerLoopError(this.program.ir.name, this.iterations);
       }
       const found = this.nextMatch();
       if (!found) break;
@@ -1150,7 +1185,7 @@ export function createRegistry() {
      */
     tokenize(code, language) {
       const program = this.get(language);
-      if (!program) throw new Error(`Unknown language: "${language}"`);
+      if (!program) throw new UnknownLanguageError(language);
       const tokenizer = new Tokenizer(this, program);
       tokenizer.code = code;
       tokenizer.run();
@@ -1316,7 +1351,7 @@ export function createRegistry() {
      */
     createSession(language, { from } = {}) {
       const program = this.get(language);
-      if (!program) throw new Error(`Unknown language: "${language}"`);
+      if (!program) throw new UnknownLanguageError(language);
       let tokenizer = new Tokenizer(this, program);
       const registry = this;
       let staged = "";

--- a/src/transformers.d.ts
+++ b/src/transformers.d.ts
@@ -1,0 +1,44 @@
+import type { ScopeEvent } from "./engine.d.ts";
+
+export type EventTransform = (events: ScopeEvent[]) => ScopeEvent[];
+
+/**
+ * Runs `events` through each of `fns` in order, threading each transform's
+ * output into the next. `transformEvents(events, [])` is a no-op.
+ */
+export function transformEvents(
+  events: ScopeEvent[],
+  fns: EventTransform[],
+): ScopeEvent[];
+
+/**
+ * Wraps every match of `pattern` in its own `OPEN`/`CLOSE` pair of `scope`
+ * (default `"mark"`). Only rewrites the interior of individual `TEXT`
+ * leaves, so it can't unbalance existing `OPEN`/`CLOSE` nesting. Throws if
+ * `pattern` doesn't have the `g` flag.
+ */
+export function markPattern(pattern: RegExp, scope?: string): EventTransform;
+
+/**
+ * Marks tabs and/or trailing whitespace. Composed entirely from
+ * `markPattern` via `transformEvents` - no new matching logic.
+ */
+export function markWhitespace(options?: {
+  tabs?: boolean;
+  trailingSpace?: boolean;
+  tabScope?: string;
+  trailingScope?: string;
+}): EventTransform;
+
+/**
+ * Wraps each 1-indexed line named in `lines` in an `OPEN`/`CLOSE` pair of
+ * its literal scope (`"mark" | "ins" | "del"`, matching `ParsedMeta.lines`
+ * in `fence.d.ts`, so `renderHtml` needs no changes to render it). A scope
+ * already open when the line starts, or still open past its end, is
+ * resumed inside the wrapper - the same "resume" trick `extendLines` uses
+ * for per-line HTML, applied here to the raw event stream. Lines absent
+ * from `lines` pass through unwrapped; `markLines({})` is a no-op.
+ */
+export function markLines(
+  lines: Record<number, "mark" | "ins" | "del">,
+): EventTransform;

--- a/src/transformers.js
+++ b/src/transformers.js
@@ -1,0 +1,154 @@
+/**
+ * Composable transforms over a tokenized `ScopeEvent[]` stream, meant to run
+ * between `Registry#tokenize` and a renderer (`renderHtml`/`toRanges`/
+ * `tokenLines`). Every transform here preserves the engine's event-stream
+ * invariant (see engine.d.ts's top doc comment): `TEXT` values concatenated
+ * in order still equal the tokenized source, and the stream stays balanced -
+ * every `OPEN` has a matching later `CLOSE`, properly nested.
+ */
+
+/**
+ * @typedef {import("./engine.d.ts").ScopeEvent} ScopeEvent
+ * @typedef {import("./transformers.d.ts").EventTransform} EventTransform
+ */
+
+const TEXT = 0;
+const OPEN = 1;
+const CLOSE = 2;
+
+const NEWLINE_SPLIT_RE = /(\n)/;
+
+/**
+ * @param {ScopeEvent[]} events
+ * @param {EventTransform[]} fns
+ * @returns {ScopeEvent[]}
+ */
+export function transformEvents(events, fns) {
+  return fns.reduce((acc, fn) => fn(acc), events);
+}
+
+/**
+ * @param {RegExp} pattern
+ * @param {string} [scope]
+ * @returns {EventTransform}
+ */
+export function markPattern(pattern, scope = "mark") {
+  if (!pattern.global) {
+    throw new Error('markPattern requires a global RegExp (the "g" flag)');
+  }
+  return (events) => {
+    /** @type {ScopeEvent[]} */
+    const out = [];
+    for (const ev of events) {
+      if (ev.t !== TEXT) {
+        out.push(ev);
+        continue;
+      }
+      const text = ev.v;
+      pattern.lastIndex = 0;
+      let last = 0;
+      for (
+        let match = pattern.exec(text);
+        match !== null;
+        match = pattern.exec(text)
+      ) {
+        if (match.index > last) {
+          out.push({ t: TEXT, v: text.slice(last, match.index) });
+        }
+        out.push({ t: OPEN, s: scope });
+        out.push({ t: TEXT, v: match[0] });
+        out.push({ t: CLOSE });
+        last = match.index + match[0].length;
+        if (match[0].length === 0) pattern.lastIndex++;
+      }
+      if (last < text.length) out.push({ t: TEXT, v: text.slice(last) });
+    }
+    return out;
+  };
+}
+
+/**
+ * @param {{ tabs?: boolean, trailingSpace?: boolean, tabScope?: string, trailingScope?: string }} [options]
+ * @returns {EventTransform}
+ */
+export function markWhitespace({
+  tabs = true,
+  trailingSpace = true,
+  tabScope = "ws-tab",
+  trailingScope = "ws-trailing",
+} = {}) {
+  /** @type {EventTransform[]} */
+  const fns = [];
+  if (tabs) fns.push(markPattern(/\t/g, tabScope));
+  if (trailingSpace) fns.push(markPattern(/[ \t]+$/gm, trailingScope));
+  return (events) => transformEvents(events, fns);
+}
+
+/**
+ * @param {Record<number, "mark" | "ins" | "del">} lines
+ * @returns {EventTransform}
+ */
+export function markLines(lines) {
+  if (Object.keys(lines).length === 0) return (events) => events;
+
+  return (events) => {
+    /** @type {ScopeEvent[]} */
+    const out = [];
+    let line = 1;
+    /** @type {string[]} */
+    const openScopes = [];
+    let wrapping = false;
+
+    const closeOpenScopes = () => {
+      for (let i = 0; i < openScopes.length; i++) out.push({ t: CLOSE });
+    };
+    const reopenScopes = () => {
+      for (const scope of openScopes) out.push({ t: OPEN, s: scope });
+    };
+    // A scope already open (or still open past the wrapped line) is
+    // "resumed" by closing it, opening the wrapper, then reopening it
+    // inside - the only way the wrapper's OPEN/CLOSE stays a validly
+    // nested pair instead of straddling it.
+    const startWrap = () => {
+      closeOpenScopes();
+      out.push({ t: OPEN, s: /** @type {string} */ (lines[line]) });
+      reopenScopes();
+      wrapping = true;
+    };
+    /** @param {boolean} continueOpenScopes */
+    const endWrap = (continueOpenScopes) => {
+      closeOpenScopes();
+      out.push({ t: CLOSE });
+      wrapping = false;
+      if (continueOpenScopes && openScopes.length > 0) reopenScopes();
+    };
+    const maybeStartWrap = () => {
+      if (!wrapping && lines[line] !== undefined) startWrap();
+    };
+
+    for (const ev of events) {
+      if (ev.t === OPEN) {
+        maybeStartWrap();
+        openScopes.push(ev.s);
+        out.push(ev);
+      } else if (ev.t === CLOSE) {
+        maybeStartWrap();
+        openScopes.pop();
+        out.push(ev);
+      } else {
+        for (const piece of ev.v.split(NEWLINE_SPLIT_RE)) {
+          if (piece === "\n") {
+            if (wrapping) endWrap(true);
+            out.push({ t: TEXT, v: "\n" });
+            line++;
+          } else if (piece !== "") {
+            maybeStartWrap();
+            out.push({ t: TEXT, v: piece });
+          }
+        }
+      }
+    }
+    if (wrapping) endWrap(false);
+    return out;
+  };
+}

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -3,7 +3,9 @@ import {
   TokenizerLoopError,
   UnknownLanguageError,
 } from "../src/engine.js";
+import css from "../src/languages/css.js";
 import javascript from "../src/languages/javascript.js";
+import typescript from "../src/languages/typescript.js";
 
 const registry = createRegistry();
 registry.register(javascript.register);
@@ -50,5 +52,82 @@ describe("TokenizerLoopError", () => {
     expect(err.message).toBe("potential infinite loop (fakelang)");
     expect(err.grammarName).toBe("fakelang");
     expect(err.iterations).toBe(500001);
+  });
+});
+
+describe("Registry contract", () => {
+  const contractRegistry = createRegistry();
+  contractRegistry.register(javascript.register);
+  contractRegistry.register(typescript.register);
+  contractRegistry.register(css.register);
+
+  it("get() resolves a canonical name and returns undefined for an unknown one", () => {
+    expect(contractRegistry.get("javascript")?.ir.name).toBe("javascript");
+    expect(contractRegistry.get("not-a-language")).toBeUndefined();
+  });
+
+  it("get() resolves an alias to the same program as its canonical name", () => {
+    expect(contractRegistry.get("ts")).toBe(contractRegistry.get("typescript"));
+  });
+
+  it("listLanguages() includes exactly the registered languages", () => {
+    expect(new Set(contractRegistry.listLanguages())).toEqual(
+      new Set(["javascript", "typescript", "css"]),
+    );
+  });
+
+  it("tokenizeRanges() ranges are sorted, non-overlapping, and in bounds", () => {
+    // toRanges only emits a range for text inside some scope, so plain
+    // unscoped text (whitespace, punctuation) between tokens has no range
+    // at all - "gapless over [0, code.length)" doesn't hold in general, only
+    // "no two ranges overlap".
+    const code = "const x = 1;\nfunction f() { return x + 2; }\n";
+    const ranges = [
+      ...contractRegistry.tokenizeRanges(code, { language: "javascript" }),
+    ].sort((a, b) => a.start - b.start);
+
+    expect(ranges.length).toBeGreaterThan(0);
+    for (const range of ranges) {
+      expect(range.start).toBeGreaterThanOrEqual(0);
+      expect(range.end).toBeLessThanOrEqual(code.length);
+      expect(range.end).toBeGreaterThan(range.start);
+    }
+    for (let i = 1; i < ranges.length; i++) {
+      expect(ranges[i]?.start).toBeGreaterThanOrEqual(ranges[i - 1]?.end ?? 0);
+    }
+  });
+
+  it("highlightAuto() picks one of the candidates and ranks secondBest below it", () => {
+    const code = "const x = 1;\nfunction f() { return x + 2; }\n";
+    const result = contractRegistry.highlightAuto(code, [
+      "javascript",
+      "typescript",
+    ]);
+
+    expect(["javascript", "typescript"]).toContain(result.language);
+    if (result.secondBest) {
+      const other =
+        result.language === "javascript" ? "typescript" : "javascript";
+      expect(result.secondBest.language).toBe(other);
+      expect(result.secondBest.relevance).toBeLessThanOrEqual(result.relevance);
+    }
+  });
+
+  it("illegal is inert on an explicit-language tokenize() call (pins the auto-detect-only behavior)", () => {
+    // typescript's grammar sets illegal: "#(?![$_A-Za-z])"
+    expect(() =>
+      contractRegistry.tokenize("const x = 1; #bad", "typescript"),
+    ).not.toThrow();
+  });
+
+  it("resume() throws on an unregistered language, but doesn't validate it upfront", () => {
+    // engine.js:1440 (createSession comment): resume() reads program.states
+    // without checking `program` itself, so an unregistered name throws a
+    // lower-level error inside Tokenizer rather than UnknownLanguageError.
+    const session = contractRegistry.createSession("javascript");
+    const snapshot = session.snapshot();
+    expect(() =>
+      contractRegistry.resume("code", "not-a-language", snapshot),
+    ).toThrow();
   });
 });

--- a/tests/registry.test.ts
+++ b/tests/registry.test.ts
@@ -1,0 +1,54 @@
+import {
+  createRegistry,
+  TokenizerLoopError,
+  UnknownLanguageError,
+} from "../src/engine.js";
+import javascript from "../src/languages/javascript.js";
+
+const registry = createRegistry();
+registry.register(javascript.register);
+
+describe("UnknownLanguageError", () => {
+  it("is thrown by tokenize for an unregistered language", () => {
+    expect(() => registry.tokenize("code", "not-a-real-language")).toThrow(
+      UnknownLanguageError,
+    );
+    try {
+      registry.tokenize("code", "not-a-real-language");
+    } catch (err) {
+      expect(err).toBeInstanceOf(Error);
+      expect(err).toBeInstanceOf(UnknownLanguageError);
+      expect((err as UnknownLanguageError).language).toBe(
+        "not-a-real-language",
+      );
+    }
+  });
+
+  it("is thrown by highlight and tokenizeRanges, via tokenize delegation", () => {
+    expect(() =>
+      registry.highlight("code", { language: "not-a-real-language" }),
+    ).toThrow(UnknownLanguageError);
+    expect(() =>
+      registry.tokenizeRanges("code", { language: "not-a-real-language" }),
+    ).toThrow(UnknownLanguageError);
+  });
+
+  it("is thrown by createSession for an unregistered language", () => {
+    expect(() => registry.createSession("not-a-real-language")).toThrow(
+      UnknownLanguageError,
+    );
+  });
+});
+
+describe("TokenizerLoopError", () => {
+  it("carries name, message, and structured fields", () => {
+    // Triggering the real 500,000-iteration path isn't a fast unit test;
+    // this only pins the error's shape.
+    const err = new TokenizerLoopError("fakelang", 500001);
+    expect(err).toBeInstanceOf(Error);
+    expect(err.name).toBe("TokenizerLoopError");
+    expect(err.message).toBe("potential infinite loop (fakelang)");
+    expect(err.grammarName).toBe("fakelang");
+    expect(err.iterations).toBe(500001);
+  });
+});

--- a/tests/transformers.test.ts
+++ b/tests/transformers.test.ts
@@ -1,0 +1,106 @@
+import { createRegistry, renderHtml, TEXT } from "../src/engine.js";
+import javascript from "../src/languages/javascript.js";
+import {
+  markLines,
+  markPattern,
+  markWhitespace,
+  transformEvents,
+} from "../src/transformers.js";
+
+const registry = createRegistry();
+registry.register(javascript.register);
+
+describe("transformEvents", () => {
+  it("is a no-op with no transforms", () => {
+    const { events } = registry.tokenize("const x = 1;", "javascript");
+    expect(transformEvents(events, [])).toEqual(events);
+  });
+});
+
+describe("markPattern", () => {
+  it("wraps exactly one match, preserving TEXT concatenation", () => {
+    const { events } = registry.tokenize("const x = 1;", "javascript");
+    const before = events
+      .filter((e) => e.t === TEXT)
+      .map((e) => e.v)
+      .join("");
+
+    const out = markPattern(/\bconst\b/g, "kw")(events);
+    const after = out
+      .filter((e) => e.t === TEXT)
+      .map((e) => e.v)
+      .join("");
+    expect(after).toBe(before);
+
+    const opens = out.filter((e) => e.t === 1 && e.s === "kw");
+    expect(opens).toHaveLength(1);
+  });
+
+  it("throws on a non-global pattern", () => {
+    expect(() => markPattern(/const/, "kw")).toThrow();
+  });
+});
+
+describe("markWhitespace", () => {
+  it("marks a tab and trailing spaces", () => {
+    const events = [{ t: TEXT, v: "a\t\nb  \n" } as const];
+    const out = markWhitespace()(events);
+
+    const tabOpens = out.filter((e) => e.t === 1 && e.s === "ws-tab");
+    const trailingOpens = out.filter((e) => e.t === 1 && e.s === "ws-trailing");
+    expect(tabOpens.length).toBeGreaterThanOrEqual(1);
+    expect(trailingOpens.length).toBeGreaterThanOrEqual(1);
+
+    const text = out
+      .filter((e) => e.t === TEXT)
+      .map((e) => e.v)
+      .join("");
+    expect(text).toBe("a\t\nb  \n");
+  });
+});
+
+describe("markLines", () => {
+  it("is a no-op with no decorated lines", () => {
+    const { events } = registry.tokenize("const x = 1;", "javascript");
+    expect(markLines({})(events)).toEqual(events);
+  });
+
+  it("stays balanced and resumes a scope spanning into a decorated line", () => {
+    const code = "/* block\n   comment */\nconsole.log(3);\n";
+    const { events } = registry.tokenize(code, "javascript");
+
+    const out = markLines({ 2: "mark" })(events);
+
+    // TEXT concatenation is preserved.
+    const before = events
+      .filter((e) => e.t === TEXT)
+      .map((e) => e.v)
+      .join("");
+    const after = out
+      .filter((e) => e.t === TEXT)
+      .map((e) => e.v)
+      .join("");
+    expect(after).toBe(before);
+
+    // stack-depth walker never goes negative, ends at 0
+    let depth = 0;
+    for (const ev of out) {
+      if (ev.t === 1) depth++;
+      else if (ev.t === 2) {
+        depth--;
+        expect(depth).toBeGreaterThanOrEqual(0);
+      }
+    }
+    expect(depth).toBe(0);
+
+    // line 2 is wrapped, with the comment scope resumed inside it
+    const html = renderHtml(out);
+    expect(html).toContain('<span class="hljs-mark">');
+    const markStart = html.indexOf('<span class="hljs-mark">');
+    const afterMark = html.slice(
+      markStart,
+      markStart + '<span class="hljs-mark">'.length + 40,
+    );
+    expect(afterMark).toContain('<span class="hljs-comment">');
+  });
+});


### PR DESCRIPTION
Adds a composable transform layer over the engine's scope-event
stream, typed errors for two existing plain-Error throws, and wires
the engine-vs-hljs perf budget script into CI so a regression past
1.5x actually fails the build.

```js
import { registry } from "svelte-highlight/registry";
import { markPattern, transformEvents } from "svelte-highlight/transformers";

const { events } = registry.tokenize(code, "javascript");
const marked = transformEvents(events, [markPattern(/\bTODO\b/g, "mark")]);
```

Also documents CDN/no-bundler usage of the engine, and that a
grammar's `illegal` pattern only aborts auto-detection, not an
explicit-language `tokenize`/`highlight` call.