### PR TITLE
feat(worker): add serveHighlighter and createWorkerHighlighter

### DIFF
--- a/README.md
+++ b/README.md
@@ -2407,6 +2407,7 @@ See it as a complete page in [examples/cdn](examples/cdn).
 
 - **Stable, semver-governed:** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`, `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`, `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`, `Registry` and its methods, `createRegistry`, `registerAll`, `StreamSession`, `TokenizedDocument`, `createTokenizedDocument`, `TextSegment`, `FenceSegment`, `MarkdownSegment`, `FenceSplitter`, `createFenceSplitter`, `UnknownLanguageError`, `TokenizerLoopError`. `Snapshot` is a serializable format that round-trips within one library version, but is **not** guaranteed stable across versions — a snapshot from an older release may be rejected on resume. The same caveat applies to `TokenizedDocument`: its method surface (`setCode`/`append`/`lineCount`/`lineRange`/`tokenizedThrough`/`checkpointCount`) is stable and semver-governed, but internally it resumes from `Snapshot`s the same way `StreamSession` does, so anything that tried to serialize and later resume a `TokenizedDocument`'s internal state directly would hit the same cross-version instability -- the public API doesn't expose that today.
 - **Generated data, versioned with the library:** `GrammarIR`/`GrammarState`. These come from the build pipeline and are consumed by `registerAll`; treat them as opaque payloads whose field-level structure may change in any minor release. Always load grammars from the same package version as the engine.
+- **Experimental, may change in a minor release:** `createWorkerHighlighter`, `serveHighlighter`, `PostMessageTarget`, `WorkerHighlighter`, `WorkerSession`, `ServeHighlighterOptions` (`svelte-highlight/worker`). The wire protocol between the two halves is not part of the public contract — only the documented function behavior is.
 
 ### Headless highlighting, isolated registry
 
@@ -2450,6 +2451,45 @@ session.replace(from, to, text); // patch an earlier range without restarting
 const snapshot = session.snapshot(); // JSON-serializable checkpoint
 const { value } = session.finish();
 ```
+
+### Highlighting in a Web Worker
+
+`svelte-highlight/worker` is a headless pair — a worker-side handler and a main-thread client — for running the engine off the main thread. Both halves have zero Svelte dependency.
+
+```js
+// highlight.worker.js
+import { serveHighlighter } from "svelte-highlight/worker";
+serveHighlighter();
+```
+
+```js
+import { createWorkerHighlighter } from "svelte-highlight/worker";
+
+const highlighter = createWorkerHighlighter(
+  typeof Worker !== "undefined"
+    ? new Worker(new URL("./highlight.worker.js", import.meta.url), { type: "module" })
+    : undefined,
+);
+```
+
+An omitted (or falsy) `worker` runs the identical API in-process against `svelte-highlight/registry`'s shared singleton instead — the SSR/tests fallback, and why the construction above is a single ternary: the same code works whether or not `Worker` exists in the current environment.
+
+```js
+const { value } = await highlighter.highlight(code, "typescript");
+const lines = await highlighter.tokenLines(code, "typescript");
+```
+
+Streaming works the same way as `registry.createSession`, just async:
+
+```js
+const session = highlighter.createSession("typescript");
+await session.append(chunk); // repeat as chunks arrive
+await session.replace(from, to, text); // patch an earlier range without restarting
+const snapshot = await session.snapshot(); // JSON-serializable checkpoint
+const { value } = await session.finish();
+```
+
+Grammars load lazily inside the worker, per language, the first time each is seen. `HighlightStream` can't yet consume a remote, worker-backed session — its incremental rendering assumes a same-thread `StreamSession` — so streaming highlight results back into a component still requires posting the resolved HTML/events yourself. `terminate()` tears down the underlying `Worker` (a no-op in local mode).
 
 ### Reaching the stream from a component — no HTML re-parsing
 

--- a/README.md
+++ b/README.md
@@ -2551,6 +2551,7 @@ By default, example set-ups use Svelte 5. The exception is `examples/vite@svelte
 - [examples/vite](examples/vite)
 - [examples/vite@svelte-4](examples/vite@svelte-4)
 - [examples/webpack](examples/webpack)
+- [examples/worker](examples/worker)
 
 ## [Changelog](CHANGELOG.md)
 

--- a/examples/worker/.gitignore
+++ b/examples/worker/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+node_modules
+dist

--- a/examples/worker/README.md
+++ b/examples/worker/README.md
@@ -1,0 +1,21 @@
+# examples/worker
+
+> `svelte-highlight` Web Worker set-up.
+
+## Available Scripts
+
+### `bun dev`
+
+Runs the project in development mode and watches for any changes.
+
+### `bun run build`
+
+Builds the project for production.
+
+### `bun preview`
+
+Preview the app locally. Run `bun run build` first.
+
+## What this demonstrates
+
+`App.svelte` generates a ~1 MB TypeScript file on mount and highlights it via `createWorkerHighlighter`, which round-trips the call through `highlight.worker.js` (a two-line `serveHighlighter()` recipe). While the highlight is pending, a counter driven by `setInterval` keeps animating on the main thread — visible proof that tokenizing a multi-MB file isn't blocking the UI, rather than something merely asserted.

--- a/examples/worker/bun.lock
+++ b/examples/worker/bun.lock
@@ -1,0 +1,193 @@
+{
+  "lockfileVersion": 2,
+  "configVersion": 1,
+  "workspaces": {
+    "": {
+      "dependencies": {
+        "svelte-highlight": "^7.21.0",
+      },
+      "devDependencies": {
+        "@sveltejs/vite-plugin-svelte": "latest",
+        "@tsconfig/svelte": "latest",
+        "svelte": "latest",
+        "typescript": "latest",
+        "vite": "latest",
+      },
+    },
+  },
+  "packages": {
+    "@jridgewell/gen-mapping": ["@jridgewell/gen-mapping@0.3.13", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.0", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA=="],
+
+    "@jridgewell/remapping": ["@jridgewell/remapping@2.3.5", "", { "dependencies": { "@jridgewell/gen-mapping": "^0.3.5", "@jridgewell/trace-mapping": "^0.3.24" } }, "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ=="],
+
+    "@jridgewell/resolve-uri": ["@jridgewell/resolve-uri@3.1.2", "", {}, "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw=="],
+
+    "@jridgewell/sourcemap-codec": ["@jridgewell/sourcemap-codec@1.6.0", "", {}, "sha512-T7jf+5zgsZHwNJ4lvQ7/aezbyk0nNX+zJVWpmHA7VYsEx7a7qr5Rg5IbtJFqkgze5Y2sruq1RUY8Q837Od7iFw=="],
+
+    "@jridgewell/trace-mapping": ["@jridgewell/trace-mapping@0.3.31", "", { "dependencies": { "@jridgewell/resolve-uri": "^3.1.0", "@jridgewell/sourcemap-codec": "^1.4.14" } }, "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw=="],
+
+    "@oxc-project/types": ["@oxc-project/types@0.148.0", "", {}, "sha512-Nm4s/jB+4FpFsPhWGEC4h7rzksesmtnMXomo6rCMcg/b8zLQuOziRgkCS1fxDCXOlJB/6Q8oABOZ/OP6RIPj9A=="],
+
+    "@rolldown/binding-android-arm-eabi": ["@rolldown/binding-android-arm-eabi@1.2.7", "", { "os": "android", "cpu": "arm" }, "sha512-EypzgnYCwyVY4NDHKzGmNJT5b+XaQEBniHxsMdeIQLB/tcCzZnhqrzHpZFbX9iaxx+5RiB8caATBtfvZP7zVxQ=="],
+
+    "@rolldown/binding-android-arm64": ["@rolldown/binding-android-arm64@1.2.7", "", { "os": "android", "cpu": "arm64" }, "sha512-l17HE9EweWaqJZhuUuNBN/FzM62xw+DECVnJyvMsxn8vJFAGLy5QfLDoYAcronkAN8VxKZHezDpulHDPx95vFw=="],
+
+    "@rolldown/binding-darwin-arm64": ["@rolldown/binding-darwin-arm64@1.2.7", "", { "os": "darwin", "cpu": "arm64" }, "sha512-8ED8ELFvHXc6OCETIn4gXObPiaR6bckM/ipXtbzlPVDRMBfEGjCKgO90F9YtfdpDatVx/ZQw7aZ1vUMf/+T3Mw=="],
+
+    "@rolldown/binding-darwin-x64": ["@rolldown/binding-darwin-x64@1.2.7", "", { "os": "darwin", "cpu": "x64" }, "sha512-/WPripjtiAIZ2tWY7ddijORT0Ujg87wxWW/qcoFVCKAWVDPhtY0xr7Dj0M3GyNGz60jGwTElhro/mkF9dT7dDQ=="],
+
+    "@rolldown/binding-freebsd-x64": ["@rolldown/binding-freebsd-x64@1.2.7", "", { "os": "freebsd", "cpu": "x64" }, "sha512-14DI4NcqpvbICxSnGLx3PmtDaWqRP/KGSGb6C+JLLVPeZRl6dKdHba3pGsqT3vpdTqhEYIPG0MMQ8c0xYqoJxA=="],
+
+    "@rolldown/binding-linux-arm-gnueabihf": ["@rolldown/binding-linux-arm-gnueabihf@1.2.7", "", { "os": "linux", "cpu": "arm" }, "sha512-bxrWIRvHWQvbJwi+VIie/kDJmQxcNE6xxWwZdqF/ExVAigtHkv54WTLQPb+QsZdnFy18fg7JPfWGL0RH6vwIlQ=="],
+
+    "@rolldown/binding-linux-arm64-gnu": ["@rolldown/binding-linux-arm64-gnu@1.2.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-toOY2BChBZyuxU7OYX6Tn389di4IzAqPTycVcci0O7FSfBqzRB3RZn+K5Is6ANf4tmgRd/K1yZTsNTXbkXsnLg=="],
+
+    "@rolldown/binding-linux-arm64-musl": ["@rolldown/binding-linux-arm64-musl@1.2.7", "", { "os": "linux", "cpu": "arm64" }, "sha512-lAIXTH/aiLRLxsTgQvfhjo4K1ydWIp00+V0voOr9beb/9ZmkUFrSIb03dXNFRgMNvkE6oGsF10ioQ6UsI+vS5Q=="],
+
+    "@rolldown/binding-linux-ppc64-gnu": ["@rolldown/binding-linux-ppc64-gnu@1.2.7", "", { "os": "linux", "cpu": "ppc64" }, "sha512-kdnwS28Pkenp/mZMRwjXXXwxQ7pIsm+bF919LUK93BOyhcLsrVKdP2p9fxpiPNPAbNuch8ypQt0pm2P2LYCAGg=="],
+
+    "@rolldown/binding-linux-s390x-gnu": ["@rolldown/binding-linux-s390x-gnu@1.2.7", "", { "os": "linux", "cpu": "s390x" }, "sha512-516OdsyLdr5E65paF3yBF55t8mfm9+gmtCsK3xI7XKXIT7EfRlHhxL8K/NR6Hu8BWSgF5+1w74lTL0+nxcc8Qw=="],
+
+    "@rolldown/binding-linux-x64-gnu": ["@rolldown/binding-linux-x64-gnu@1.2.7", "", { "os": "linux", "cpu": "x64" }, "sha512-r8/z8n7GFaYRln3xmP1Cxy0HH/HLM0uBUPkEuSVEfKGDA89M0FsZRZJRSwe/tJjRx+fpH/gjorfhB8tmEbSFLA=="],
+
+    "@rolldown/binding-linux-x64-musl": ["@rolldown/binding-linux-x64-musl@1.2.7", "", { "os": "linux", "cpu": "x64" }, "sha512-pAsE8iiDxUg1xBqdhrTfg45AVDVpirjz00sblEYClGNNcMnDb+e8beQgqIAw6LvauX/APvgxUnwrgun/YYGBhw=="],
+
+    "@rolldown/binding-openharmony-arm64": ["@rolldown/binding-openharmony-arm64@1.2.7", "", { "os": "none", "cpu": "arm64" }, "sha512-lTcIYmmnQQA8Or/2DatS6oSqcdLHvendjS+zLu+FwgToynWMRSmQdpM65fTANJgIS4mjbMOo5KT2lnT9SAb96w=="],
+
+    "@rolldown/binding-win32-arm64-msvc": ["@rolldown/binding-win32-arm64-msvc@1.2.7", "", { "os": "win32", "cpu": "arm64" }, "sha512-e3Gu3WxbNk/UqQhxqU7YIYO+9ZBvWNz3U+h/qRFosscMFzdRPbXYSaSWgSnklv2fz1TgzBTcti2z35c/7irsHw=="],
+
+    "@rolldown/binding-win32-x64-msvc": ["@rolldown/binding-win32-x64-msvc@1.2.7", "", { "os": "win32", "cpu": "x64" }, "sha512-W/jg5qoRSqjsEv0+dZi4e687mcHqmVuU0P4fK6qS/xjetW2Gmc1W8j//z5nAeNcC8Ttm0hV46IjcYeuVwYhuiw=="],
+
+    "@rolldown/pluginutils": ["@rolldown/pluginutils@1.0.1", "", {}, "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw=="],
+
+    "@sveltejs/acorn-typescript": ["@sveltejs/acorn-typescript@1.0.13", "", { "peerDependencies": { "acorn": "^8.9.0" } }, "sha512-wgKggnhZVL9Bfx1OaKKTrYY9BFRk6C8UAkQNUcIv1+llzYrIqy+RZm5HPKzn0NpEBvTVhTqB4kQyllZywsRBRQ=="],
+
+    "@sveltejs/vite-plugin-svelte": ["@sveltejs/vite-plugin-svelte@7.3.0", "", { "dependencies": { "deepmerge": "^4.3.1", "magic-string": "^1.0.0", "obug": "^2.1.0", "vitefu": "^1.1.2" }, "peerDependencies": { "svelte": "^5.46.4", "vite": "^8.0.0-beta.7 || ^8.0.0" } }, "sha512-QbRoJyD92e9R0ufeQIWRHrCC0ObcqSv/aBDdrQMoU+sypav3cDx5wytdQ6GLdXjEMO6xjrXGzfkUygng8JMv0A=="],
+
+    "@tsconfig/svelte": ["@tsconfig/svelte@5.0.8", "", {}, "sha512-UkNnw1/oFEfecR8ypyHIQuWYdkPvHiwcQ78sh+ymIiYoF+uc5H1UBetbjyqT+vgGJ3qQN6nhucJviX6HesWtKQ=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+
+    "acorn": ["acorn@8.18.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-lGq+9yr1/GuAWaVYIHRjvvySG5/4VfKIvC8EWxStPdcDh/Ka7FG3twP6v4d5BkravUilhIAsG4Qj83t02LWUPQ=="],
+
+    "aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
+
+    "axobject-query": ["axobject-query@4.1.0", "", {}, "sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ=="],
+
+    "clsx": ["clsx@2.1.1", "", {}, "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
+
+    "detect-libc": ["detect-libc@2.1.2", "", {}, "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ=="],
+
+    "devalue": ["devalue@5.9.2", "", {}, "sha512-po4PAY5c53tw5XMocSnf8A/5OHhbbUftpr93aEN6BBoAdntUmK7vu7wOATqvt7cXO7m1Cl4gMVn6p7n6n4mj0w=="],
+
+    "esm-env": ["esm-env@1.2.2", "", {}, "sha512-Epxrv+Nr/CaL4ZcFGPJIYLWFom+YeV1DqMLHJoEd9SYRxNbaFruBwfEX/kkHUJf55j2+TUbmDcmuilbP1TmXHA=="],
+
+    "esrap": ["esrap@2.3.7", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.4.15" }, "peerDependencies": { "@typescript-eslint/types": "^8.2.0" }, "optionalPeers": ["@typescript-eslint/types"] }, "sha512-n2nf7fZR3c9yXf0BPEuHuXqT+KW0SJVj4cN5FMEkpCZ3scLjOQWpiccyCxVzCC2q1wubTghuEGzngJY/7Ah0Ow=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "fsevents": ["fsevents@2.3.3", "", { "os": "darwin" }, "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw=="],
+
+    "is-reference": ["is-reference@3.0.3", "", { "dependencies": { "@types/estree": "^1.0.6" } }, "sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw=="],
+
+    "lightningcss": ["lightningcss@1.33.0", "", { "dependencies": { "detect-libc": "^2.0.3" }, "optionalDependencies": { "lightningcss-android-arm64": "1.33.0", "lightningcss-darwin-arm64": "1.33.0", "lightningcss-darwin-x64": "1.33.0", "lightningcss-freebsd-x64": "1.33.0", "lightningcss-linux-arm-gnueabihf": "1.33.0", "lightningcss-linux-arm64-gnu": "1.33.0", "lightningcss-linux-arm64-musl": "1.33.0", "lightningcss-linux-x64-gnu": "1.33.0", "lightningcss-linux-x64-musl": "1.33.0", "lightningcss-win32-arm64-msvc": "1.33.0", "lightningcss-win32-x64-msvc": "1.33.0" } }, "sha512-WkUDrojuJs0xkgGf2udWxa3yGBRxPtxUkB79i6aCZLRgc7PM8fZe9TosfPDcvEpQZbuFASnHYmRLBLUbmLOIIA=="],
+
+    "lightningcss-android-arm64": ["lightningcss-android-arm64@1.33.0", "", { "os": "android", "cpu": "arm64" }, "sha512-gEpRTalKdosp4Bb8qWtc2iOgE5SeIHlpS1up9bFq2wAyYhl1UdTObYiHe98zEM9SQvSoqQZ1IQD0JNpg3Ml5pg=="],
+
+    "lightningcss-darwin-arm64": ["lightningcss-darwin-arm64@1.33.0", "", { "os": "darwin", "cpu": "arm64" }, "sha512-Sciaz8eenNTKn9b3t7+xr0ipTp9YxKQY4npwQ3mrRuL0BAVHBLyZxofhaKBAVtzmtRZ/zTyo0/to4B1uWG/Djg=="],
+
+    "lightningcss-darwin-x64": ["lightningcss-darwin-x64@1.33.0", "", { "os": "darwin", "cpu": "x64" }, "sha512-Z5UPAxzrjlWNNyGy6i65cJzzvgJ5D3T6wMvs+gWpY9d7qRhANrxqAp6LhxIgZhWEw18RfJTGcRxjuLIBr+m8XQ=="],
+
+    "lightningcss-freebsd-x64": ["lightningcss-freebsd-x64@1.33.0", "", { "os": "freebsd", "cpu": "x64" }, "sha512-QQM/Ti/hQajJwCY+RiWuCZ9sdtI/XQk7nDK5vC8kkdwixezOlDgvDx7+RT+QjK6FcFT4MpsuoBnHIo/O3StRRg=="],
+
+    "lightningcss-linux-arm-gnueabihf": ["lightningcss-linux-arm-gnueabihf@1.33.0", "", { "os": "linux", "cpu": "arm" }, "sha512-N7FVBe6iS24MlM6R/4RBTxGhQheZGs7tiQ9U32UtF75NzP5Q7xWPRqLBCKxlRQRk3rY1jCIPLzx7WzOhuUIRLQ=="],
+
+    "lightningcss-linux-arm64-gnu": ["lightningcss-linux-arm64-gnu@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-j2v/itmy4HlNxlc6voKXYgBqNi0Ng2LShg4z7GufpEgs05P+2suBVyi9I6YHq5uoVFx9ETin3eCEhLVyXGQnKg=="],
+
+    "lightningcss-linux-arm64-musl": ["lightningcss-linux-arm64-musl@1.33.0", "", { "os": "linux", "cpu": "arm64" }, "sha512-yiO5ROMuYQgXbC60yjZU5CYSFZGKXL0HFATXt9mHJn1+zW55oCtMI9NfcVhYLMFDL7gV7oBPon/EmMMGg2OvtQ=="],
+
+    "lightningcss-linux-x64-gnu": ["lightningcss-linux-x64-gnu@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-ar+Ju7LmcN0Jo4FpL4hpFybwNG9/3A/Br5KW2n2jyODg3MEZXaDYADdemoNS+BDNfMgKvylJLj4S5tyRActuAg=="],
+
+    "lightningcss-linux-x64-musl": ["lightningcss-linux-x64-musl@1.33.0", "", { "os": "linux", "cpu": "x64" }, "sha512-RYiYbkokw0trfKqqzfF55lginwEPrD3OJDfTuJzFs1MK6iFnDenaz1fqLLtX4ITG3OktJQXOeTaw1awrBAlZPw=="],
+
+    "lightningcss-win32-arm64-msvc": ["lightningcss-win32-arm64-msvc@1.33.0", "", { "os": "win32", "cpu": "arm64" }, "sha512-1K+MPfLSFVpphzpdbfkhlWk6wBrTObBzS2T6db10PNOZgR9GoVsAWzwNyuhUYYbTp23j+4RrncfujZ4uAzXvwA=="],
+
+    "lightningcss-win32-x64-msvc": ["lightningcss-win32-x64-msvc@1.33.0", "", { "os": "win32", "cpu": "x64" }, "sha512-OlEICDx/Xl0FqSp4bry8zFnCvGpig3Gl4gCquvYwHuqJKEC1+n9NgDniFvqHGmMv1ZkqDJrDqKKSykTDX+ehuA=="],
+
+    "locate-character": ["locate-character@3.0.0", "", {}, "sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA=="],
+
+    "magic-string": ["magic-string@1.2.3", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-Bpb0W2TbLKOZ7vJnOUnVRGq3WL2p+ISV29M6hYPL1AFCpyKZpdr5ytiXoTSSxRVhg8YW7f65+6gbG8WG6PCa/g=="],
+
+    "nanoid": ["nanoid@3.3.18", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-DTg4MJbGMWkfi6VZFdNt2/caMbQy4Ou+Op/hJQvGEWcnVfoA1QA+xzRKAzw9jD6+GVOOeYr/mIcuDSdug6F6+w=="],
+
+    "obug": ["obug@2.1.4", "", {}, "sha512-4a+OsYv9UktOJKE+l1A4OufDgdRF9PifWj+tJnHURo/P+WOxpG4GzUFL9qCalmWauao6ogiG+QvnCovwPoyAWA=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
+    "picomatch": ["picomatch@4.0.7", "", {}, "sha512-qcJu88Q2IWqJsDD529JKMdwGm/dvInW4HvQnRwiH9JtihJvzGOscDtHE3x1pBKeUOTysQ8kVmLnJ2kJu7yhcGA=="],
+
+    "postcss": ["postcss@8.5.28", "", { "dependencies": { "nanoid": "^3.3.18", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-RRuzqDtt5Y9h3quz5hWhK+TPnsmVs6WwSU6LkJMeY4HstUEDuYTG8UJSdawMRzmzAtV+KEoG8N3Qg2qLy5vM/A=="],
+
+    "rolldown": ["rolldown@1.2.7", "", { "dependencies": { "@oxc-project/types": "=0.148.0", "@rolldown/pluginutils": "^1.0.0" }, "optionalDependencies": { "@rolldown/binding-android-arm-eabi": "1.2.7", "@rolldown/binding-android-arm64": "1.2.7", "@rolldown/binding-darwin-arm64": "1.2.7", "@rolldown/binding-darwin-x64": "1.2.7", "@rolldown/binding-freebsd-x64": "1.2.7", "@rolldown/binding-linux-arm-gnueabihf": "1.2.7", "@rolldown/binding-linux-arm64-gnu": "1.2.7", "@rolldown/binding-linux-arm64-musl": "1.2.7", "@rolldown/binding-linux-ppc64-gnu": "1.2.7", "@rolldown/binding-linux-s390x-gnu": "1.2.7", "@rolldown/binding-linux-x64-gnu": "1.2.7", "@rolldown/binding-linux-x64-musl": "1.2.7", "@rolldown/binding-openharmony-arm64": "1.2.7", "@rolldown/binding-win32-arm64-msvc": "1.2.7", "@rolldown/binding-win32-x64-msvc": "1.2.7" }, "bin": { "rolldown": "./bin/cli.mjs" } }, "sha512-g0EtLvBjTUB7jhyV0S/TCup3v/XSVl45vUIGbOGU4QPiyjTenCe4mKuFvW9fEgYmS2Fo42AUssRmNuMziXdrig=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
+
+    "svelte": ["svelte@5.57.0", "", { "dependencies": { "@jridgewell/remapping": "^2.3.4", "@jridgewell/sourcemap-codec": "^1.5.0", "@sveltejs/acorn-typescript": "^1.0.10", "@types/estree": "^1.0.5", "acorn": "^8.12.1", "aria-query": "5.3.1", "axobject-query": "^4.1.0", "clsx": "^2.1.1", "devalue": "^5.8.1", "esm-env": "^1.2.1", "esrap": "^2.2.12", "is-reference": "^3.0.3", "locate-character": "^3.0.0", "magic-string": "^0.30.11", "zimmerframe": "^1.1.2" } }, "sha512-NdbDn7fl4be1ViUG0oq/lvG6OZy3oENolV2ONjiqqsfVoeAfzaQAKUcEX3MrQod/Bebv1PgwET9rfXhgn9s4Kg=="],
+
+    "svelte-highlight": ["svelte-highlight@7.21.0", "", {}, "sha512-NpVt0n6ihgjK2H0w3vkwnKTC/ab4QCuxRgsb9EZdGxcr19fS9zIuJWewYAMD04aKfLoc/ziLQuPv0McFzcD7zQ=="],
+
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+
+    "vite": ["vite@8.2.2", "", { "dependencies": { "lightningcss": "^1.33.0", "picomatch": "^4.0.5", "postcss": "^8.5.26", "rolldown": "~1.2.4", "tinyglobby": "^0.2.17" }, "optionalDependencies": { "fsevents": "~2.3.3" }, "peerDependencies": { "@types/node": "^20.19.0 || >=22.12.0", "@vitejs/devtools": "^0.4.0 || ^0.5.0", "esbuild": "^0.27.0 || ^0.28.0", "jiti": ">=1.21.0", "less": "^4.0.0", "sass": "^1.70.0", "sass-embedded": "^1.70.0", "stylus": ">=0.54.8", "sugarss": "^5.0.0", "terser": "^5.16.0", "tsx": "^4.8.1", "yaml": "^2.4.2" }, "optionalPeers": ["@types/node", "@vitejs/devtools", "esbuild", "jiti", "less", "sass", "sass-embedded", "stylus", "sugarss", "terser", "tsx", "yaml"], "bin": { "vite": "bin/vite.js" } }, "sha512-cFKLV/PRgAUlIRm5WjMjJ86jrftzpqcgH+Us+DS8mI3CDNiH30Whrz8uHL3+MOLPAgqbMBAqWdAHAphOAM+z/Q=="],
+
+    "vitefu": ["vitefu@1.1.3", "", { "peerDependencies": { "vite": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0" }, "optionalPeers": ["vite"] }, "sha512-ub4okH7Z5KLjb6hDyjqrGXqWtWvoYdU3IGm/NorpgHncKoLTCfRIbvlhBm7r0YstIaQRYlp4yEbFqDcKSzXSSg=="],
+
+    "zimmerframe": ["zimmerframe@1.1.5", "", {}, "sha512-msJxIvYDYcoNL+PJsu+7qmpDWsYmAxTY+2TNYXXF0hzBzBk0BMecOqDOG/EckUoKCuKwObfbugIl8QpqHDXeFA=="],
+
+    "svelte/magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+  }
+}

--- a/examples/worker/index.html
+++ b/examples/worker/index.html
@@ -1,0 +1,15 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  </head>
+  <body>
+    <script type="module">
+      import { mount } from "svelte";
+      import App from "./src/App.svelte";
+
+      mount(App, { target: document.body });
+    </script>
+  </body>
+</html>

--- a/examples/worker/package.json
+++ b/examples/worker/package.json
@@ -1,0 +1,19 @@
+{
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "dev": "vite",
+    "build": "vite build",
+    "preview": "vite preview"
+  },
+  "dependencies": {
+    "svelte-highlight": "^7.21.0"
+  },
+  "devDependencies": {
+    "@sveltejs/vite-plugin-svelte": "latest",
+    "@tsconfig/svelte": "latest",
+    "svelte": "latest",
+    "typescript": "latest",
+    "vite": "latest"
+  }
+}

--- a/examples/worker/src/App.svelte
+++ b/examples/worker/src/App.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { onMount } from "svelte";
+  import { createWorkerHighlighter } from "svelte-highlight/worker";
+
+  // 14,000 lines joins to just over 1,000,000 characters.
+  const LINE_COUNT = 14000;
+
+  function makeCode(): string {
+    return Array.from(
+      { length: LINE_COUNT },
+      (_, i) =>
+        `function fn${i}(a: number, b: number): number {\n  return a + b + ${i};\n}\n`,
+    ).join("\n");
+  }
+
+  let value = "";
+  let done = false;
+  let elapsedMs = 0;
+  let styles: string;
+
+  onMount(async () => {
+    styles = (await import("svelte-highlight/styles/atom-one-dark")).default;
+
+    const code = makeCode();
+    const worker = new Worker(
+      new URL("./highlight.worker.js", import.meta.url),
+      { type: "module" },
+    );
+    const highlighter = createWorkerHighlighter(worker);
+
+    const start = performance.now();
+    const timer = setInterval(() => {
+      elapsedMs = performance.now() - start;
+    }, 50);
+
+    const result = await highlighter.highlight(code, "typescript");
+    clearInterval(timer);
+    value = result.value;
+    done = true;
+  });
+</script>
+
+<svelte:head>
+  {#if styles}
+    {@html styles}
+  {/if}
+</svelte:head>
+
+{#if !done}
+  <p>
+    Highlighting a ~1 MB file in a Worker… {Math.round(elapsedMs)}ms elapsed.
+    This counter keeps ticking on the main thread the whole time, proving
+    it's not blocked.
+  </p>
+{:else}
+  <pre class="hljs"><code>{@html value}</code></pre>
+{/if}

--- a/examples/worker/src/highlight.worker.js
+++ b/examples/worker/src/highlight.worker.js
@@ -1,0 +1,2 @@
+import { serveHighlighter } from "svelte-highlight/worker";
+serveHighlighter();

--- a/examples/worker/tsconfig.json
+++ b/examples/worker/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "@tsconfig/svelte/tsconfig.json",
+  "compilerOptions": {
+    "strict": true
+  },
+  "include": ["src/**/*.d.ts", "src/**/*.ts", "src/**/*.svelte"]
+}

--- a/examples/worker/vite.config.ts
+++ b/examples/worker/vite.config.ts
@@ -1,0 +1,13 @@
+import { svelte, vitePreprocess } from "@sveltejs/vite-plugin-svelte";
+import type { UserConfig } from "vite";
+
+export default {
+  resolve: {
+    conditions: ["browser"],
+  },
+  plugins: [
+    svelte({
+      preprocess: vitePreprocess(),
+    }),
+  ],
+} satisfies UserConfig;

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -156,6 +156,8 @@ pkgJson.exports = {
     types: "./transformers.d.ts",
     default: "./transformers.js",
   },
+  "./worker": { types: "./worker.d.ts", import: "./worker.js" },
+  "./worker.js": { types: "./worker.d.ts", import: "./worker.js" },
   "./package.json": "./package.json",
 };
 

--- a/src/worker.d.ts
+++ b/src/worker.d.ts
@@ -1,0 +1,45 @@
+import type {
+  HighlightResult,
+  LineToken,
+  Registry,
+  ScopeEvent,
+  Snapshot,
+} from "./engine.d.ts";
+import type { LanguageType } from "./languages/index.d.ts";
+
+/** Shape both a real `Worker` and a `MessagePort` satisfy. */
+export interface PostMessageTarget {
+  postMessage(message: unknown, transfer?: Transferable[]): void;
+  onmessage: ((event: MessageEvent) => void) | null;
+  terminate?(): void;
+  close?(): void;
+}
+
+export interface ServeHighlighterOptions {
+  registry?: Registry;
+  loadLanguage?: (name: string) => Promise<LanguageType<string>>;
+}
+
+export declare function serveHighlighter(
+  scope?: PostMessageTarget,
+  options?: ServeHighlighterOptions,
+): void;
+
+export interface WorkerSession {
+  append(chunk: string): Promise<void>;
+  replace(from: number, to: number, text: string): Promise<void>;
+  finish(options?: { canonicalize?: boolean }): Promise<HighlightResult>;
+  events(): Promise<ScopeEvent[]>;
+  snapshot(): Promise<Snapshot>;
+}
+
+export interface WorkerHighlighter {
+  highlight(code: string, language: string): Promise<HighlightResult>;
+  tokenLines(code: string, language: string): Promise<LineToken[][]>;
+  createSession(language: string): WorkerSession;
+  terminate(): void;
+}
+
+export declare function createWorkerHighlighter(
+  worker?: PostMessageTarget,
+): WorkerHighlighter;

--- a/src/worker.js
+++ b/src/worker.js
@@ -1,0 +1,379 @@
+import { createRegistry, registerAll, tokenLines } from "./engine.js";
+import { resolveLanguageName } from "./fence.js";
+import { LanguageLoadError, loadLanguage } from "./load-language.js";
+import { ensureRegistered, registry as sharedRegistry } from "./registry.js";
+
+/**
+ * @typedef {import("./worker.d.ts").PostMessageTarget} PostMessageTarget
+ * @typedef {import("./worker.d.ts").ServeHighlighterOptions} ServeHighlighterOptions
+ * @typedef {import("./worker.d.ts").WorkerSession} WorkerSession
+ * @typedef {import("./worker.d.ts").WorkerHighlighter} WorkerHighlighter
+ * @typedef {import("./engine.d.ts").Registry} Registry
+ */
+
+/**
+ * Resolves `name` to a canonical, registered language name on `registry`,
+ * loading and registering the grammar on demand the first time it's seen.
+ * Concurrent calls for the same (resolved) name share one in-flight load.
+ * @param {Registry} registry
+ * @param {(name: string) => Promise<import("./languages/index.d.ts").LanguageType<string>>} loadLanguageFn
+ * @returns {(name: string) => Promise<string>}
+ */
+function createLanguageResolver(registry, loadLanguageFn) {
+  /** @type {Map<string, Promise<string>>} */
+  const pending = new Map();
+
+  return async function ensureLanguage(name) {
+    const resolved = resolveLanguageName(name);
+    if (resolved === undefined) throw new LanguageLoadError(name);
+    if (registry.get(resolved) !== undefined) return resolved;
+
+    let promise = pending.get(resolved);
+    if (promise === undefined) {
+      promise = (async () => {
+        const language = await loadLanguageFn(resolved);
+        registerAll(registry, language);
+        return resolved;
+      })();
+      pending.set(resolved, promise);
+    }
+    return promise;
+  };
+}
+
+/**
+ * @param {unknown} error
+ * @returns {{ name: string; message: string; language?: string }}
+ */
+function serializeError(error) {
+  if (error instanceof LanguageLoadError) {
+    return {
+      name: error.name,
+      message: error.message,
+      language: error.language,
+    };
+  }
+  const err = /** @type {{ name?: string; message?: string }} */ (error);
+  return {
+    name: err?.name ?? "Error",
+    message: err?.message ?? String(error),
+  };
+}
+
+/**
+ * Installs an `onmessage` handler on `scope` that answers highlight and
+ * streaming-session requests inside a worker (or any `postMessage`-shaped
+ * target). Grammars register on demand the first time a language name is
+ * seen, resolving aliases the same way `svelte-highlight/fence` does.
+ * @param {PostMessageTarget} [scope]
+ * @param {ServeHighlighterOptions} [options]
+ */
+export function serveHighlighter(
+  scope = /** @type {any} */ (typeof self === "undefined" ? undefined : self),
+  {
+    registry = createRegistry(),
+    loadLanguage:
+      loadLanguageFn = /** @type {(name: string) => Promise<import("./languages/index.d.ts").LanguageType<string>>} */ (
+      loadLanguage
+    ),
+  } = {},
+) {
+  const ensureLanguage = createLanguageResolver(registry, loadLanguageFn);
+  /** @type {Map<number, import("./engine.d.ts").StreamSession>} */
+  const sessions = new Map();
+
+  /**
+   * @param {number} sessionId
+   * @returns {import("./engine.d.ts").StreamSession}
+   */
+  function getSession(sessionId) {
+    const session = sessions.get(sessionId);
+    if (session === undefined) throw new Error(`Unknown session: ${sessionId}`);
+    return session;
+  }
+
+  /**
+   * @param {any} msg
+   * @returns {Promise<unknown>}
+   */
+  async function dispatch(msg) {
+    switch (msg.op) {
+      case "highlight": {
+        const language = await ensureLanguage(msg.language);
+        return registry.highlight(msg.code, { language });
+      }
+      case "tokenLines": {
+        const language = await ensureLanguage(msg.language);
+        const { events } = registry.tokenize(msg.code, language);
+        return tokenLines(events);
+      }
+      case "loadLanguage": {
+        const language = await ensureLanguage(msg.language);
+        return { language };
+      }
+      case "session.create": {
+        const language = await ensureLanguage(msg.language);
+        sessions.set(msg.sessionId, registry.createSession(language));
+        return undefined;
+      }
+      case "session.append": {
+        getSession(msg.sessionId).append(msg.text);
+        return undefined;
+      }
+      case "session.replace": {
+        getSession(msg.sessionId).replace(msg.from, msg.to, msg.text);
+        return undefined;
+      }
+      case "session.finish": {
+        const session = getSession(msg.sessionId);
+        const result = session.finish(msg.options);
+        sessions.delete(msg.sessionId);
+        return result;
+      }
+      case "session.snapshot": {
+        const session = getSession(msg.sessionId);
+        return { snapshot: session.snapshot(), events: session.events() };
+      }
+      default:
+        throw new Error(`Unknown op: ${msg.op}`);
+    }
+  }
+
+  // Processed strictly in arrival order: an async handler (e.g. one that
+  // loads a grammar) must fully settle before the next message is handled,
+  // so e.g. a session.create's registration always completes before a
+  // subsequent session.append for the same session is processed.
+  let queue = Promise.resolve();
+
+  scope.onmessage = (event) => {
+    const msg = event.data;
+    queue = queue.then(async () => {
+      try {
+        const result = await dispatch(msg);
+        scope.postMessage({ id: msg.id, result });
+      } catch (error) {
+        scope.postMessage({ id: msg.id, error: serializeError(error) });
+      }
+    });
+  };
+}
+
+/**
+ * @param {{ name: string; message: string; language?: string }} error
+ * @returns {Error}
+ */
+function toError(error) {
+  if (error.name === "LanguageLoadError") {
+    return new LanguageLoadError(/** @type {string} */ (error.language));
+  }
+  return Object.assign(new Error(error.message), { name: error.name });
+}
+
+/**
+ * @param {PostMessageTarget} worker
+ * @returns {WorkerHighlighter}
+ */
+function createRemoteHighlighter(worker) {
+  let nextId = 1;
+  let nextSessionId = 1;
+  /** @type {Map<number, { resolve: (value: any) => void; reject: (reason?: unknown) => void }>} */
+  const pending = new Map();
+
+  worker.onmessage = (event) => {
+    const { id, result, error } = event.data;
+    const callbacks = pending.get(id);
+    if (callbacks === undefined) return;
+    pending.delete(id);
+    if (error) callbacks.reject(toError(error));
+    else callbacks.resolve(result);
+  };
+
+  /**
+   * @param {string} op
+   * @param {Record<string, unknown>} payload
+   * @returns {Promise<any>}
+   */
+  function send(op, payload) {
+    const id = nextId++;
+    return new Promise((resolve, reject) => {
+      pending.set(id, { resolve, reject });
+      worker.postMessage({ id, op, ...payload });
+    });
+  }
+
+  /**
+   * @param {string} language
+   * @returns {WorkerSession}
+   */
+  function createSession(language) {
+    const sessionId = nextSessionId++;
+    const created = send("session.create", { sessionId, language });
+
+    /** @type {{ text: string; promise: Promise<void>; resolve: () => void; reject: (reason?: unknown) => void } | null} */
+    let pendingAppend = null;
+
+    function flushAppend() {
+      const batch = /** @type {NonNullable<typeof pendingAppend>} */ (
+        pendingAppend
+      );
+      pendingAppend = null;
+      created
+        .then(() => send("session.append", { sessionId, text: batch.text }))
+        .then(() => batch.resolve(), batch.reject);
+    }
+
+    return {
+      append(chunk) {
+        if (pendingAppend === null) {
+          /** @type {() => void} */
+          let resolveFn = () => {};
+          /** @type {(reason?: unknown) => void} */
+          let rejectFn = () => {};
+          const promise = new Promise((resolve, reject) => {
+            resolveFn = /** @type {() => void} */ (resolve);
+            rejectFn = reject;
+          });
+          pendingAppend = {
+            text: chunk,
+            promise,
+            resolve: resolveFn,
+            reject: rejectFn,
+          };
+          queueMicrotask(flushAppend);
+        } else {
+          pendingAppend.text += chunk;
+        }
+        return pendingAppend.promise;
+      },
+      async replace(from, to, text) {
+        if (pendingAppend) await pendingAppend.promise;
+        await created;
+        await send("session.replace", { sessionId, from, to, text });
+      },
+      async finish(options) {
+        if (pendingAppend) await pendingAppend.promise;
+        await created;
+        return send("session.finish", { sessionId, options });
+      },
+      async snapshot() {
+        if (pendingAppend) await pendingAppend.promise;
+        await created;
+        const { snapshot } = await send("session.snapshot", { sessionId });
+        return snapshot;
+      },
+      async events() {
+        if (pendingAppend) await pendingAppend.promise;
+        await created;
+        const { events } = await send("session.snapshot", { sessionId });
+        return events;
+      },
+    };
+  }
+
+  return {
+    highlight(code, language) {
+      return send("highlight", { code, language });
+    },
+    tokenLines(code, language) {
+      return send("tokenLines", { code, language });
+    },
+    createSession,
+    terminate() {
+      if (typeof worker.terminate === "function") worker.terminate();
+      else worker.close?.();
+    },
+  };
+}
+
+/**
+ * Same resolve-then-register logic as `createLanguageResolver`, but against
+ * `svelte-highlight/registry`'s shared singleton via `ensureRegistered`
+ * (which also registers a grammar's embedded sub-languages) instead of an
+ * arbitrary registry + `registerAll`.
+ * @type {Map<string, Promise<string>>}
+ */
+const localPending = new Map();
+
+/**
+ * @param {string} name
+ * @returns {Promise<string>}
+ */
+async function ensureLocalLanguage(name) {
+  const resolved = resolveLanguageName(name);
+  if (resolved === undefined) throw new LanguageLoadError(name);
+  if (sharedRegistry.get(resolved) !== undefined) return resolved;
+
+  let promise = localPending.get(resolved);
+  if (promise === undefined) {
+    promise = (async () => {
+      const language = await loadLanguage(
+        /** @type {import("./languages/index.d.ts").LanguageName} */ (resolved),
+      );
+      ensureRegistered(language);
+      return resolved;
+    })();
+    localPending.set(resolved, promise);
+  }
+  return promise;
+}
+
+/**
+ * @returns {WorkerHighlighter}
+ */
+function createLocalHighlighter() {
+  /**
+   * @param {string} language
+   * @returns {WorkerSession}
+   */
+  function createSession(language) {
+    const sessionPromise = ensureLocalLanguage(language).then((resolved) =>
+      sharedRegistry.createSession(resolved),
+    );
+
+    return {
+      async append(chunk) {
+        (await sessionPromise).append(chunk);
+      },
+      async replace(from, to, text) {
+        (await sessionPromise).replace(from, to, text);
+      },
+      async finish(options) {
+        return (await sessionPromise).finish(options);
+      },
+      async snapshot() {
+        return (await sessionPromise).snapshot();
+      },
+      async events() {
+        return (await sessionPromise).events();
+      },
+    };
+  }
+
+  return {
+    async highlight(code, language) {
+      const resolved = await ensureLocalLanguage(language);
+      return sharedRegistry.highlight(code, { language: resolved });
+    },
+    async tokenLines(code, language) {
+      const resolved = await ensureLocalLanguage(language);
+      const { events } = sharedRegistry.tokenize(code, resolved);
+      return tokenLines(events);
+    },
+    createSession,
+    terminate() {},
+  };
+}
+
+/**
+ * The main-thread client for a `serveHighlighter` worker. Given a `worker`
+ * (real `Worker`, or anything `postMessage`/`onmessage`-shaped), every call
+ * round-trips through it. Given no `worker`, runs the identical API
+ * in-process against `svelte-highlight/registry`'s shared singleton, so a
+ * language loaded this way is visible to `<Highlight>` on the same page —
+ * the SSR/tests fallback.
+ * @param {PostMessageTarget} [worker]
+ * @returns {WorkerHighlighter}
+ */
+export function createWorkerHighlighter(worker) {
+  return worker ? createRemoteHighlighter(worker) : createLocalHighlighter();
+}

--- a/tests/worker.test.ts
+++ b/tests/worker.test.ts
@@ -1,0 +1,144 @@
+import { createRegistry, registerAll, tokenLines } from "../src/engine.js";
+import { LanguageLoadError } from "../src/load-language.js";
+import type { PostMessageTarget, WorkerHighlighter } from "../src/worker.d.ts";
+import { createWorkerHighlighter, serveHighlighter } from "../src/worker.js";
+
+function makeSpyWorker() {
+  const { port1, port2 } = new MessageChannel();
+  serveHighlighter(port1 as unknown as PostMessageTarget);
+  const sent: Record<string, unknown>[] = [];
+  const spyWorker = {
+    postMessage: (msg: unknown, transfer?: Transferable[]) => {
+      sent.push(msg as Record<string, unknown>);
+      if (transfer) port2.postMessage(msg, transfer);
+      else port2.postMessage(msg);
+    },
+    set onmessage(fn: ((event: MessageEvent) => void) | null) {
+      port2.onmessage = fn;
+    },
+    terminate: () => port2.close(),
+  } as unknown as PostMessageTarget;
+  return { sent, spyWorker };
+}
+
+async function referenceHighlight(code: string, name: string) {
+  const registry = createRegistry();
+  const language = (await import(`../src/languages/${name}.js`)).default;
+  registerAll(registry, language);
+  return registry.highlight(code, { language: name });
+}
+
+async function referenceTokenLines(code: string, name: string) {
+  const registry = createRegistry();
+  const language = (await import(`../src/languages/${name}.js`)).default;
+  registerAll(registry, language);
+  const { events } = registry.tokenize(code, name);
+  return tokenLines(events);
+}
+
+const SAMPLES: Record<string, string> = {
+  // biome-ignore lint/suspicious/noTemplateCurlyInString: `${name}` is TypeScript source text being highlighted, not a JS template placeholder
+  typescript: "const greet = (name: string): string => `Hi, ${name}`;",
+  python: "def greet(name):\n    return f'Hi, {name}'",
+  css: ".a { color: red; }\n.b::before { content: 'x'; }",
+};
+
+describe("createWorkerHighlighter", () => {
+  for (const mode of ["worker", "local"] as const) {
+    describe(`${mode} mode`, () => {
+      function getHighlighter(): WorkerHighlighter {
+        if (mode === "worker") {
+          const { spyWorker } = makeSpyWorker();
+          return createWorkerHighlighter(spyWorker);
+        }
+        return createWorkerHighlighter();
+      }
+
+      for (const name of Object.keys(SAMPLES)) {
+        it(`highlight() and tokenLines() match a direct registry for ${name}`, async () => {
+          const h = getHighlighter();
+          const code = /** @type {string} */ (SAMPLES[name] as string);
+
+          const result = await h.highlight(code, name);
+          const reference = await referenceHighlight(code, name);
+          expect(result).toEqual(reference);
+
+          const lines = await h.tokenLines(code, name);
+          const referenceLines = await referenceTokenLines(code, name);
+          expect(lines).toEqual(referenceLines);
+
+          h.terminate();
+        });
+      }
+
+      it("rejects LanguageLoadError for an unknown language", async () => {
+        const h = getHighlighter();
+        let error: unknown;
+        try {
+          await h.highlight("code", "not-a-real-language");
+        } catch (err) {
+          error = err;
+        }
+        expect(error).toBeInstanceOf(LanguageLoadError);
+        expect((error as LanguageLoadError).language).toBe(
+          "not-a-real-language",
+        );
+        h.terminate();
+      });
+
+      it("session append/replace/finish matches a direct StreamSession", async () => {
+        const h = getHighlighter();
+        const session = h.createSession("typescript");
+
+        await session.append("const a = 1;");
+        await session.append("\nconst b = 2;");
+
+        const snapshotBeforeFinish = await session.snapshot();
+        const eventsBeforeFinish = await session.events();
+        expect(snapshotBeforeFinish).toBeTruthy();
+        expect(Array.isArray(eventsBeforeFinish)).toBe(true);
+
+        await session.replace(0, 5, "let");
+
+        const result = await session.finish();
+
+        const registry = createRegistry();
+        const typescript = (await import("../src/languages/typescript.js"))
+          .default;
+        registerAll(registry, typescript);
+        const reference = registry.createSession("typescript");
+        reference.append("const a = 1;");
+        reference.append("\nconst b = 2;");
+        reference.replace(0, 5, "let");
+        const referenceResult = reference.finish();
+
+        expect(result).toEqual(referenceResult);
+        h.terminate();
+      });
+
+      it("terminate() does not throw", () => {
+        const h = getHighlighter();
+        expect(() => h.terminate()).not.toThrow();
+      });
+    });
+  }
+
+  it("batches synchronous append() calls into one session.append message", async () => {
+    const { sent, spyWorker } = makeSpyWorker();
+    const h = createWorkerHighlighter(spyWorker);
+    const session = h.createSession("typescript");
+
+    const promises = [
+      session.append("a"),
+      session.append("b"),
+      session.append("c"),
+    ];
+    await Promise.all(promises);
+
+    const appendMessages = sent.filter((m) => m.op === "session.append");
+    expect(appendMessages).toHaveLength(1);
+    expect(appendMessages[0]?.text).toBe("abc");
+
+    h.terminate();
+  });
+});


### PR DESCRIPTION
Adds svelte-highlight/worker for running the highlighting engine off
the main thread: serveHighlighter answers requests inside a worker,
createWorkerHighlighter is the matching client (and runs in-process
against the shared registry when no worker is available, for SSR and
tests). Includes README docs and an examples/worker demo that
highlights a ~1 MB file in a Worker while keeping the main thread
responsive.

```js
// highlight.worker.js
import { serveHighlighter } from "svelte-highlight/worker";
serveHighlighter();
```

```js
import { createWorkerHighlighter } from "svelte-highlight/worker";

const highlighter = createWorkerHighlighter(
  typeof Worker !== "undefined"
    ? new Worker(new URL("./highlight.worker.js", import.meta.url), {
        type: "module",
      })
    : undefined,
);

const { value } = await highlighter.highlight(code, "typescript");
```