### PR TITLE
feat(action): dispatch highlighted and error events

### DIFF
--- a/README.md
+++ b/README.md
@@ -1526,6 +1526,12 @@ Omit `code` to highlight the element's existing contents:
 ></pre>
 ```
 
+`language` is also optional: when omitted, the action reads a `language-xxx` class off its own node (the Prism/highlight.js Markdown convention) and resolves it via `loadLanguage`, so server-rendered Markdown output needs no per-block `language` prop. With no matching class, it warns in dev and dispatches `error`.
+
+```svelte
+<pre><code class="language-typescript" use:highlight>const add = (a, b) => a + b;</code></pre>
+```
+
 ### Dispatched Events
 
 The action dispatches `highlighted` (`detail: { html, language }`) on success and `error` (`detail: { error }`) on failure, on the node it's placed on.

--- a/README.md
+++ b/README.md
@@ -1526,6 +1526,20 @@ Omit `code` to highlight the element's existing contents:
 ></pre>
 ```
 
+### Dispatched Events
+
+The action dispatches `highlighted` (`detail: { html, language }`) on success and `error` (`detail: { error }`) on failure, on the node it's placed on.
+
+```svelte
+<pre><code
+  use:highlight={{ language: typescript, code }}
+  on:highlighted={(e) => console.log(e.detail.html, e.detail.language)}
+  on:error={(e) => console.error(e.detail.error)}
+></code></pre>
+```
+
+`highlighted` is also a composition hook for a sibling `LineNumbers`: `on:highlighted={(e) => (highlighted = e.detail.html)}` feeding `<LineNumbers {highlighted} languageName={typescript.name} />`.
+
 ## Code Window
 
 Wrap a code block in `CodeWindow` to frame it with window chrome. It's purely cosmetic; the default slot renders your content unchanged.

--- a/README.md
+++ b/README.md
@@ -1500,6 +1500,8 @@ function rehypeHighlightFence() {
 
 Use the `highlight` action to highlight existing `<pre><code>` markup in place. This is useful for progressively enhancing server-rendered content (e.g. markdown) without swapping in a component.
 
+Place `use:highlight` on the `<code>` element inside a `<pre>`, matching the theme CSS's `.hljs code` selector -- elsewhere (directly on `<pre>`, or a non-`<pre><code>` element) it still highlights but may not be visually targeted by the active theme.
+
 The action accepts the same `language` prop as the components. When `code` is omitted, the element's existing `textContent` is highlighted. Updating `code` re-highlights the element.
 
 ```svelte

--- a/src/action.d.ts
+++ b/src/action.d.ts
@@ -16,5 +16,10 @@ export type HighlightActionParameters = {
 
 /**
  * Highlight element contents in place with highlight.js.
+ *
+ * Dispatches two events on the node:
+ * - `highlighted`: `detail: { html: string; language: string }`, after a
+ *   successful highlight.
+ * - `error`: `detail: { error: unknown }`, after a failed highlight.
  */
 export declare const highlight: Action<HTMLElement, HighlightActionParameters>;

--- a/src/action.d.ts
+++ b/src/action.d.ts
@@ -21,6 +21,11 @@ export type HighlightActionParameters = {
 /**
  * Highlight element contents in place with highlight.js.
  *
+ * Should be placed on the `<code>` element inside a `<pre>`, matching the
+ * theme CSS's `.hljs code` selector -- elsewhere (directly on `<pre>`, or a
+ * non-`<pre><code>` element) it still highlights but may not be visually
+ * targeted by the active theme.
+ *
  * Dispatches two events on the node:
  * - `highlighted`: `detail: { html: string; language: string }`, after a
  *   successful highlight.

--- a/src/action.d.ts
+++ b/src/action.d.ts
@@ -3,9 +3,13 @@ import type { LanguageType } from "./languages";
 
 export type HighlightActionParameters = {
   /**
-   * Language used to highlight the element's contents.
+   * Language used to highlight the element's contents. When omitted, the
+   * action reads a `language-xxx` class off the node itself (the
+   * Prism/highlight.js Markdown convention) and resolves it via
+   * `loadLanguage`. No `language` prop and no matching class dispatches
+   * `error` and leaves the content untouched.
    */
-  language: LanguageType<string>;
+  language?: LanguageType<string>;
 
   /**
    * Code to highlight. When omitted, the element's

--- a/src/action.js
+++ b/src/action.js
@@ -4,6 +4,9 @@ import { ensureRegistered, registry } from "./registry.js";
  * Highlight an element in place with highlight.js.
  * Omits `code` to highlight existing `textContent`.
  *
+ * Dispatches `highlighted` ({ html, language }) on the node after a
+ * successful highlight, and `error` ({ error }) after a failed one.
+ *
  * @param {HTMLElement} node
  * @param {{ language: import("./languages").LanguageType<string>; code?: string }} parameters
  * @returns {ReturnType<import("svelte/action").Action<HTMLElement, { language: import("./languages").LanguageType<string>; code?: string }>>}
@@ -29,11 +32,26 @@ export function highlight(node, parameters) {
           error,
         );
       }
+      // Deferred: Svelte wraps `on:` listeners on this node in an effect
+      // that flushes after this action's own (synchronous) mount/update
+      // runs, so dispatching synchronously here would fire before a
+      // listener declared via `on:error` is attached.
+      queueMicrotask(() =>
+        node.dispatchEvent(new CustomEvent("error", { detail: { error } })),
+      );
       return;
     }
 
     node.innerHTML = value;
     node.classList.add("hljs");
+    // See the `error` dispatch above for why this is deferred.
+    queueMicrotask(() =>
+      node.dispatchEvent(
+        new CustomEvent("highlighted", {
+          detail: { html: value, language: language.name },
+        }),
+      ),
+    );
   }
 
   apply(parameters);

--- a/src/action.js
+++ b/src/action.js
@@ -1,24 +1,46 @@
+import { loadLanguage } from "./load-language.js";
 import { ensureRegistered, registry } from "./registry.js";
+
+const LANGUAGE_CLASS = /(?:^|\s)language-([\w#+-]+)(?:\s|$)/;
 
 /**
  * Highlight an element in place with highlight.js.
  * Omits `code` to highlight existing `textContent`.
  *
+ * Omits `language` to resolve it from a `class="language-xxx"` token on the
+ * node itself (the Prism/highlight.js Markdown convention), loaded via
+ * `loadLanguage`. No matching class dispatches `error` and leaves the
+ * content untouched.
+ *
  * Dispatches `highlighted` ({ html, language }) on the node after a
  * successful highlight, and `error` ({ error }) after a failed one.
  *
  * @param {HTMLElement} node
- * @param {{ language: import("./languages").LanguageType<string>; code?: string }} parameters
- * @returns {ReturnType<import("svelte/action").Action<HTMLElement, { language: import("./languages").LanguageType<string>; code?: string }>>}
+ * @param {{ language?: import("./languages").LanguageType<string>; code?: string }} [parameters]
+ * @returns {ReturnType<import("svelte/action").Action<HTMLElement, { language?: import("./languages").LanguageType<string>; code?: string }>>}
  */
-export function highlight(node, parameters) {
+export function highlight(node, parameters = {}) {
   // Snapshot the pre-action source once: updates that omit `code` fall back
   // to this instead of `node.textContent`, which after the first highlight
   // pass holds the already-highlighted (and DOM-normalized) output.
   const originalText = node.textContent ?? "";
 
-  /** @param {{ language: import("./languages").LanguageType<string>; code?: string }} params */
-  function apply({ language, code }) {
+  // Guards a `loadLanguage` continuation from applying stale results if a
+  // newer `apply()` call (from `update` or a fresh `destroy`) has since
+  // superseded it.
+  let generation = 0;
+  let destroyed = false;
+
+  /**
+   * @param {import("./languages").LanguageType<string>} language
+   * @param {string | undefined} code
+   * @param {number} gen
+   */
+  function highlightWith(language, code, gen) {
+    if (destroyed || gen !== generation) {
+      return;
+    }
+
     const source = code ?? originalText;
     let value;
 
@@ -54,11 +76,58 @@ export function highlight(node, parameters) {
     );
   }
 
+  /** @param {{ language?: import("./languages").LanguageType<string>; code?: string }} params */
+  function apply({ language, code } = {}) {
+    generation += 1;
+    const gen = generation;
+
+    if (language) {
+      highlightWith(language, code, gen);
+      return;
+    }
+
+    const match = node.getAttribute("class")?.match(LANGUAGE_CLASS);
+
+    if (!match) {
+      const error = new Error(
+        'no "language" parameter and no "language-xxx" class found',
+      );
+      if (import.meta.env?.DEV) {
+        console.warn(`[svelte-highlight] ${error.message}.`);
+      }
+      queueMicrotask(() =>
+        node.dispatchEvent(new CustomEvent("error", { detail: { error } })),
+      );
+      return;
+    }
+
+    const name = /** @type {string} */ (match[1]);
+
+    loadLanguage(/** @type {import("./languages").LanguageName} */ (name)).then(
+      (language) => highlightWith(language, code, gen),
+      (error) => {
+        if (destroyed || gen !== generation) {
+          return;
+        }
+        if (import.meta.env?.DEV) {
+          console.warn(
+            `[svelte-highlight] failed to load language "${name}" from class="language-${name}"; leaving content unchanged.`,
+            error,
+          );
+        }
+        queueMicrotask(() =>
+          node.dispatchEvent(new CustomEvent("error", { detail: { error } })),
+        );
+      },
+    );
+  }
+
   apply(parameters);
 
   return {
     update: apply,
     destroy() {
+      destroyed = true;
       node.classList.remove("hljs");
       node.textContent = originalText;
     },

--- a/tests/e2e/HighlightAction.classConvention.test.svelte
+++ b/tests/e2e/HighlightAction.classConvention.test.svelte
@@ -1,0 +1,11 @@
+<script>
+  import { highlight } from "svelte-highlight";
+
+  let lastEvent = "";
+</script>
+
+<pre
+><code class="language-typescript" use:highlight>const add = (a, b) => a + b;</code></pre>
+<pre
+><code use:highlight on:error={() => (lastEvent = "error")}>plain text, no class</code></pre>
+<p data-testid="last-event">{lastEvent}</p>

--- a/tests/e2e/HighlightAction.events.test.svelte
+++ b/tests/e2e/HighlightAction.events.test.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import { highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  let language: any = typescript;
+  let lastEvent = "";
+
+  const broken = {
+    name: "broken-grammar",
+    register: {
+      name: "broken-grammar",
+      caseInsensitive: false,
+      unicode: false,
+      disableAutodetect: false,
+      states: [
+        { relevance: 1, rules: [1] },
+        { relevance: 1, rules: [], scope: "broken", begin: "(" },
+      ],
+    },
+  };
+</script>
+
+<button type="button" on:click={() => (language = broken)}>Break</button>
+<pre><code
+    use:highlight={{ language, code: "const add = (a, b) => a + b;" }}
+    on:highlighted={() => (lastEvent = "highlighted")}
+    on:error={() => (lastEvent = "error")}
+  ></code></pre>
+<p data-testid="last-event">{lastEvent}</p>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -14,6 +14,7 @@ import HighlightEmptyCode from "./Highlight.emptyCode.test.svelte";
 import HighlightEvents from "./Highlight.events.test.svelte";
 import Highlight from "./Highlight.test.svelte";
 import HighlightWrap from "./Highlight.wrap.test.svelte";
+import HighlightActionEvents from "./HighlightAction.events.test.svelte";
 import HighlightActionOmittedCode from "./HighlightAction.omittedCode.test.svelte";
 import HighlightActionRegisterThrows from "./HighlightAction.registerThrows.test.svelte";
 import HighlightAction from "./HighlightAction.test.svelte";
@@ -420,6 +421,18 @@ test("highlight action - destroy restores the original content", async ({
 
   expect(await handle?.evaluate((el) => el.innerHTML)).toBe("const s = 1;");
   expect(await handle?.evaluate((el) => el.className)).toBe("");
+});
+
+test("highlight action - dispatches highlighted and error events", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightActionEvents);
+  await expect(page.locator('[data-testid="last-event"]')).toHaveText(
+    "highlighted",
+  );
+  await page.getByRole("button", { name: "Break" }).click();
+  await expect(page.locator('[data-testid="last-event"]')).toHaveText("error");
 });
 
 test("HighlightAuto", async ({ mount, page }) => {

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -14,6 +14,7 @@ import HighlightEmptyCode from "./Highlight.emptyCode.test.svelte";
 import HighlightEvents from "./Highlight.events.test.svelte";
 import Highlight from "./Highlight.test.svelte";
 import HighlightWrap from "./Highlight.wrap.test.svelte";
+import HighlightActionClassConvention from "./HighlightAction.classConvention.test.svelte";
 import HighlightActionEvents from "./HighlightAction.events.test.svelte";
 import HighlightActionOmittedCode from "./HighlightAction.omittedCode.test.svelte";
 import HighlightActionRegisterThrows from "./HighlightAction.registerThrows.test.svelte";
@@ -432,6 +433,17 @@ test("highlight action - dispatches highlighted and error events", async ({
     "highlighted",
   );
   await page.getByRole("button", { name: "Break" }).click();
+  await expect(page.locator('[data-testid="last-event"]')).toHaveText("error");
+});
+
+test('highlight action - honors class="language-xxx" and errors when no class matches', async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightActionClassConvention);
+  const code = page.locator("pre code.hljs");
+  await expect(code).toBeVisible();
+  await expect(code.locator(".hljs-keyword").first()).toHaveText("const");
   await expect(page.locator('[data-testid="last-event"]')).toHaveText("error");
 });
 

--- a/www/components/HighlightAction.svelte
+++ b/www/components/HighlightAction.svelte
@@ -1,0 +1,56 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+  import { HighlightSvelte, highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code = "const add = (a, b) => a + b;";
+
+  const snippet = `<script>
+  import { highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+  const code = "const add = (a, b) => a + b;";
+  let status = "";
+<\/script>
+
+<svelte:head>
+  {@html ${THEME_MODULE_NAME}}
+</svelte:head>
+
+<pre><code
+  use:highlight={{ language: typescript, code }}
+  on:highlighted={() => (status = "highlighted")}
+  on:error={() => (status = "error")}
+></code></pre>
+<p>{status}</p>`;
+
+  const broken = {
+    name: "broken-grammar",
+    register: {
+      name: "broken-grammar",
+      caseInsensitive: false,
+      unicode: false,
+      disableAutodetect: false,
+      states: [
+        { relevance: 1, rules: [1] },
+        { relevance: 1, rules: [], scope: "broken", begin: "(" },
+      ],
+    },
+  };
+
+  let language = typescript;
+  let status = "";
+</script>
+
+<HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+
+<button type="button" on:click={() => (language = broken)}>
+  Break the grammar
+</button>
+<pre><code
+    use:highlight={{ language, code }}
+    on:highlighted={() => (status = "highlighted")}
+    on:error={() => (status = "error")}
+  ></code></pre>
+<p>Status: {status}</p>

--- a/www/components/HighlightAction.svelte
+++ b/www/components/HighlightAction.svelte
@@ -39,6 +39,11 @@
     },
   };
 
+  const classConventionSnippet = `<pre><code
+  class="language-typescript"
+  use:highlight
+>const add = (a, b) => a + b;</code></pre>`;
+
   let language = typescript;
   let status = "";
 </script>
@@ -54,3 +59,9 @@
     on:error={() => (status = "error")}
   ></code></pre>
 <p>Status: {status}</p>
+
+<HighlightSvelte code={classConventionSnippet} class={THEME_MODULE_NAME} />
+
+<pre><code class="language-typescript" use:highlight
+  >const add = (a, b) => a + b;</code
+></pre>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -11,6 +11,7 @@
   import CustomLanguage from "@components/CustomLanguage.svelte";
   import FileTabs from "@components/FileTabs.svelte";
   import HighlightWrap from "@components/Highlight/Wrap.svelte";
+  import HighlightAction from "@components/HighlightAction.svelte";
   import EditableBasic from "@components/HighlightEditable/Basic.svelte";
   import EditableCommands from "@components/HighlightEditable/Commands.svelte";
   import EditableComposition from "@components/HighlightEditable/Composition.svelte";
@@ -334,6 +335,11 @@ export { add, mul };\`,
       <code class="code">code</code>
       re-highlights the element.
     </p>
+    <p class="mb-5">
+      The action dispatches <code class="code">highlighted</code> and
+      <code class="code">error</code>
+      events on the node it's placed on.
+    </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
     <HighlightSvelte
@@ -352,6 +358,7 @@ export { add, mul };\`,
 <pre><code use:highlight={{ language: typescript, code }}><\/code><\/pre>`}
       class={THEME_MODULE_NAME}
     />
+    <HighlightAction />
   </Column>
 </Row>
 


### PR DESCRIPTION
The highlight action now dispatches highlighted/error events, falls
back to a class="language-xxx" attribute when language is omitted,
and its README/type docs cover the expected `<pre><code>` placement.

```svelte
<pre><code
  class="language-typescript"
  use:highlight
  on:highlighted={(e) => console.log(e.detail.html)}
  on:error={(e) => console.error(e.detail.error)}
></code></pre>
```