### PR TITLE
feat(components): add scrollToLine to HighlightStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -1804,7 +1804,7 @@ Per-chunk work is O(tail), not O(stream length so far): finished output is seale
 <HighlightStream language={typescript} {code} {done} virtualize style="height: 20em;" />
 ```
 
-`virtualize` renders only the lines within the scrolled viewport (plus `overscan`), the same windowing `HighlightVirtual` does for static documents -- a stream that runs to tens of thousands of lines still costs a couple dozen DOM nodes. It swaps the sealed-chunk session for `TokenizedDocument` (see [Large documents](#large-documents) below), so output always reflects the streaming (non-canonicalized) parse, even once `done` -- unlike the default mode, which upgrades to a canonical final render. `on:highlight` isn't dispatched in this mode, since materializing the full HTML on every repaint would defeat the point of windowing; `on:done`, the caret, and `autoScroll` all keep working. `on:windowchange` fires with `{ start, end, lineCount }` whenever the rendered window moves, so you can show something like "lines *N*-*M* of *T*" without counting DOM nodes yourself. Row math assumes one line per fixed-height row, so `virtualize` can't wrap lines -- it always renders with `white-space: pre`, overriding any `white-space` you pass through `$$restProps`.
+`virtualize` renders only the lines within the scrolled viewport (plus `overscan`), the same windowing `HighlightVirtual` does for static documents -- a stream that runs to tens of thousands of lines still costs a couple dozen DOM nodes. It swaps the sealed-chunk session for `TokenizedDocument` (see [Large documents](#large-documents) below), so output always reflects the streaming (non-canonicalized) parse, even once `done` -- unlike the default mode, which upgrades to a canonical final render. `on:highlight` isn't dispatched in this mode, since materializing the full HTML on every repaint would defeat the point of windowing; `on:done`, the caret, and `autoScroll` all keep working. `on:windowchange` fires with `{ start, end, lineCount }` whenever the rendered window moves, so you can show something like "lines *N*-*M* of *T*" without counting DOM nodes yourself. Row math assumes one line per fixed-height row, so `virtualize` can't wrap lines -- it always renders with `white-space: pre`, overriding any `white-space` you pass through `$$restProps`. `bind:this`, then call `scrollToLine(line)` to scroll a given line into view -- works in both `virtualize` and default modes.
 
 ### Streaming Markdown with multiple fences
 
@@ -2310,6 +2310,10 @@ Use `bind:this`, then call `undo()`, `redo()`, `focus()`, `selectAll()`, `insert
 | doneText           | `string`                                | `"Code finished streaming"` |
 
 `$$restProps` are forwarded to the top-level `pre` element. `overscan` and `checkpointInterval` only apply when `virtualize` is set. `doneText` is announced by a visually-hidden live region once `done` becomes `true`; set it to `""` to disable the announcement.
+
+#### Methods
+
+Use `bind:this`, then call `scrollToLine(line)` -- works in both `virtualize` and default modes.
 
 #### Dispatched Events
 

--- a/README.md
+++ b/README.md
@@ -1932,6 +1932,59 @@ For documents in the low thousands to tens of thousands of lines (roughly 2,000-
 
 Each line is its own block-level `<div>`, not a row in a `<table>`/`<tr>` (the way `LineNumbers` renders) -- `content-visibility` doesn't apply to table-internal display types, so off-screen table rows never get the skip. Off-screen `<div>` lines do: the browser skips layout/paint/style for them, using `contain-intrinsic-size` as a placeholder size until they scroll near the viewport. Unlike `HighlightVirtual`, this is a progressive enhancement, not a hard requirement -- browsers without `content-visibility` support just render every line normally, and you get native text selection, find-in-page, and line wrapping for free (drop the `white-space: pre` on each line's `<div>` to allow it).
 
+## Find in document
+
+Browser Cmd+F can't see rows a virtualized view (`HighlightVirtual`, `HighlightStream`'s `virtualize` mode) hasn't mounted, and neither of them ships a search box -- `svelte-highlight/search` is a headless find-in-document engine plus a DOM-painting helper, so any consumer can build one. No `<input>` component is exported; that's application UI, not a library primitive.
+
+`createSearch(source)` accepts a plain `string` (split on `"\n"`), a `string[]` of lines, or a `TokenizedDocument` (duck-typed -- only `lineCount`/`lineRange` are used, never checked via `instanceof`), such as the one backing a `HighlightStream` in `virtualize` mode. Against a `TokenizedDocument`, repeated `query()` calls with unchanged text/options only rescan lines appended since the last call, instead of rescanning the whole document every time:
+
+```svelte
+<script>
+  import { HighlightVirtual } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import { createSearch, highlightMatches } from "svelte-highlight/search";
+  import "svelte-highlight/search.css";
+
+  export let code;
+  const search = createSearch(code);
+
+  /** @type {HighlightVirtual} */
+  let ref;
+  /** @type {HTMLElement} */
+  let root;
+  let dispose = () => {};
+
+  function repaint() {
+    dispose();
+    dispose = highlightMatches(root, search.matches(), {
+      current: search.current()?.index,
+    }).dispose;
+  }
+
+  const unsubscribe = search.onChange(repaint);
+
+  function onInput(event) {
+    search.query(event.currentTarget.value, { wholeWord: true });
+  }
+
+  function next() {
+    const match = search.next();
+    if (match) ref.scrollToLine(match.line);
+  }
+</script>
+
+<input on:input={onInput} />
+<button on:click={next}>Next ({search.count()})</button>
+
+<div bind:this={root}>
+  <HighlightVirtual bind:this={ref} language={typescript} {code} on:windowchange={repaint} />
+</div>
+```
+
+`query(text, options)` runs a search; `options.caseSensitive` and `options.wholeWord` (wraps the pattern in `\b...\b`) both default to `false`. `options.regex` treats `text` as a regular expression source instead of literal text -- capped at 256 characters and compiled in a `try`/`catch`, so an over-long or invalid pattern yields zero matches and sets `error()` rather than throwing. Empty `text` clears matches without an error. `matches()` returns every `{ line, start, end }` match in document order (never spanning a line); `count()` is its length. `current()`/`next()`/`prev()` return the selected match plus its `index` into `matches()`, wrapping around the ends; all return `undefined` before any query or with zero matches. `setSource(source)` swaps the document and re-runs an already-active query as a full rescan. `onChange(callback)` fires after every mutating call and returns an unsubscribe function.
+
+`highlightMatches(root, matches, { current, name })` paints `matches` into `root`, restricted to whatever rows are currently rendered there -- resolved per match's line via `[data-line]` (the row shape `HighlightVirtual`/`HighlightStream` render), then the `line`-th `.line` element (the shape `highlightFence`/fenced code renders), then the whole `<code>` split on `"\n"`; matches whose line resolves to nothing are skipped. It uses the CSS Custom Highlight API when available (two `Highlight`s: `name`, defaulting to `"shl-search"`, and `${name}-current` for the match at index `current`), or falls back to wrapping text in `<mark data-shl-search>` (plus `data-shl-search-current`) when it isn't. It paints once per call and returns `{ dispose() }` -- there's no diffing against a previous call, so a consumer disposes and re-runs it after the rendered window changes (`on:windowchange`) or the query changes (`onChange`), as in the example above. It's a no-op on the server. `import "svelte-highlight/search.css"` is optional and styles both highlight names via the `--search-match-background`/`--search-current-background` CSS variables; passing a custom `name` bypasses it, since the stylesheet only targets the default names.
+
 ## Terminal Output
 
 Use `AnsiOutput` to render terminal output that still contains ANSI [SGR](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters) escape codes. Colors, bold, dim, italic, and underline become styled HTML, along with OSC 8 hyperlinks, carriage-return overwrites, and reverse/strikethrough. The parser is separate from highlight.js, so reach for it with build logs, CLI output, and test runners.
@@ -2431,7 +2484,7 @@ See it as a complete page in [examples/cdn](examples/cdn).
 
 ### Stability tiers
 
-- **Stable, semver-governed:** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`, `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`, `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`, `Registry` and its methods, `createRegistry`, `registerAll`, `StreamSession`, `TokenizedDocument`, `createTokenizedDocument`, `TextSegment`, `FenceSegment`, `MarkdownSegment`, `FenceSplitter`, `createFenceSplitter`, `UnknownLanguageError`, `TokenizerLoopError`. `Snapshot` is a serializable format that round-trips within one library version, but is **not** guaranteed stable across versions — a snapshot from an older release may be rejected on resume. The same caveat applies to `TokenizedDocument`: its method surface (`setCode`/`append`/`lineCount`/`lineRange`/`tokenizedThrough`/`checkpointCount`) is stable and semver-governed, but internally it resumes from `Snapshot`s the same way `StreamSession` does, so anything that tried to serialize and later resume a `TokenizedDocument`'s internal state directly would hit the same cross-version instability -- the public API doesn't expose that today.
+- **Stable, semver-governed:** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`, `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`, `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`, `Registry` and its methods, `createRegistry`, `registerAll`, `StreamSession`, `TokenizedDocument`, `createTokenizedDocument`, `TextSegment`, `FenceSegment`, `MarkdownSegment`, `FenceSplitter`, `createFenceSplitter`, `SearchMatch`, `SearchOptions`, `Search`, `createSearch`, `highlightMatches`, `UnknownLanguageError`, `TokenizerLoopError`. `Snapshot` is a serializable format that round-trips within one library version, but is **not** guaranteed stable across versions — a snapshot from an older release may be rejected on resume. The same caveat applies to `TokenizedDocument`: its method surface (`setCode`/`append`/`lineCount`/`lineRange`/`tokenizedThrough`/`checkpointCount`) is stable and semver-governed, but internally it resumes from `Snapshot`s the same way `StreamSession` does, so anything that tried to serialize and later resume a `TokenizedDocument`'s internal state directly would hit the same cross-version instability -- the public API doesn't expose that today.
 - **Generated data, versioned with the library:** `GrammarIR`/`GrammarState`. These come from the build pipeline and are consumed by `registerAll`; treat them as opaque payloads whose field-level structure may change in any minor release. Always load grammars from the same package version as the engine.
 - **Experimental, may change in a minor release:** `createWorkerHighlighter`, `serveHighlighter`, `PostMessageTarget`, `WorkerHighlighter`, `WorkerSession`, `ServeHighlighterOptions` (`svelte-highlight/worker`). The wire protocol between the two halves is not part of the public contract — only the documented function behavior is.
 

--- a/bench/search.bench.ts
+++ b/bench/search.bench.ts
@@ -1,0 +1,79 @@
+/**
+ * search.js: createSearch's scan cost as documents grow, the relative
+ * cost of its literal/caseSensitive/wholeWord/regex modes, and the
+ * incremental-rescan optimization against a growing TokenizedDocument -
+ * repeated query()s only rescan newly appended lines instead of the whole
+ * document, the same kind of typing-simulation comparison
+ * incremental.bench.ts runs for parseIncremental/reparseIncremental.
+ *
+ * highlightMatches (the DOM-painting half of this module) isn't benched
+ * here: it walks real DOM (TreeWalker, Range, CSS.highlights), which this
+ * Bun-native bench environment has no shim for.
+ */
+import { group, task } from "ostia";
+import javascript from "../src/languages/javascript.js";
+import { createSearch } from "../src/search.js";
+import { createTokenizedDocument } from "../src/tokenized-document.js";
+import { jsLines } from "./_shared.ts";
+
+group("createSearch query() full rescan by document size", () => {
+  for (const lines of [2_000, 20_000, 100_000]) {
+    const code = jsLines(lines);
+    task(`${lines.toLocaleString()} lines`, () =>
+      createSearch(code).query("return"),
+    );
+  }
+});
+
+group("createSearch query() mode cost @ 20,000 lines", () => {
+  const code = jsLines(20_000);
+  task("literal (case-insensitive)", () => createSearch(code).query("return"));
+  task("caseSensitive", () =>
+    createSearch(code).query("return", { caseSensitive: true }),
+  );
+  task("wholeWord", () =>
+    createSearch(code).query("return", { wholeWord: true }),
+  );
+  task("regex", () => createSearch(code).query("a \\+ b", { regex: true }));
+});
+
+function incrementalRepeatedQuery(totalLines: number, steps: number) {
+  const doc = createTokenizedDocument({ language: javascript });
+  const search = createSearch(doc);
+  const perStep = Math.ceil(totalLines / steps);
+  for (let s = 0; s < steps; s += 1) {
+    doc.append(jsLines(perStep));
+    search.query("return");
+  }
+}
+
+function freshSearchPerStep(totalLines: number, steps: number) {
+  const doc = createTokenizedDocument({ language: javascript });
+  const perStep = Math.ceil(totalLines / steps);
+  for (let s = 0; s < steps; s += 1) {
+    doc.append(jsLines(perStep));
+    createSearch(doc).query("return");
+  }
+}
+
+group(
+  "createSearch incremental rescan vs a fresh full rescan every append",
+  () => {
+    for (const [totalLines, steps] of [
+      [8_000, 20],
+      [40_000, 40],
+    ] as const) {
+      task(
+        `query() reused across ${steps} appends (${totalLines.toLocaleString()} lines total)`,
+        () => incrementalRepeatedQuery(totalLines, steps),
+      );
+      task(
+        `fresh createSearch() + full query() per append (${totalLines.toLocaleString()} lines total)`,
+        () => freshSearchPerStep(totalLines, steps),
+      );
+    }
+  },
+);
+
+// Run this suite with `ostia bench bench/search.bench.ts` for a fast
+// feedback loop; `bun run bench` runs every *.bench.ts suite for a full-baseline run.

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -158,6 +158,17 @@ pkgJson.exports = {
   },
   "./worker": { types: "./worker.d.ts", import: "./worker.js" },
   "./worker.js": { types: "./worker.d.ts", import: "./worker.js" },
+  "./search": {
+    types: "./search.d.ts",
+    import: "./search.js",
+  },
+  "./search.js": {
+    types: "./search.d.ts",
+    import: "./search.js",
+  },
+  "./search.css": {
+    import: "./search.css",
+  },
   "./package.json": "./package.json",
 };
 
@@ -169,7 +180,12 @@ pkgJson.types = "./index.d.ts";
 // We specify it here to be sure so that it will not be mistakenly tree-shaken.
 // `cp -r ./src/ ./package` flattens src/ into the package root, so these
 // globs must match the published layout, not the source layout.
-pkgJson.sideEffects = ["styles/*.css", "themes/*.css", "langtag.css"];
+pkgJson.sideEffects = [
+  "styles/*.css",
+  "themes/*.css",
+  "langtag.css",
+  "search.css",
+];
 
 await Bun.write("./package/package.json", JSON.stringify(pkgJson, null, 2));
 console.timeEnd("package");

--- a/src/HighlightStream.svelte
+++ b/src/HighlightStream.svelte
@@ -379,6 +379,28 @@
     }
   }
 
+  /**
+   * Scroll a given line into the rendered window.
+   * @param {number} line
+   */
+  export function scrollToLine(line) {
+    if (!container) return;
+    if (virtualize) {
+      const target = Math.max(0, Math.min(line, vLineCount)) * vLineHeight;
+      const maxScrollTop = Math.max(
+        0,
+        container.scrollHeight - container.clientHeight,
+      );
+      container.scrollTop = Math.max(0, Math.min(target, maxScrollTop));
+      vScrollTop = container.scrollTop;
+      computeVirtualWindow();
+    } else {
+      container
+        .querySelector(`[data-line="${line}"]`)
+        ?.scrollIntoView({ block: "nearest" });
+    }
+  }
+
   // Mirrors `scrollToBottom`/the shrink-clamp in `HighlightVirtual`, merged:
   // while streaming with `autoScroll`, stick to the (growing) bottom; once
   // the user scrolls away, just keep the scroll position in bounds.

--- a/src/HighlightStream.svelte.d.ts
+++ b/src/HighlightStream.svelte.d.ts
@@ -132,4 +132,7 @@ export default class HighlightStream extends SvelteComponentTyped<
   HighlightStreamProps,
   HighlightStreamEvents,
   Record<string, never>
-> {}
+> {
+  /** Scroll a given line into the rendered window. */
+  scrollToLine(line: number): void;
+}

--- a/src/search.css
+++ b/src/search.css
@@ -1,0 +1,16 @@
+::highlight(shl-search) {
+  background-color: var(--search-match-background, rgba(255, 235, 59, 0.4));
+}
+
+mark[data-shl-search] {
+  background-color: var(--search-match-background, rgba(255, 235, 59, 0.4));
+  color: inherit;
+}
+
+::highlight(shl-search-current) {
+  background-color: var(--search-current-background, rgba(255, 152, 0, 0.6));
+}
+
+mark[data-shl-search][data-shl-search-current] {
+  background-color: var(--search-current-background, rgba(255, 152, 0, 0.6));
+}

--- a/src/search.d.ts
+++ b/src/search.d.ts
@@ -1,0 +1,63 @@
+import type { TokenizedDocument } from "./tokenized-document.js";
+
+export interface SearchMatch {
+  /** 0-indexed line number. */
+  line: number;
+  /** Start offset into the line's plain text (inclusive). */
+  start: number;
+  /** End offset into the line's plain text (exclusive). */
+  end: number;
+}
+
+export interface SearchOptions {
+  /**
+   * Treat `text` as a regular expression source instead of literal text.
+   * Capped at 256 characters; over the cap, or an invalid pattern, yields
+   * zero matches and sets `error()`.
+   * @default false
+   */
+  regex?: boolean;
+  /** @default false */
+  caseSensitive?: boolean;
+  /** Wraps the pattern in `\b...\b`. @default false */
+  wholeWord?: boolean;
+}
+
+/**
+ * A plain string (split on `"\n"`), an array of lines used as-is, or a
+ * duck-typed `TokenizedDocument` (only `lineCount`/`lineRange` are used;
+ * never checked via `instanceof`) whose highlighted-HTML lines are decoded
+ * back to plain text before matching.
+ */
+export type SearchSource =
+  | string
+  | string[]
+  | Pick<TokenizedDocument, "lineCount" | "lineRange">;
+
+export interface Search {
+  /** Runs a new search. Empty `text` clears matches without an error. */
+  query(text: string, options?: SearchOptions): void;
+  /** All matches, in document order. Same array identity until the next mutation. */
+  matches(): readonly SearchMatch[];
+  /** `matches().length`. */
+  count(): number;
+  /** Set when the last `query()` couldn't compile its pattern. */
+  error(): string | undefined;
+  /** The currently selected match, or `undefined` before any query or with zero matches. */
+  current(): (SearchMatch & { index: number }) | undefined;
+  /** Advances to (and returns) the next match, wrapping around the end. */
+  next(): (SearchMatch & { index: number }) | undefined;
+  /** Moves to (and returns) the previous match, wrapping around the start. */
+  prev(): (SearchMatch & { index: number }) | undefined;
+  /** Replaces the source and re-runs an already-active query as a full rescan. */
+  setSource(source: SearchSource): void;
+  /** Runs `callback` after every mutating call. Returns an unsubscribe function. */
+  onChange(callback: () => void): () => void;
+}
+
+/**
+ * Headless find-in-document search over a plain string, a line array, or a
+ * `TokenizedDocument` (incrementally rescanning only newly appended lines
+ * when the same query is repeated against a grown document).
+ */
+export declare function createSearch(source: SearchSource): Search;

--- a/src/search.d.ts
+++ b/src/search.d.ts
@@ -61,3 +61,32 @@ export interface Search {
  * when the same query is repeated against a grown document).
  */
 export declare function createSearch(source: SearchSource): Search;
+
+export interface HighlightMatchesOptions {
+  /** 0-based index into `matches` of the selected ("current") match. */
+  current?: number;
+  /**
+   * Name registered with `CSS.highlights` (and `${name}-current` for the
+   * current match). A custom name bypasses `search.css`'s built-in rules.
+   * @default "shl-search"
+   */
+  name?: string;
+}
+
+/**
+ * Paints `matches` into `root`, restricted to whatever rows are currently
+ * rendered there: resolved per match's line via `[data-line]`, then the
+ * `line`-th `.line` element, then the whole `<code>` split on `"\n"`.
+ * Matches whose line resolves to nothing are skipped.
+ *
+ * Uses the CSS Custom Highlight API when available (two `Highlight`s:
+ * `name` and `${name}-current`), else wraps text in
+ * `<mark data-shl-search>` (plus `data-shl-search-current`). A no-op on the
+ * server. Paints once per call -- call `dispose()` and re-run to repaint
+ * after the rendered window or the query changes.
+ */
+export declare function highlightMatches(
+  root: Element,
+  matches: readonly SearchMatch[],
+  options?: HighlightMatchesOptions,
+): { dispose(): void };

--- a/src/search.js
+++ b/src/search.js
@@ -258,7 +258,12 @@ export function createSearch(source) {
     currentIndex =
       currentIndex === undefined ? 0 : (currentIndex + 1) % matches.length;
     notify();
-    return { .../** @type {import("./search.d.ts").SearchMatch} */ (matches[currentIndex]), index: currentIndex };
+    return {
+      .../** @type {import("./search.d.ts").SearchMatch} */ (
+        matches[currentIndex]
+      ),
+      index: currentIndex,
+    };
   }
 
   function prev() {
@@ -268,7 +273,12 @@ export function createSearch(source) {
         ? matches.length - 1
         : (currentIndex - 1 + matches.length) % matches.length;
     notify();
-    return { .../** @type {import("./search.d.ts").SearchMatch} */ (matches[currentIndex]), index: currentIndex };
+    return {
+      .../** @type {import("./search.d.ts").SearchMatch} */ (
+        matches[currentIndex]
+      ),
+      index: currentIndex,
+    };
   }
 
   /** @param {import("./search.d.ts").SearchSource} newSource */
@@ -303,5 +313,206 @@ export function createSearch(source) {
     prev,
     setSource,
     onChange,
+  };
+}
+
+/**
+ * Resolves the rendered row for `line`: `[data-line]` first, then the
+ * `line`-th `.line` element (0-indexed), then the whole `<code>` (offsets
+ * treated as absolute into its full `textContent`, split on `"\n"`).
+ * @param {Element} root
+ * @param {number} line
+ * @param {Map<Element, number[]>} codeLineOffsets
+ * @returns {{ container: Element; baseOffset: number } | undefined}
+ */
+function resolveLineScope(root, line, codeLineOffsets) {
+  const byDataLine = root.querySelector(`[data-line="${line}"]`);
+  if (byDataLine) return { container: byDataLine, baseOffset: 0 };
+
+  const byClass = root.querySelectorAll(".line")[line];
+  if (byClass) return { container: byClass, baseOffset: 0 };
+
+  const code = root.querySelector("code");
+  if (!code) return undefined;
+
+  let offsets = codeLineOffsets.get(code);
+  if (!offsets) {
+    offsets = [];
+    let consumed = 0;
+    for (const text of (code.textContent ?? "").split("\n")) {
+      offsets.push(consumed);
+      consumed += text.length + 1;
+    }
+    codeLineOffsets.set(code, offsets);
+  }
+
+  const baseOffset = offsets[line];
+  return baseOffset === undefined ? undefined : { container: code, baseOffset };
+}
+
+/**
+ * Walks `container`'s text nodes to find the (node, local offset) boundary
+ * for an absolute character offset into its full text content.
+ * @param {Node} container
+ * @param {number} offset
+ * @returns {{ node: Text; offset: number } | undefined}
+ */
+function resolveTextPosition(container, offset) {
+  const walker = document.createTreeWalker(container, NodeFilter.SHOW_TEXT);
+  let consumed = 0;
+  let node = /** @type {Text | null} */ (walker.nextNode());
+  while (node !== null) {
+    const length = node.data.length;
+    if (offset <= consumed + length) return { node, offset: offset - consumed };
+    consumed += length;
+    node = /** @type {Text | null} */ (walker.nextNode());
+  }
+  return undefined;
+}
+
+/**
+ * @param {{ container: Element; baseOffset: number }} scope
+ * @param {number} start
+ * @param {number} end
+ * @returns {Range | undefined}
+ */
+function resolveRange(scope, start, end) {
+  const from = resolveTextPosition(scope.container, scope.baseOffset + start);
+  const to = resolveTextPosition(scope.container, scope.baseOffset + end);
+  if (!from || !to) return undefined;
+  const range = new Range();
+  range.setStart(from.node, from.offset);
+  range.setEnd(to.node, to.offset);
+  return range;
+}
+
+/**
+ * Wraps a match's text in one `<mark>` per text node it spans, splitting
+ * nodes as needed. Re-walks `scope.container` fresh each call, so callers
+ * must process matches within a scope in descending `start` order.
+ * @param {{ container: Element; baseOffset: number }} scope
+ * @param {number} start
+ * @param {number} end
+ * @param {boolean} isCurrent
+ * @returns {HTMLElement[]}
+ */
+function wrapMatchInMarks(scope, start, end, isCurrent) {
+  const globalStart = scope.baseOffset + start;
+  const globalEnd = scope.baseOffset + end;
+
+  const walker = document.createTreeWalker(
+    scope.container,
+    NodeFilter.SHOW_TEXT,
+  );
+  /** @type {Text[]} */
+  const textNodes = [];
+  let node = /** @type {Text | null} */ (walker.nextNode());
+  while (node !== null) {
+    textNodes.push(node);
+    node = /** @type {Text | null} */ (walker.nextNode());
+  }
+
+  /** @type {HTMLElement[]} */
+  const marks = [];
+  let consumed = 0;
+  for (const textNode of textNodes) {
+    const length = textNode.data.length;
+    const nodeStart = consumed;
+    const nodeEnd = consumed + length;
+    consumed = nodeEnd;
+
+    const overlapStart = Math.max(globalStart, nodeStart);
+    const overlapEnd = Math.min(globalEnd, nodeEnd);
+    if (overlapStart >= overlapEnd) continue;
+
+    const localStart = overlapStart - nodeStart;
+    const localEnd = overlapEnd - nodeStart;
+
+    let middle = textNode;
+    if (localEnd < length) middle.splitText(localEnd);
+    if (localStart > 0) middle = middle.splitText(localStart);
+
+    const mark = document.createElement("mark");
+    mark.dataset.shlSearch = "";
+    if (isCurrent) mark.dataset.shlSearchCurrent = "";
+    middle.replaceWith(mark);
+    mark.appendChild(middle);
+    marks.push(mark);
+  }
+
+  return marks;
+}
+
+/**
+ * Paints `matches` into `root` (the currently-rendered rows only): the CSS
+ * Custom Highlight API when available, else `<mark data-shl-search>`
+ * wrapping. One full paint per call - repaint-on-change is the caller's job.
+ * @param {Element} root
+ * @param {readonly import("./search.d.ts").SearchMatch[]} matches
+ * @param {{ current?: number; name?: string }} [options]
+ * @returns {{ dispose(): void }}
+ */
+export function highlightMatches(
+  root,
+  matches,
+  { current, name = "shl-search" } = {},
+) {
+  if (typeof document === "undefined") return { dispose() {} };
+
+  /** @type {Map<number, { start: number; end: number; index: number }[]>} */
+  const byLine = new Map();
+  matches.forEach((match, index) => {
+    const list = byLine.get(match.line) ?? [];
+    list.push({ start: match.start, end: match.end, index });
+    byLine.set(match.line, list);
+  });
+
+  /** @type {Map<Element, number[]>} */
+  const codeLineOffsets = new Map();
+
+  if ("highlights" in CSS) {
+    const highlight = new Highlight();
+    const currentHighlight = new Highlight();
+    CSS.highlights.set(name, highlight);
+    CSS.highlights.set(`${name}-current`, currentHighlight);
+
+    for (const [line, lineMatches] of byLine) {
+      const scope = resolveLineScope(root, line, codeLineOffsets);
+      if (!scope) continue;
+      for (const { start, end, index } of lineMatches) {
+        const range = resolveRange(scope, start, end);
+        if (!range) continue;
+        if (index === current) currentHighlight.add(range);
+        else highlight.add(range);
+      }
+    }
+
+    return {
+      dispose() {
+        CSS.highlights.delete(name);
+        CSS.highlights.delete(`${name}-current`);
+      },
+    };
+  }
+
+  /** @type {HTMLElement[]} */
+  const createdMarks = [];
+
+  for (const [line, lineMatches] of byLine) {
+    const scope = resolveLineScope(root, line, codeLineOffsets);
+    if (!scope) continue;
+    const descending = [...lineMatches].sort((a, b) => b.start - a.start);
+    for (const { start, end, index } of descending) {
+      createdMarks.push(
+        ...wrapMatchInMarks(scope, start, end, index === current),
+      );
+    }
+  }
+
+  return {
+    dispose() {
+      for (const mark of createdMarks) mark.replaceWith(...mark.childNodes);
+      root.normalize();
+    },
   };
 }

--- a/src/search.js
+++ b/src/search.js
@@ -1,0 +1,307 @@
+const ENTITY_RE = /&amp;|&lt;|&gt;|&quot;|&#x27;/g;
+/** @type {Record<string, string>} */
+const ENTITY_MAP = {
+  "&amp;": "&",
+  "&lt;": "<",
+  "&gt;": ">",
+  "&quot;": '"',
+  "&#x27;": "'",
+};
+const TAG_RE = /<[^>]*>/g;
+const REGEX_SOURCE_LIMIT = 256;
+
+/**
+ * Decodes the five entities `escapeHtml` (`./engine.js`) produces, then
+ * strips tag markup - exact for this engine's rendered HTML, not a general
+ * HTML parser.
+ * @param {string} html
+ * @returns {string}
+ */
+function toPlainText(html) {
+  return html
+    .replace(ENTITY_RE, (entity) => ENTITY_MAP[entity] ?? entity)
+    .replace(TAG_RE, "");
+}
+
+/**
+ * @param {import("./search.d.ts").SearchSource} source
+ * @returns {{ kind: "string" | "array" | "tokenized"; lineCount(): number; lineRange(start: number, end: number): string[] }}
+ */
+function createAdapter(source) {
+  if (typeof source === "string") {
+    const lines = source.split("\n");
+    return {
+      kind: "string",
+      lineCount: () => lines.length,
+      lineRange: (start, end) => lines.slice(start, end),
+    };
+  }
+
+  if (Array.isArray(source)) {
+    return {
+      kind: "array",
+      lineCount: () => source.length,
+      lineRange: (start, end) => source.slice(start, end),
+    };
+  }
+
+  return {
+    kind: "tokenized",
+    lineCount: () => source.lineCount(),
+    lineRange: (start, end) => source.lineRange(start, end).map(toPlainText),
+  };
+}
+
+/** @param {string} text */
+function escapeRegExp(text) {
+  return text.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * @param {string} source
+ * @param {boolean} wholeWord
+ */
+function applyWholeWord(source, wholeWord) {
+  return wholeWord ? `\\b${source}\\b` : source;
+}
+
+/**
+ * @param {string} text
+ * @param {Required<import("./search.d.ts").SearchOptions>} options
+ * @returns {{ pattern: RegExp | null; error: string | undefined }}
+ */
+function compilePattern(text, { regex, caseSensitive, wholeWord }) {
+  const flags = `g${caseSensitive ? "" : "i"}`;
+
+  if (regex) {
+    if (text.length > REGEX_SOURCE_LIMIT) {
+      return {
+        pattern: null,
+        error: `Pattern exceeds ${REGEX_SOURCE_LIMIT} characters`,
+      };
+    }
+    try {
+      return {
+        pattern: new RegExp(applyWholeWord(text, wholeWord), flags),
+        error: undefined,
+      };
+    } catch (err) {
+      return {
+        pattern: null,
+        error: err instanceof Error ? err.message : String(err),
+      };
+    }
+  }
+
+  return {
+    pattern: new RegExp(applyWholeWord(escapeRegExp(text), wholeWord), flags),
+    error: undefined,
+  };
+}
+
+/**
+ * @param {import("./search.d.ts").SearchOptions & { regex: boolean; caseSensitive: boolean; wholeWord: boolean }} a
+ * @param {typeof a} b
+ */
+function optionsEqual(a, b) {
+  return (
+    a.regex === b.regex &&
+    a.caseSensitive === b.caseSensitive &&
+    a.wholeWord === b.wholeWord
+  );
+}
+
+/**
+ * @param {import("./search.d.ts").SearchSource} source
+ * @returns {import("./search.d.ts").Search}
+ */
+export function createSearch(source) {
+  let adapter = createAdapter(source);
+
+  /** @type {import("./search.d.ts").SearchMatch[]} */
+  let matches = [];
+  /** @type {number | undefined} */
+  let currentIndex;
+  /** @type {string | undefined} */
+  let errorMessage;
+  let hasQueried = false;
+  let lastText = "";
+  let lastOptions = { regex: false, caseSensitive: false, wholeWord: false };
+  let lastScannedLineCount = 0;
+
+  /** @type {Set<() => void>} */
+  const listeners = new Set();
+
+  function notify() {
+    for (const listener of listeners) listener();
+  }
+
+  /**
+   * @param {number} start
+   * @param {number} end
+   * @param {RegExp} pattern
+   * @returns {import("./search.d.ts").SearchMatch[]}
+   */
+  function scanRange(start, end, pattern) {
+    const lines = adapter.lineRange(start, end);
+    /** @type {import("./search.d.ts").SearchMatch[]} */
+    const found = [];
+    for (let i = 0; i < lines.length; i += 1) {
+      const line = start + i;
+      const text = /** @type {string} */ (lines[i]);
+      pattern.lastIndex = 0;
+      let match = pattern.exec(text);
+      while (match !== null) {
+        const matchStart = match.index;
+        const matchEnd = matchStart + match[0].length;
+        found.push({ line, start: matchStart, end: matchEnd });
+        if (match[0].length === 0) pattern.lastIndex += 1;
+        match = pattern.exec(text);
+      }
+    }
+    return found;
+  }
+
+  /**
+   * @param {string} text
+   * @param {import("./search.d.ts").SearchOptions} [options]
+   */
+  function query(text, options = {}) {
+    const normalized = {
+      regex: !!options.regex,
+      caseSensitive: !!options.caseSensitive,
+      wholeWord: !!options.wholeWord,
+    };
+
+    if (text === "") {
+      matches = [];
+      currentIndex = undefined;
+      errorMessage = undefined;
+      lastText = text;
+      lastOptions = normalized;
+      lastScannedLineCount = adapter.lineCount();
+      hasQueried = true;
+      notify();
+      return;
+    }
+
+    const sameQuery =
+      hasQueried && text === lastText && optionsEqual(normalized, lastOptions);
+
+    if (sameQuery && adapter.kind === "tokenized") {
+      const newLineCount = adapter.lineCount();
+
+      if (newLineCount === lastScannedLineCount) {
+        notify();
+        return;
+      }
+
+      if (newLineCount > lastScannedLineCount) {
+        const { pattern, error } = compilePattern(text, normalized);
+        if (pattern === null) {
+          matches = [];
+          currentIndex = undefined;
+          errorMessage = error;
+          lastScannedLineCount = newLineCount;
+          notify();
+          return;
+        }
+        matches = [
+          ...matches,
+          ...scanRange(lastScannedLineCount, newLineCount, pattern),
+        ];
+        errorMessage = undefined;
+        lastScannedLineCount = newLineCount;
+        notify();
+        return;
+      }
+
+      // Shrink: fall through to a full rescan below.
+    }
+
+    const { pattern, error } = compilePattern(text, normalized);
+    lastText = text;
+    lastOptions = normalized;
+    hasQueried = true;
+    lastScannedLineCount = adapter.lineCount();
+
+    if (pattern === null) {
+      matches = [];
+      currentIndex = undefined;
+      errorMessage = error;
+      notify();
+      return;
+    }
+
+    errorMessage = undefined;
+    matches = scanRange(0, lastScannedLineCount, pattern);
+    currentIndex = matches.length > 0 ? 0 : undefined;
+    notify();
+  }
+
+  function count() {
+    return matches.length;
+  }
+
+  function error() {
+    return errorMessage;
+  }
+
+  function current() {
+    if (currentIndex === undefined) return undefined;
+    const match = matches[currentIndex];
+    return match === undefined ? undefined : { ...match, index: currentIndex };
+  }
+
+  function next() {
+    if (matches.length === 0) return undefined;
+    currentIndex =
+      currentIndex === undefined ? 0 : (currentIndex + 1) % matches.length;
+    notify();
+    return { .../** @type {import("./search.d.ts").SearchMatch} */ (matches[currentIndex]), index: currentIndex };
+  }
+
+  function prev() {
+    if (matches.length === 0) return undefined;
+    currentIndex =
+      currentIndex === undefined
+        ? matches.length - 1
+        : (currentIndex - 1 + matches.length) % matches.length;
+    notify();
+    return { .../** @type {import("./search.d.ts").SearchMatch} */ (matches[currentIndex]), index: currentIndex };
+  }
+
+  /** @param {import("./search.d.ts").SearchSource} newSource */
+  function setSource(newSource) {
+    adapter = createAdapter(newSource);
+    const wasQueried = hasQueried;
+    matches = [];
+    currentIndex = undefined;
+    errorMessage = undefined;
+    lastScannedLineCount = 0;
+    hasQueried = false;
+    if (wasQueried) {
+      query(lastText, lastOptions);
+    } else {
+      notify();
+    }
+  }
+
+  /** @param {() => void} callback */
+  function onChange(callback) {
+    listeners.add(callback);
+    return () => listeners.delete(callback);
+  }
+
+  return {
+    query,
+    matches: () => matches,
+    count,
+    error,
+    current,
+    next,
+    prev,
+    setSource,
+    onChange,
+  };
+}

--- a/tests/e2e/HighlightSearch.test.svelte
+++ b/tests/e2e/HighlightSearch.test.svelte
@@ -70,7 +70,7 @@
 
 <svelte:head>{@html atomOneDark}</svelte:head>
 
-<input data-testid="query" on:input={onInput} />
+<input data-testid="query" on:input={onInput}>
 <span data-testid="count">{count}</span>
 <button type="button" data-testid="next" on:click={next}>Next</button>
 <button type="button" data-testid="prev" on:click={prev}>Prev</button>

--- a/tests/e2e/HighlightSearch.test.svelte
+++ b/tests/e2e/HighlightSearch.test.svelte
@@ -1,0 +1,87 @@
+<script>
+  import { onDestroy } from "svelte";
+  import { HighlightVirtual } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+  import { createSearch, highlightMatches } from "../../src/search.js";
+
+  export let forceFallback = false;
+
+  if (forceFallback) {
+    Reflect.deleteProperty(CSS, "highlights");
+  }
+
+  const LINE_COUNT = 4000;
+
+  // A 5-line cluster of matches every 200 lines: dense enough that several
+  // land in the same rendered window together (some current, some not), but
+  // spaced out enough that later clusters start outside the initial window.
+  function generateCode(lines) {
+    let out = "";
+    for (let i = 0; i < lines; i++) {
+      const word = i % 200 < 5 ? "NEEDLE" : `x${i}`;
+      out += `const ${word} = ${i}; // line ${i}\n`;
+    }
+    return out;
+  }
+
+  const code = generateCode(LINE_COUNT);
+  const search = createSearch(code);
+
+  /** @type {import("../../src/HighlightVirtual.svelte").default} */
+  let ref;
+  /** @type {HTMLDivElement} */
+  let rootEl;
+
+  let count = 0;
+  let dispose = () => {};
+
+  function repaint() {
+    dispose();
+    dispose = highlightMatches(rootEl, search.matches(), {
+      current: search.current()?.index,
+    }).dispose;
+  }
+
+  const unsubscribe = search.onChange(() => {
+    count = search.count();
+    repaint();
+  });
+
+  onDestroy(() => {
+    dispose();
+    unsubscribe();
+  });
+
+  function onInput(event) {
+    search.query(event.currentTarget.value);
+  }
+
+  function next() {
+    const match = search.next();
+    if (match) ref?.scrollToLine(match.line);
+  }
+
+  function prev() {
+    const match = search.prev();
+    if (match) ref?.scrollToLine(match.line);
+  }
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<input data-testid="query" on:input={onInput} />
+<span data-testid="count">{count}</span>
+<button type="button" data-testid="next" on:click={next}>Next</button>
+<button type="button" data-testid="prev" on:click={prev}>Prev</button>
+
+<div bind:this={rootEl}>
+  <HighlightVirtual
+    bind:this={ref}
+    language={javascript}
+    {code}
+    data-testid="virtual"
+    style="height: 300px; width: 600px;"
+    on:windowchange={repaint}
+  />
+</div>

--- a/tests/e2e/HighlightStream.virtualize.test.svelte
+++ b/tests/e2e/HighlightStream.virtualize.test.svelte
@@ -6,6 +6,8 @@
   export let overscan = 5;
   export let autoScroll = false;
 
+  /** @type {import("../../src/HighlightStream.svelte").default} */
+  let ref;
   let code = "";
   let done = false;
   let doneCount = 0;
@@ -45,6 +47,7 @@
 <span data-testid="window-change-snapshot">{JSON.stringify(lastWindow)}</span>
 
 <HighlightStream
+  bind:this={ref}
   language={javascript}
   {code}
   {done}
@@ -59,3 +62,10 @@
     lastWindow = e.detail;
   }}
 />
+<button
+  type="button"
+  data-testid="scroll-to-1000"
+  on:click={() => ref.scrollToLine(1000)}
+>
+  Scroll to line 1000
+</button>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -1904,6 +1904,20 @@ test("HighlightStream virtualize - shows correct content at a scrolled position"
   );
 });
 
+test("HighlightStream virtualize - scrollToLine scrolls a given line into the rendered window", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightStreamVirtualize);
+
+  const stream = page.getByTestId("stream");
+  await page.getByTestId("append-many").click();
+  await expect(stream.locator("[data-line]").first()).toBeVisible();
+
+  await page.getByTestId("scroll-to-1000").click();
+  await expect(stream.locator("[data-line='1000']")).toBeVisible();
+});
+
 test("HighlightStream virtualize - the caret only renders once the window reaches the live tail", async ({
   mount,
   page,

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -30,6 +30,7 @@ import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
 import HighlightEditableCssHighlights from "./HighlightEditable.cssHighlights.test.svelte";
 import HighlightEditableLanguageSwap from "./HighlightEditable.languageSwap.test.svelte";
 import HighlightEditable from "./HighlightEditable.test.svelte";
+import HighlightSearch from "./HighlightSearch.test.svelte";
 import HighlightStreamMidLineHighlight from "./HighlightStream.midLineHighlight.test.svelte";
 import HighlightStreamRegenerate from "./HighlightStream.regenerate.test.svelte";
 import HighlightStreamSealing from "./HighlightStream.sealing.test.svelte";
@@ -1493,6 +1494,90 @@ test("HighlightEditable css-highlights engine - falls back to the DOM engine wit
     "dom",
   );
   await expect(page.locator(".hljs-keyword").first()).toHaveText("const");
+});
+
+test("Search - shows a match count and highlights occurrences in the rendered window", async ({
+  mount,
+  page,
+}) => {
+  const supported = await page.evaluate(
+    () => typeof CSS !== "undefined" && "highlights" in CSS,
+  );
+
+  await mount(HighlightSearch);
+
+  await page.getByTestId("query").fill("NEEDLE");
+  await expect(page.getByTestId("count")).not.toHaveText("0");
+
+  if (supported) {
+    const painted = await page.evaluate(() => {
+      const highlight = CSS.highlights.get("shl-search");
+      return highlight ? highlight.size > 0 : false;
+    });
+    expect(painted).toBe(true);
+  } else {
+    await expect(page.locator("mark[data-shl-search]").first()).toBeVisible();
+  }
+});
+
+test("Search - next scrolls the current match into the rendered window", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightSearch);
+
+  const virtual = page.getByTestId("virtual");
+  await page.getByTestId("query").fill("NEEDLE");
+  await expect(page.getByTestId("count")).not.toHaveText("0");
+
+  const next = page.getByTestId("next");
+  // Lines 0-4 form the first match cluster, all inside the initial rendered
+  // window; the 6th match (index 5) is line 200, well outside it.
+  // biome-ignore lint/performance/noAwaitInLoops: each click's scroll must land before the next
+  for (let i = 0; i < 5; i += 1) await next.click();
+
+  await expect(virtual.locator('[data-line="200"]')).toBeVisible();
+});
+
+test("Search - falls back to <mark> wrapping without CSS.highlights", async ({
+  mount,
+  page,
+}) => {
+  const errors: string[] = [];
+  page.on("console", (message) => {
+    if (message.type() === "error") errors.push(message.text());
+  });
+  page.on("pageerror", (error) => errors.push(error.message));
+
+  await mount(HighlightSearch, { props: { forceFallback: true } });
+
+  await page.getByTestId("query").fill("NEEDLE");
+  await expect(page.locator("mark[data-shl-search]").first()).toBeVisible();
+  expect(await page.locator("mark[data-shl-search]").count()).toBeGreaterThan(
+    0,
+  );
+
+  expect(errors).toEqual([]);
+});
+
+test("Search - registers a highlight via the CSS Custom Highlight API", async ({
+  mount,
+  page,
+}) => {
+  const supported = await page.evaluate(
+    () => typeof CSS !== "undefined" && "highlights" in CSS,
+  );
+  test.skip(!supported, "CSS Custom Highlight API not supported");
+
+  await mount(HighlightSearch);
+
+  await page.getByTestId("query").fill("NEEDLE");
+  await expect(page.getByTestId("count")).not.toHaveText("0");
+
+  const size = await page.evaluate(
+    () => CSS.highlights.get("shl-search")?.size ?? 0,
+  );
+  expect(size).toBeGreaterThan(0);
 });
 
 test("HighlightStream - streaming chunks (split mid-keyword and mid-template-literal) settle to Highlight's output", async ({

--- a/tests/search.test.ts
+++ b/tests/search.test.ts
@@ -1,0 +1,143 @@
+import { createSearch } from "../src/search.js";
+
+describe("createSearch", () => {
+  it("matches case-insensitively by default", () => {
+    const search = createSearch("Foo\nfoo\nFOO");
+    search.query("foo");
+    expect(search.count()).toBe(3);
+  });
+
+  it("narrows to exact case with caseSensitive", () => {
+    const search = createSearch("Foo\nfoo\nFOO");
+    search.query("foo", { caseSensitive: true });
+    expect(search.count()).toBe(1);
+    expect(search.matches()[0]).toEqual({ line: 1, start: 0, end: 3 });
+  });
+
+  it("narrows to whole words with wholeWord", () => {
+    const search = createSearch("foo foobar foo");
+    search.query("foo", { wholeWord: true });
+    expect(search.count()).toBe(2);
+  });
+
+  it("compiles a regex pattern", () => {
+    const search = createSearch("a1 b22 c333");
+    search.query("\\d+", { regex: true });
+    expect(search.matches().map((m) => [m.start, m.end])).toEqual([
+      [1, 2],
+      [4, 6],
+      [8, 11],
+    ]);
+  });
+
+  it("reports an error and zero matches for an invalid regex", () => {
+    const search = createSearch("abc");
+    search.query("(", { regex: true });
+    expect(search.count()).toBe(0);
+    expect(search.error()).toBeDefined();
+  });
+
+  it("reports an error and zero matches for a regex over 256 characters", () => {
+    const search = createSearch("abc");
+    search.query("a".repeat(300), { regex: true });
+    expect(search.count()).toBe(0);
+    expect(search.error()).toBeDefined();
+  });
+
+  it("wraps next()/prev() around a 3-match result", () => {
+    const search = createSearch("foo foo foo");
+    search.query("foo");
+    expect(search.count()).toBe(3);
+
+    expect(search.current()?.index).toBe(0);
+    expect(search.next()?.index).toBe(1);
+    expect(search.next()?.index).toBe(2);
+    expect(search.next()?.index).toBe(0);
+    expect(search.prev()?.index).toBe(2);
+  });
+
+  it("no-ops next()/prev() at zero matches", () => {
+    const search = createSearch("abc");
+    search.query("xyz");
+    expect(search.next()).toBeUndefined();
+    expect(search.prev()).toBeUndefined();
+  });
+
+  it("matches a string[] source's entries directly", () => {
+    const search = createSearch(["const a = 1;", "const b = 2;"]);
+    search.query("const");
+    expect(search.count()).toBe(2);
+    expect(search.matches().map((m) => m.line)).toEqual([0, 1]);
+  });
+
+  it("matches a TokenizedDocument source against its decoded plain text", () => {
+    const doc = {
+      lineCount: () => 1,
+      lineRange: () => ['<span class="hljs-keyword">const</span> x = 1'],
+    };
+    const search = createSearch(doc);
+    search.query("x = 1");
+    expect(search.count()).toBe(1);
+    expect(search.matches()[0]).toEqual({ line: 0, start: 6, end: 11 });
+  });
+
+  it("rescans only newly appended lines for a repeated query against a grown TokenizedDocument", () => {
+    let lineCount = 100;
+    const calls: Array<[number, number]> = [];
+    const doc = {
+      lineCount: () => lineCount,
+      lineRange: (start: number, end: number) => {
+        calls.push([start, end]);
+        const lines: string[] = [];
+        for (let i = start; i < end; i += 1) lines.push(`line ${i}`);
+        return lines;
+      },
+    };
+
+    const search = createSearch(doc);
+    search.query("line");
+    expect(search.count()).toBe(100);
+
+    lineCount = 110;
+    calls.length = 0;
+    search.query("line");
+    expect(search.count()).toBe(110);
+    expect(calls[0]?.[0]).toBe(100);
+  });
+
+  it("setSource swaps results without re-touching the old source", () => {
+    let touched = false;
+    const oldSource = {
+      lineCount: () => 1,
+      lineRange: () => {
+        touched = true;
+        return ["foo"];
+      },
+    };
+
+    const search = createSearch(oldSource);
+    search.query("foo");
+    expect(search.count()).toBe(1);
+
+    touched = false;
+    search.setSource("bar\nfoo");
+    expect(touched).toBe(false);
+    expect(search.count()).toBe(1);
+    expect(search.matches()[0]?.line).toBe(1);
+  });
+
+  it("fires onChange and stops after unsubscribe", () => {
+    const search = createSearch("foo");
+    let calls = 0;
+    const unsubscribe = search.onChange(() => {
+      calls += 1;
+    });
+
+    search.query("foo");
+    expect(calls).toBe(1);
+
+    unsubscribe();
+    search.query("bar");
+    expect(calls).toBe(1);
+  });
+});

--- a/www/components/HighlightStream/Virtualize.svelte
+++ b/www/components/HighlightStream/Virtualize.svelte
@@ -1,6 +1,6 @@
 <script>
   import { THEME_MODULE_NAME } from "@www/constants";
-  import { Button, Toggle } from "carbon-components-svelte";
+  import { Button, NumberInput, Toggle } from "carbon-components-svelte";
   import { onDestroy, onMount } from "svelte";
   import { HighlightStream } from "svelte-highlight";
   import javascript from "svelte-highlight/languages/javascript";
@@ -20,6 +20,14 @@
   let windowEnd = 0;
   let windowLineCount = 0;
   let stop = () => {};
+  let jumpToLine = 750;
+
+  /** @type {HighlightStream} */
+  let ref;
+
+  function jump() {
+    ref?.scrollToLine(jumpToLine ?? 0);
+  }
 
   function run() {
     stop();
@@ -51,6 +59,7 @@
 </p>
 
 <HighlightStream
+  bind:this={ref}
   language={javascript}
   {code}
   {done}
@@ -77,6 +86,17 @@
     {paused ? "Resume" : "Pause"}
   </Button>
   <Button size="small" kind="tertiary" on:click={run}>Replay</Button>
+  <div style="display: flex; align-items: flex-end; gap: 0.5rem">
+    <NumberInput
+      id="jump-to-line"
+      size="sm"
+      min={0}
+      max={LINE_COUNT}
+      bind:value={jumpToLine}
+      labelText={`Jump to line (of ${LINE_COUNT.toLocaleString()})`}
+    />
+    <Button size="small" kind="tertiary" on:click={jump}>Jump</Button>
+  </div>
   <p class="label-01" style="margin-bottom: 0.5rem">
     Status:{" "}
     <code class="code">{done ? "done" : paused ? "paused" : "streaming…"}</code>

--- a/www/components/HighlightVirtual/Search.svelte
+++ b/www/components/HighlightVirtual/Search.svelte
@@ -1,0 +1,74 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { Button, Search } from "carbon-components-svelte";
+  import { onDestroy } from "svelte";
+  import { HighlightVirtual } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import { createSearch, highlightMatches } from "svelte-highlight/search";
+  import "svelte-highlight/search.css";
+  import { generateTypeScript } from "./generate-large-code.js";
+
+  const LINE_COUNT = 20_000;
+  const code = generateTypeScript(LINE_COUNT);
+  const search = createSearch(code);
+
+  let query = "value";
+  let label = "0 of 0";
+
+  /** @type {HighlightVirtual} */
+  let ref;
+  /** @type {HTMLElement} */
+  let root;
+  let dispose = () => {};
+
+  function repaint() {
+    dispose();
+    dispose = highlightMatches(root, search.matches(), {
+      current: search.current()?.index,
+    }).dispose;
+  }
+
+  const unsubscribe = search.onChange(() => {
+    const current = search.current();
+    const count = search.count();
+    label = count === 0 ? "0 of 0" : `${(current?.index ?? 0) + 1} of ${count}`;
+    repaint();
+  });
+
+  onDestroy(() => {
+    dispose();
+    unsubscribe();
+  });
+
+  $: search.query(query);
+
+  function jump(match) {
+    if (match) ref?.scrollToLine(match.line);
+  }
+</script>
+
+<div
+  style="display: flex; flex-wrap: wrap; align-items: flex-end; gap: 1rem; margin-bottom: 1rem"
+>
+  <Search bind:value={query} labelText="Find in document" size="sm" />
+  <Button size="small" kind="tertiary" on:click={() => jump(search.prev())}>
+    Prev
+  </Button>
+  <Button size="small" kind="tertiary" on:click={() => jump(search.next())}>
+    Next
+  </Button>
+  <p class="label-01" style="margin-bottom: 0.5rem">
+    Match <code class="code">{label}</code>
+  </p>
+</div>
+
+<div bind:this={root}>
+  <HighlightVirtual
+    bind:this={ref}
+    language={typescript}
+    {code}
+    class={THEME_MODULE_NAME}
+    style="height: 320px"
+    on:windowchange={repaint}
+  />
+</div>

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -24,6 +24,7 @@
   import HighlightVirtualBasic from "@components/HighlightVirtual/Basic.svelte";
   import HighlightVirtualControls from "@components/HighlightVirtual/Controls.svelte";
   import HighlightVirtualHeadless from "@components/HighlightVirtual/Headless.svelte";
+  import HighlightVirtualSearch from "@components/HighlightVirtual/Search.svelte";
   import Basic from "@components/LineNumbers/Basic.svelte";
   import ContainerStyle from "@components/LineNumbers/ContainerStyle.svelte";
   import FocusLines from "@components/LineNumbers/FocusLines.svelte";
@@ -766,6 +767,20 @@ export { add, mul };\`,
     />
   </Column>
   <Column xlg={10} lg={10} md={12}> <HighlightVirtualHeadless /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">svelte-highlight/search</code>
+      is a headless find-in-document engine (<code class="code"
+        >createSearch</code
+      >) plus a DOM-painting helper (<code class="code">highlightMatches</code>)
+      -- no search-box component is exported, so this input and its
+      "next"/"prev" buttons are demo UI, not a library primitive. Matches
+      outside the rendered window are found immediately;
+      <code class="code">scrollToLine</code>
+      brings them into view.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <HighlightVirtualSearch /> </Column>
 </Row>
 
 <Row class="mb-9">


### PR DESCRIPTION
Adds `svelte-highlight/search`, a headless find-in-document engine
plus a DOM-painting helper, and gives `HighlightStream` the
`scrollToLine` method it already had on `HighlightVirtual`. Browser
Cmd+F can't see rows a virtualized view hasn't mounted, and neither
component ships a search box, so this fills that gap as a headless
primitive instead.

```js
import { createSearch, highlightMatches } from "svelte-highlight/search";

const search = createSearch(code); // string, string[], or TokenizedDocument
search.query("needle", { wholeWord: true });

const { dispose } = highlightMatches(root, search.matches(), {
  current: search.current()?.index,
});
```