### PR TITLE
chore(bench): upgrade ostia to 0.2.3

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -21,7 +21,7 @@
         "cssnano": "^7.1.9",
         "cssnano-preset-lite": "^4.0.6",
         "highlight.js": "11.12.0",
-        "ostia": "^0.2.2",
+        "ostia": "^0.2.3",
         "postcss": "^8.5.19",
         "postcss-discard-duplicates": "^7.0.4",
         "postcss-inline-css-vars": "^0.1.0",
@@ -700,7 +700,7 @@
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.5", "", { "dependencies": { "oniguruma-parser": "^0.12.1", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-Zjygswjpsewa0NLTsiizVuMQZbp0MDyM6lIt66OxsF21npUDlzpHi1Mgb/qhQdkb+dWFTzJmFbEWdvZgRho8eQ=="],
 
-    "ostia": ["ostia@0.2.2", "", { "bin": { "ostia": "cli.js" } }, "sha512-tVufhb4wNVNXg6yHcEVtIKYu24Zr95xxbAfaqCAm/sH+oCfFiFCIUyimoPKVJ2b4yGZ/YwLuzSsfntCLya6wNQ=="],
+    "ostia": ["ostia@0.2.3", "", { "bin": { "ostia": "cli.js" } }, "sha512-o/zO4BQDn9RKmo3RYjmLvohT4/41RRBK/1pIgAeZ6ok98g1386ywS9JAgkzJRPXkXxYkvemIm4E8dnfuDBEHRw=="],
 
     "p-limit": ["p-limit@7.3.0", "", { "dependencies": { "yocto-queue": "^1.2.1" } }, "sha512-7cIXg/Z0M5WZRblrsOla88S4wAK+zOQQWeBYfV3qJuJXMr+LnbYjaadrFaS0JILfEDPVqHyKnZ1Z/1d6J9VVUw=="],
 

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "cssnano": "^7.1.9",
     "cssnano-preset-lite": "^4.0.6",
     "highlight.js": "11.12.0",
-    "ostia": "^0.2.2",
+    "ostia": "^0.2.3",
     "postcss": "^8.5.19",
     "postcss-discard-duplicates": "^7.0.4",
     "postcss-inline-css-vars": "^0.1.0",


### PR DESCRIPTION
Bumps the dev-only bench CLI dependency. Nothing else in the repo
touches ostia's library API, config file, or saved baselines, so no
other migration steps apply.