### PR TITLE
docs(languages): fix yarnspinner entry formatting

### DIFF
--- a/SUPPORTED_LANGUAGES.md
+++ b/SUPPORTED_LANGUAGES.md
@@ -4335,12 +4335,17 @@
   import { yara } from "svelte-highlight/languages";
 </script>
 ```
+
 ## yarnspinner (`yarnspinner`)
+
 > Custom svelte-highlight language (not exported by highlight.js)
+
 ```html
 <script>
   // direct import (recommended)
   import yarnspinner from "svelte-highlight/languages/yarnspinner";
+
+  // base import
   import { yarnspinner } from "svelte-highlight/languages";
 </script>
 ```


### PR DESCRIPTION
The yarnspinner entry was missing the blank lines and the "base
import" comment that every other entry in the file has, so it
rendered as one squashed block instead of matching the rest.