### PR TITLE
fix(search): guard repaint against unmounted root in demo

### DIFF
--- a/www/components/HighlightVirtual/Search.svelte
+++ b/www/components/HighlightVirtual/Search.svelte
@@ -22,6 +22,7 @@
   let dispose = () => {};
 
   function repaint() {
+    if (!root) return;
     dispose();
     dispose = highlightMatches(root, search.matches(), {
       current: search.current()?.index,


### PR DESCRIPTION
Fixes an uncaught TypeError in the search demo where the initial
search.query() call ran before Svelte's bind:this had resolved the
root element, crashing highlightMatches with querySelector on
undefined.