### PR TITLE
docs(components): add CSS variable tables to CopyButton and CodeWindow

### DIFF
--- a/README.md
+++ b/README.md
@@ -2191,10 +2191,26 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 
 `$$restProps` are forwarded to the top-level `button` element.
 
+#### CSS Variables
+
+| Variable             | Description                          | Default value |
+| :-------------------- | :----------------------------------- | :------------ |
+| --copy-top           | Top offset of the button             | `0.5em`       |
+| --copy-right         | Right offset of the button           | `0.5em`       |
+| --copy-size          | Width and height of the button       | `2em`         |
+| --copy-padding       | Inner padding of the button          | `0.5em`       |
+| --copy-background    | Background color of the button       | `inherit`     |
+| --copy-color         | Foreground color of the button       | `inherit`     |
+| --copy-border-radius | Border radius of the button          | `4px`         |
+| --copy-border        | Border of the button                 | `none`        |
+| --copy-z-index       | Stacking order of the button         | `2`           |
+
 #### Dispatched Events
 
 - **on:copy**: fired after a successful copy, with `{ code }` -- the `transform`-applied string, not the original `code` prop
 - **on:error**: fired if the copy behavior throws, with `{ error }`
+- **on:mouseenter**: forwarded `MouseEvent`, useful for prefetching an async copy on hover
+- **on:mouseleave**: forwarded `MouseEvent`
 
 ```svelte
 <CopyButton
@@ -2214,6 +2230,29 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 | title   | `string`                           | `""`          |
 
 `$$restProps` are forwarded to the top-level `div` element.
+
+#### CSS Variables
+
+| Variable              | Description                              | Default value                       |
+| :-------------------- | :---------------------------------------- | :---------------------------------- |
+| --window-background   | Background color of the window body      | `#1e1e1e`                           |
+| --window-border       | Border of the window                     | `1px solid rgba(255, 255, 255, 0.1)`|
+| --window-radius       | Corner radius of the window              | `0`                                 |
+| --titlebar-gap        | Gap between items in the title bar       | `0.5em`                             |
+| --titlebar-padding    | Padding of the title bar                 | `0.65em 1em`                        |
+| --titlebar-background | Background color of the title bar        | `#2d2d2d`                           |
+| --titlebar-border     | Bottom border of the title bar           | `1px solid rgba(255, 255, 255, 0.1)`|
+| --titlebar-color      | Text color of the title bar              | `rgba(255, 255, 255, 0.6)`          |
+| --titlebar-font-family| Font family of the title bar             | `system-ui, -apple-system, sans-serif`|
+| --titlebar-font-size  | Font size of the title bar               | `0.8125em`                          |
+| --dot-gap             | Gap between the macOS traffic-light dots | `0.5em`                             |
+| --dot-size            | Diameter of the macOS traffic-light dots | `0.75em`                            |
+| --dot-close           | Color of the "close" traffic-light dot   | `#ff5f56`                           |
+| --dot-minimize        | Color of the "minimize" traffic-light dot| `#ffbd2e`                           |
+| --dot-maximize        | Color of the "maximize" traffic-light dot| `#27c93f`                           |
+| --prompt-font-family  | Font family of the terminal prompt       | `ui-monospace, monospace`           |
+| --prompt-font-weight  | Font weight of the terminal prompt       | `700`                               |
+| --prompt-color        | Color of the terminal prompt             | `inherit`                           |
 
 ### `AnsiOutput`
 

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,3 +1,4 @@
+import sitemap from "@astrojs/sitemap";
 import svelte from "@astrojs/svelte";
 import { defineConfig } from "astro/config";
 import { optimizeCss, optimizeImports } from "carbon-preprocess-svelte";
@@ -5,12 +6,14 @@ import path from "node:path";
 import pkg from "./package.json" assert { type: "json" };
 
 export default defineConfig({
+  site: "https://svhe.onrender.com",
   outDir: "build",
   trailingSlash: "never",
   integrations: [
     svelte({
       preprocess: [optimizeImports()],
     }),
+    sitemap(),
   ],
   srcDir: "./www",
   publicDir: "./www/public",

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "svelte-highlight",
       "devDependencies": {
+        "@astrojs/sitemap": "^3.7.4",
         "@astrojs/svelte": "^8.1.2",
         "@biomejs/biome": "2.5.12",
         "@jridgewell/trace-mapping": "^0.3.31",
@@ -39,6 +40,8 @@
     "@astrojs/markdown-remark": ["@astrojs/markdown-remark@7.2.0", "", { "dependencies": { "@astrojs/internal-helpers": "0.10.0", "@astrojs/prism": "4.0.2", "github-slugger": "^2.0.0", "hast-util-from-html": "^2.0.3", "hast-util-to-text": "^4.0.2", "mdast-util-definitions": "^6.0.0", "rehype-raw": "^7.0.0", "rehype-stringify": "^10.0.1", "remark-gfm": "^4.0.1", "remark-parse": "^11.0.0", "remark-rehype": "^11.1.2", "remark-smartypants": "^3.0.2", "unified": "^11.0.5", "unist-util-remove-position": "^5.0.0", "unist-util-visit": "^5.1.0", "unist-util-visit-parents": "^6.0.2", "vfile": "^6.0.3" } }, "sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw=="],
 
     "@astrojs/prism": ["@astrojs/prism@4.0.2", "", { "dependencies": { "prismjs": "^1.30.0" } }, "sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA=="],
+
+    "@astrojs/sitemap": ["@astrojs/sitemap@3.7.4", "", { "dependencies": { "sitemap": "^9.0.0", "zod": "^4.3.6" } }, "sha512-LbKNC24bdUWcQf/pThB6qLlSqHojxGjZDURIzFocY8rlWnAn2t74nnhnK6S5x0NHriHoAduLEpVjRykmeGiVvA=="],
 
     "@astrojs/svelte": ["@astrojs/svelte@8.1.2", "", { "dependencies": { "@sveltejs/vite-plugin-svelte": "^6.2.4", "svelte2tsx": "^0.7.55", "vite": "^7.3.2", "vitefu": "^1.1.2" }, "peerDependencies": { "astro": "^6.0.0", "svelte": "^5.43.6", "typescript": "^5.3.3 || ^6.0.0" } }, "sha512-L4eBoTY+DdgyH1g8pmKJxidRSvdk+NbkyJt5+f8EtdyJtPdxogeCyG3eEDmlIqqXxzNqLg7k/tYCjfBQ4kDMRA=="],
 
@@ -310,6 +313,8 @@
 
     "@types/node": ["@types/node@26.4.1", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-k97ENvZWtvA6yqz5/FS6a7duDgOPEeOQOc2iKS/nY6mX6qJUKtLnWzQS+Xj6tXweyj6ZcTAK2Qecetnvi9nCLA=="],
 
+    "@types/sax": ["@types/sax@1.2.7", "", { "dependencies": { "@types/node": "*" } }, "sha512-rO73L89PJxeYM3s3pPPjiPgVVcymqU490g0YO5n5By0k2Erzj6tay/4lr1CHAAU4JyOWd1rpQ8bCf6cZfHU96A=="],
+
     "@types/stack-utils": ["@types/stack-utils@2.0.3", "", {}, "sha512-9aEbYZ3TbYMznPdcdr3SmIrLXwC/AKZXQeCf9Pgao5CKb8CyHuEX5jzWPTkvregvhRJHcpRO6BFoGW9ycaOkYw=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
@@ -341,6 +346,8 @@
     "ansi-styles": ["ansi-styles@5.2.0", "", {}, "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA=="],
 
     "anymatch": ["anymatch@3.1.3", "", { "dependencies": { "normalize-path": "^3.0.0", "picomatch": "^2.0.4" } }, "sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw=="],
+
+    "arg": ["arg@5.0.2", "", {}, "sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
 
@@ -846,6 +853,8 @@
 
     "sisteransi": ["sisteransi@1.0.5", "", {}, "sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg=="],
 
+    "sitemap": ["sitemap@9.0.1", "", { "dependencies": { "@types/node": "^24.9.2", "@types/sax": "^1.2.1", "arg": "^5.0.0", "sax": "^1.4.1" }, "bin": { "sitemap": "dist/esm/cli.js" } }, "sha512-S6hzjGJSG3d6if0YoF5kTyeRJvia6FSTBroE5fQ0bu1QNxyJqhhinfUsXi9fH3MgtXODWvwo2BDyQSnhPQ88uQ=="],
+
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
     "smol-toml": ["smol-toml@1.6.1", "", {}, "sha512-dWUG8F5sIIARXih1DTaQAX4SsiTXhInKf1buxdY9DIg4ZYPZK5nGM1VRIYmEbDbsHt7USo99xSLFu5Q1IqTmsg=="],
@@ -972,6 +981,8 @@
 
     "playwright/playwright-core": ["playwright-core@1.61.1", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-h7Qlt6m4REp25qvIdvbDtVmD4LqVXfpRxhORv9L0jzETM05p4fuPJ3dKyuSXQxDSbXnmS79HAgi9589lGSpLkg=="],
 
+    "sitemap/@types/node": ["@types/node@24.13.3", "", { "dependencies": { "undici-types": "~7.18.0" } }, "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q=="],
+
     "svelte/aria-query": ["aria-query@5.3.1", "", {}, "sha512-Z/ZeOgVl7bcSYZ/u/rh0fOpvEpq//LZmdbkXyc7syVzjPAhfOa9ebsdTSjEBDU4vs5nC98Kfduj1uFo0qyET3g=="],
 
     "@astrojs/svelte/@sveltejs/vite-plugin-svelte/@sveltejs/vite-plugin-svelte-inspector": ["@sveltejs/vite-plugin-svelte-inspector@5.0.2", "", { "dependencies": { "obug": "^2.1.0" }, "peerDependencies": { "@sveltejs/vite-plugin-svelte": "^6.0.0-next.0", "svelte": "^5.0.0", "vite": "^6.3.0 || ^7.0.0" } }, "sha512-TZzRTcEtZffICSAoZGkPSl6Etsj2torOVrx6Uw0KpXxrec9Gg6jFWQ60Q3+LmNGfZSxHRCZL7vXVZIWmuV50Ig=="],
@@ -981,6 +992,8 @@
     "@playwright/experimental-ct-core/vite/esbuild": ["esbuild@0.25.9", "", { "optionalDependencies": { "@esbuild/aix-ppc64": "0.25.9", "@esbuild/android-arm": "0.25.9", "@esbuild/android-arm64": "0.25.9", "@esbuild/android-x64": "0.25.9", "@esbuild/darwin-arm64": "0.25.9", "@esbuild/darwin-x64": "0.25.9", "@esbuild/freebsd-arm64": "0.25.9", "@esbuild/freebsd-x64": "0.25.9", "@esbuild/linux-arm": "0.25.9", "@esbuild/linux-arm64": "0.25.9", "@esbuild/linux-ia32": "0.25.9", "@esbuild/linux-loong64": "0.25.9", "@esbuild/linux-mips64el": "0.25.9", "@esbuild/linux-ppc64": "0.25.9", "@esbuild/linux-riscv64": "0.25.9", "@esbuild/linux-s390x": "0.25.9", "@esbuild/linux-x64": "0.25.9", "@esbuild/netbsd-arm64": "0.25.9", "@esbuild/netbsd-x64": "0.25.9", "@esbuild/openbsd-arm64": "0.25.9", "@esbuild/openbsd-x64": "0.25.9", "@esbuild/openharmony-arm64": "0.25.9", "@esbuild/sunos-x64": "0.25.9", "@esbuild/win32-arm64": "0.25.9", "@esbuild/win32-ia32": "0.25.9", "@esbuild/win32-x64": "0.25.9" }, "bin": { "esbuild": "bin/esbuild" } }, "sha512-CRbODhYyQx3qp7ZEwzxOk4JBqmD/seJrzPa/cGjY1VtIn5E09Oi9/dB4JwctnfZ8Q8iT7rioVv5k/FNT/uf54g=="],
 
     "csso/css-tree/mdn-data": ["mdn-data@2.0.28", "", {}, "sha512-aylIc7Z9y4yzHYAJNuESG3hfhC+0Ibp/MAMiaOZgNv4pmEdFyfZhhhny4MNiAfWdBQ1RQ2mfDWmM1x8SvGyp8g=="],
+
+    "sitemap/@types/node/undici-types": ["undici-types@7.18.2", "", {}, "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w=="],
 
     "@playwright/experimental-ct-core/vite/esbuild/@esbuild/aix-ppc64": ["@esbuild/aix-ppc64@0.25.9", "", { "os": "aix", "cpu": "ppc64" }, "sha512-OaGtL73Jck6pBKjNIe24BnFE6agGl+6KxDtTfHhy1HmhthfKouEcOhqpSL64K4/0WCtbKFLOdzD/44cJ4k9opA=="],
 

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "playwright": "playwright"
   },
   "devDependencies": {
+    "@astrojs/sitemap": "^3.7.4",
     "@astrojs/svelte": "^8.1.2",
     "@biomejs/biome": "2.5.12",
     "@jridgewell/trace-mapping": "^0.3.31",

--- a/www/components/EnginePreview.svelte
+++ b/www/components/EnginePreview.svelte
@@ -1,0 +1,151 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import {
+    Button,
+    Select,
+    SelectItem,
+    TextArea,
+  } from "carbon-components-svelte";
+  import {
+    CLOSE,
+    createRegistry,
+    OPEN,
+    registerAll,
+    renderHtml,
+    TEXT,
+    tokenLines,
+  } from "svelte-highlight/engine";
+  import bash from "svelte-highlight/languages/bash";
+  import javascript from "svelte-highlight/languages/javascript";
+  import json from "svelte-highlight/languages/json";
+  import python from "svelte-highlight/languages/python";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const LANGUAGES = [typescript, javascript, python, json, bash];
+  const EVENT_TYPE_NAME = { [TEXT]: "TEXT", [OPEN]: "OPEN", [CLOSE]: "CLOSE" };
+  const STREAM_CHUNK_SIZE = 20;
+
+  const registry = createRegistry();
+  for (const language of LANGUAGES) {
+    registerAll(registry, language);
+  }
+
+  let code = `function add(a: number, b: number): number {
+  return a + b;
+}
+
+console.log(add(1, 2));`;
+  let language = typescript.name;
+
+  let events = [];
+  let value = "";
+
+  function run() {
+    ({ events, value } = registry.highlight(code, { language }));
+  }
+
+  run();
+
+  $: lines = tokenLines(events);
+
+  let session;
+  let streamedLength = 0;
+  let streamValue = "";
+
+  function resetStream() {
+    session = undefined;
+    streamedLength = 0;
+    streamValue = "";
+  }
+
+  function step() {
+    if (!session) session = registry.createSession(language);
+    const chunk = code.slice(
+      streamedLength,
+      streamedLength + STREAM_CHUNK_SIZE,
+    );
+    if (!chunk) return;
+    session.append(chunk);
+    streamedLength += chunk.length;
+    streamValue = renderHtml(session.events());
+  }
+
+  $: {
+    code;
+    language;
+    resetStream();
+  }
+</script>
+
+<p class="label-01 mb-5">
+  <code class="code">svelte-highlight/engine</code>, headless -- an isolated
+  <code class="code">Registry</code>
+  built with <code class="code">createRegistry</code>
+  and <code class="code">registerAll</code>, with zero Svelte dependency.
+</p>
+
+<div
+  class="mb-5"
+  style="display: flex; flex-direction: column; gap: 1rem; max-width: 40rem"
+>
+  <TextArea labelText="code" bind:value={code} rows={8} />
+  <Select labelText="language" bind:selected={language}>
+    {#each LANGUAGES as lang}
+      <SelectItem value={lang.name} />
+    {/each}
+  </Select>
+  <Button size="small" kind="tertiary" on:click={run}>Highlight</Button>
+</div>
+
+<h3>renderHtml(events)</h3>
+<pre class={THEME_MODULE_NAME}><code class="hljs">{@html value}</code></pre>
+
+<h3>events (first 30)</h3>
+<ul class="label-01 mb-5">
+  {#each events.slice(0, 30) as ev, i}
+    <li>
+      <code class="code">{i}: {EVENT_TYPE_NAME[ev.t]}</code>
+      {#if ev.t === TEXT}
+        <code class="code">v={JSON.stringify(ev.v)}</code>
+      {:else if ev.t === OPEN}
+        <code class="code">s={ev.s}</code>
+      {/if}
+    </li>
+  {/each}
+</ul>
+
+<h3>tokenLines(events)</h3>
+<table class="mb-5">
+  <tbody>
+    {#each lines as line, i}
+      <tr>
+        <td class="label-01" style="vertical-align: top; padding-right: 1rem">
+          {i}
+        </td>
+        <td>
+          {#each line as token}
+            <span
+              title={token.scopes.join(" ")}
+              style="margin-right: 0.5rem; white-space: pre"
+              >{token.text}</span
+            >
+          {/each}
+        </td>
+      </tr>
+    {/each}
+  </tbody>
+</table>
+
+<h3>Streaming: registry.createSession(language)</h3>
+<div
+  class="mb-3"
+  style="display: flex; gap: 1rem; align-items: center; flex-wrap: wrap"
+>
+  <Button size="small" kind="tertiary" on:click={step}
+    >Append next {STREAM_CHUNK_SIZE} chars</Button
+  >
+  <Button size="small" kind="tertiary" on:click={resetStream}>Reset</Button>
+  <p class="label-01">{streamedLength} / {code.length} chars streamed</p>
+</div>
+<pre class={THEME_MODULE_NAME}><code class="hljs">{@html streamValue}</code
+  ></pre>

--- a/www/components/LanguagePreview.svelte
+++ b/www/components/LanguagePreview.svelte
@@ -146,7 +146,7 @@
   import { yarnspinnerPreviewSnippets } from "@www/preview/yarnspinner-preview-snippets";
   import { zigPreviewSnippets } from "@www/preview/zig-preview-snippets";
   import { Column, Row } from "carbon-components-svelte";
-  import { Highlight } from "svelte-highlight";
+  import { CopyButton, Highlight } from "svelte-highlight";
   import agda from "svelte-highlight/languages/agda";
   import angular from "svelte-highlight/languages/angular";
   import assemblyscript from "svelte-highlight/languages/assemblyscript";
@@ -461,12 +461,15 @@
     {#each previewThemes as theme}
       <Column xlg={10} lg={10} md={12} class="mb-5">
         <div class="label-01 mb-3">{theme.name}</div>
-        <Highlight
-          class={theme.moduleName}
-          language={lang}
-          code={snippet.code}
-          langtag
-        />
+        <div style="position: relative">
+          <Highlight
+            class={theme.moduleName}
+            language={lang}
+            code={snippet.code}
+            langtag
+          />
+          <CopyButton code={snippet.code} />
+        </div>
       </Column>
     {/each}
   </Row>

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -212,7 +212,7 @@
 <Content>
   <Grid padding>
     <Row>
-      <Column> <h2>{title}</h2> </Column>
+      <Column> <h1>{title}</h1> </Column>
     </Row>
     <slot />
   </Grid>

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -73,6 +73,7 @@
     "/preview-editable": "Editable highlight preview",
     "/preview-highlight-stream": "HighlightStream preview",
     "/preview-virtual": "HighlightVirtual preview",
+    "/preview-engine": "Headless engine preview",
     "/preview-jq": "jq language preview",
     "/preview-kql": "KQL language preview",
     "/preview-logql": "LogQL language preview",

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -263,7 +263,9 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h2 id="svelte-syntax-highlighting">Svelte Syntax Highlighting</h2> </Column>
+  <Column xlg={12}>
+    <h2 id="svelte-syntax-highlighting">Svelte Syntax Highlighting</h2>
+  </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Use the <code class="code">HighlightSvelte</code> component for Svelte
@@ -934,7 +936,9 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h2 id="language-targeting">Language Targeting</h2> </Column>
+  <Column xlg={12}>
+    <h2 id="language-targeting">Language Targeting</h2>
+  </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       All <code class="code">Highlight</code> components apply a
@@ -1053,7 +1057,9 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h2 id="loading-a-language-by-name">Loading a Language by Name</h2> </Column>
+  <Column xlg={12}>
+    <h2 id="loading-a-language-by-name">Loading a Language by Name</h2>
+  </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Import a language as a static string when you know it ahead of time—the

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -54,7 +54,7 @@
     Row,
     UnorderedList,
   } from "carbon-components-svelte";
-  import Highlight, { HighlightSvelte } from "svelte-highlight";
+  import Highlight, { CopyButton, HighlightSvelte } from "svelte-highlight";
   import css from "svelte-highlight/languages/css";
   import javascript from "svelte-highlight/languages/javascript";
 
@@ -92,6 +92,87 @@ export { add, mul };\`,
 <span class="line" data-line-state="ins"><span class="hljs-keyword">const</span> <span class="hljs-title function_">mul</span> = (<span class="hljs-params">a, b</span>) =&gt; a * b;</span>
 <span class="line" data-line-state="del"><span class="hljs-keyword">const</span> <span class="hljs-title function_">oldSub</span> = (<span class="hljs-params">a, b</span>) =&gt; a - b;</span>
 <span class="line"><span class="hljs-keyword">export</span> { add, mul };</span></code></pre>`;
+
+  const languageNamesSnippet = `<script>
+  import { HighlightAuto } from "svelte-highlight";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const x = 42;";
+<\/script>
+
+<svelte:head>
+  {@html atomOneDark}
+</svelte:head>
+
+<HighlightAuto {code} languageNames={["javascript", "typescript"]} />`;
+
+  const actionSnippet = `<script>
+  import { highlight } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const code = "const add = (a, b) => a + b;";
+<\/script>
+
+<svelte:head>
+  {@html github}
+<\/svelte:head>
+
+<pre><code use:highlight={{ language: typescript, code }}><\/code><\/pre>`;
+
+  const langtagBasicSnippet = `<script>
+  import { HighlightAuto } from "svelte-highlight";
+
+  $: code = \`body {\n  padding: 0;\n  color: red;\n}\`;
+<\/script>
+
+<HighlightAuto {code} langtag \/>`;
+
+  const langtagStylePropsSnippet = `<HighlightAuto
+  {code}
+  langtag
+  --langtag-top="0.5rem"
+  --langtag-right="0.5rem"
+  --langtag-background="linear-gradient(135deg, #2996cf, 80%, white)"
+  --langtag-color="#fff"
+  --langtag-border-radius="6px"
+  --langtag-padding="0.5rem"
+  --langtag-font-size="0.75em"
+/>`;
+
+  const loadLanguageSnippet = `<script>
+  import { Highlight, loadLanguage } from "svelte-highlight";
+  import github from "svelte-highlight/styles/github";
+
+  // The language name is not known until runtime.
+  export let language = "typescript";
+  export let code = "const add = (a, b) => a + b;";
+<\/script>
+
+<svelte:head>
+  {@html github}
+<\/svelte:head>
+
+{#await loadLanguage(language) then grammar}
+  <Highlight {code} language={grammar} \/>
+{:catch}
+  <pre>{code}<\/pre>
+{/await}`;
+
+  const staticModeHtmlSourceSnippet = `<script>
+  import Highlight from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+<\/script>
+
+<Highlight language={javascript} code="const x = 1;" />`;
+
+  const staticModeHtmlOutputSnippet = `<pre class="hljs" data-language="javascript"><code class="hljs"
+  ><span class="hljs-keyword">const</span> x = <span class="hljs-number">1</span>;</code
+></pre>`;
+
+  const langtagDemoSourceSnippet = `<Highlight language={javascript} code="const x = 1;" langtag />`;
+
+  const langtagDemoOutputSnippet = `<pre class="hljs" data-language="javascript" style="position:relative;overflow-x:var(--overflow-x, auto);overflow-y:var(--overflow-y, auto);border-radius:var(--border-radius, 0);width:var(--width, auto);max-width:var(--max-width, none)"><code class="hljs"><span class="hljs-keyword">const</span> x = <span class="hljs-number">1</span>;</code><span style="position:absolute;top:var(--langtag-top, 0);right:var(--langtag-right, 0);display:flex;align-items:center;justify-content:center;background:var(--langtag-background, inherit);color:var(--langtag-color, inherit);border-radius:var(--langtag-border-radius, 0);padding:var(--langtag-padding, 1em);font-size:var(--langtag-font-size, inherit);">javascript</span></pre>`;
 </script>
 
 <Row>
@@ -174,7 +255,10 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <HighlightSvelte code={svelteHeadCdn} class={THEME_MODULE_NAME} />
+    <div style="position: relative">
+      <HighlightSvelte code={svelteHeadCdn} class={THEME_MODULE_NAME} />
+      <CopyButton code={svelteHeadCdn} />
+    </div>
     <InlineNotification
       lowContrast
       hideCloseButton
@@ -304,21 +388,10 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <HighlightSvelte
-      code={`<script>
-  import { HighlightAuto } from "svelte-highlight";
-  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
-
-  const code = "const x = 42;";
-<\/script>
-
-<svelte:head>
-  {@html atomOneDark}
-</svelte:head>
-
-<HighlightAuto {code} languageNames={["javascript", "typescript"]} />`}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <HighlightSvelte code={languageNamesSnippet} class={THEME_MODULE_NAME} />
+      <CopyButton code={languageNamesSnippet} />
+    </div>
   </Column>
 </Row>
 
@@ -345,22 +418,10 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <HighlightSvelte
-      code={`<script>
-  import { highlight } from "svelte-highlight";
-  import typescript from "svelte-highlight/languages/typescript";
-  import github from "svelte-highlight/styles/github";
-
-  const code = "const add = (a, b) => a + b;";
-<\/script>
-
-<svelte:head>
-  {@html github}
-<\/svelte:head>
-
-<pre><code use:highlight={{ language: typescript, code }}><\/code><\/pre>`}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <HighlightSvelte code={actionSnippet} class={THEME_MODULE_NAME} />
+      <CopyButton code={actionSnippet} />
+    </div>
     <HighlightAction />
   </Column>
 </Row>
@@ -953,11 +1014,16 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <Highlight
-      code={'[data-language="css"] {\n  /* custom style rules */\n}'}
-      language={css}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <Highlight
+        code={'[data-language="css"] {\n  /* custom style rules */\n}'}
+        language={css}
+        class={THEME_MODULE_NAME}
+      />
+      <CopyButton
+        code={'[data-language="css"] {\n  /* custom style rules */\n}'}
+      />
+    </div>
   </Column>
 </Row>
 
@@ -992,40 +1058,30 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <HighlightSvelte
-      code={`<script>
-  import { HighlightAuto } from "svelte-highlight";
-
-  $: code = \`body {\n  padding: 0;\n  color: red;\n}\`;
-<\/script>
-
-<HighlightAuto {code} langtag \/>`}
-      class={THEME_MODULE_NAME}
-      langtag
-    />
+    <div style="position: relative">
+      <HighlightSvelte
+        code={langtagBasicSnippet}
+        class={THEME_MODULE_NAME}
+        langtag
+      />
+      <CopyButton code={langtagBasicSnippet} />
+    </div>
     <br>
-    <HighlightSvelte
-      code={`<HighlightAuto
-  {code}
-  langtag
-  --langtag-top="0.5rem"
-  --langtag-right="0.5rem"
-  --langtag-background="linear-gradient(135deg, #2996cf, 80%, white)"
-  --langtag-color="#fff"
-  --langtag-border-radius="6px"
-  --langtag-padding="0.5rem"
-  --langtag-font-size="0.75em"
-/>`}
-      class={THEME_MODULE_NAME}
-      langtag
-      --langtag-top="0.5rem"
-      --langtag-right="0.5rem"
-      --langtag-background="linear-gradient(135deg, #2996cf, 80%, white)"
-      --langtag-color="#fff"
-      --langtag-border-radius="6px"
-      --langtag-padding="0.5rem"
-      --langtag-font-size="0.75em"
-    />
+    <div style="position: relative">
+      <HighlightSvelte
+        code={langtagStylePropsSnippet}
+        class={THEME_MODULE_NAME}
+        langtag
+        --langtag-top="0.5rem"
+        --langtag-right="0.5rem"
+        --langtag-background="linear-gradient(135deg, #2996cf, 80%, white)"
+        --langtag-color="#fff"
+        --langtag-border-radius="6px"
+        --langtag-padding="0.5rem"
+        --langtag-font-size="0.75em"
+      />
+      <CopyButton code={langtagStylePropsSnippet} />
+    </div>
   </Column>
 </Row>
 
@@ -1082,27 +1138,10 @@ export { add, mul };\`,
     />
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <HighlightSvelte
-      code={`<script>
-  import { Highlight, loadLanguage } from "svelte-highlight";
-  import github from "svelte-highlight/styles/github";
-
-  // The language name is not known until runtime.
-  export let language = "typescript";
-  export let code = "const add = (a, b) => a + b;";
-<\/script>
-
-<svelte:head>
-  {@html github}
-<\/svelte:head>
-
-{#await loadLanguage(language) then grammar}
-  <Highlight {code} language={grammar} \/>
-{:catch}
-  <pre>{code}<\/pre>
-{/await}`}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <HighlightSvelte code={loadLanguageSnippet} class={THEME_MODULE_NAME} />
+      <CopyButton code={loadLanguageSnippet} />
+    </div>
   </Column>
 </Row>
 
@@ -1124,11 +1163,14 @@ export { add, mul };\`,
     <p class="mb-5">Wire it into your Vite/Svelte preprocess config:</p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <Highlight
-      code={viteConfigSnippet}
-      language={javascript}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <Highlight
+        code={viteConfigSnippet}
+        language={javascript}
+        class={THEME_MODULE_NAME}
+      />
+      <CopyButton code={viteConfigSnippet} />
+    </div>
   </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
@@ -1138,15 +1180,13 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <HighlightSvelte
-      code={`<script>
-  import Highlight from "svelte-highlight";
-  import javascript from "svelte-highlight/languages/javascript";
-<\/script>
-
-<Highlight language={javascript} code="const x = 1;" />`}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <HighlightSvelte
+        code={staticModeHtmlSourceSnippet}
+        class={THEME_MODULE_NAME}
+      />
+      <CopyButton code={staticModeHtmlSourceSnippet} />
+    </div>
   </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
@@ -1155,12 +1195,13 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <HighlightSvelte
-      code={`<pre class="hljs" data-language="javascript"><code class="hljs"
-  ><span class="hljs-keyword">const</span> x = <span class="hljs-number">1</span>;</code
-></pre>`}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <HighlightSvelte
+        code={staticModeHtmlOutputSnippet}
+        class={THEME_MODULE_NAME}
+      />
+      <CopyButton code={staticModeHtmlOutputSnippet} />
+    </div>
   </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
@@ -1200,15 +1241,21 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <Highlight
-      code={`<Highlight language={javascript} code="const x = 1;" langtag />`}
-      language={javascript}
-      class={THEME_MODULE_NAME}
-    />
-    <HighlightSvelte
-      code={`<pre class="hljs" data-language="javascript" style="position:relative;overflow-x:var(--overflow-x, auto);overflow-y:var(--overflow-y, auto);border-radius:var(--border-radius, 0);width:var(--width, auto);max-width:var(--max-width, none)"><code class="hljs"><span class="hljs-keyword">const</span> x = <span class="hljs-number">1</span>;</code><span style="position:absolute;top:var(--langtag-top, 0);right:var(--langtag-right, 0);display:flex;align-items:center;justify-content:center;background:var(--langtag-background, inherit);color:var(--langtag-color, inherit);border-radius:var(--langtag-border-radius, 0);padding:var(--langtag-padding, 1em);font-size:var(--langtag-font-size, inherit);">javascript</span></pre>`}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <Highlight
+        code={langtagDemoSourceSnippet}
+        language={javascript}
+        class={THEME_MODULE_NAME}
+      />
+      <CopyButton code={langtagDemoSourceSnippet} />
+    </div>
+    <div style="position: relative">
+      <HighlightSvelte
+        code={langtagDemoOutputSnippet}
+        class={THEME_MODULE_NAME}
+      />
+      <CopyButton code={langtagDemoOutputSnippet} />
+    </div>
   </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
@@ -1226,11 +1273,14 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <Highlight
-      code={highlightStaticOnWarnSnippet}
-      language={javascript}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <Highlight
+        code={highlightStaticOnWarnSnippet}
+        language={javascript}
+        class={THEME_MODULE_NAME}
+      />
+      <CopyButton code={highlightStaticOnWarnSnippet} />
+    </div>
     <InlineNotification
       lowContrast
       hideCloseButton
@@ -1257,11 +1307,14 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <Highlight
-      code={highlightFenceCallSnippet}
-      language={javascript}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <Highlight
+        code={highlightFenceCallSnippet}
+        language={javascript}
+        class={THEME_MODULE_NAME}
+      />
+      <CopyButton code={highlightFenceCallSnippet} />
+    </div>
   </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
@@ -1274,10 +1327,13 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}>
-    <HighlightSvelte
-      code={highlightFenceOutputSnippet}
-      class={THEME_MODULE_NAME}
-    />
+    <div style="position: relative">
+      <HighlightSvelte
+        code={highlightFenceOutputSnippet}
+        class={THEME_MODULE_NAME}
+      />
+      <CopyButton code={highlightFenceOutputSnippet} />
+    </div>
   </Column>
 </Row>
 

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -123,7 +123,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Usage</h3> </Column>
+  <Column xlg={12}> <h2 id="usage">Usage</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">The default Highlight component requires two props:</p>
     <UnorderedList class="mb-5">
@@ -198,7 +198,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Scoping styles</h3> </Column>
+  <Column xlg={12}> <h2 id="scoping-styles">Scoping styles</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Themes target global <code class="code">.hljs</code> selectors, so the
@@ -216,7 +216,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Dark mode</h3> </Column>
+  <Column xlg={12}> <h2 id="dark-mode">Dark mode</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       <code class="code">HighlightStyle</code>
@@ -263,7 +263,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Svelte Syntax Highlighting</h3> </Column>
+  <Column xlg={12}> <h2 id="svelte-syntax-highlighting">Svelte Syntax Highlighting</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Use the <code class="code">HighlightSvelte</code> component for Svelte
@@ -276,7 +276,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Auto-highlighting</h3> </Column>
+  <Column xlg={12}> <h2 id="auto-highlighting">Auto-highlighting</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       The <code class="code">HighlightAuto</code> component invokes the
@@ -321,7 +321,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Action</h3> </Column>
+  <Column xlg={12}> <h2 id="action">Action</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Use the <code class="code">highlight</code> action to highlight existing
@@ -364,7 +364,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Line Numbers</h3> </Column>
+  <Column xlg={12}> <h2 id="line-numbers">Line Numbers</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Use the <code class="code">LineNumbers</code> component to render the
@@ -483,7 +483,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Copy Button</h3> </Column>
+  <Column xlg={12}> <h2 id="copy-button">Copy Button</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Compose the <code class="code">CopyButton</code> component alongside
@@ -541,7 +541,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Code Window</h3> </Column>
+  <Column xlg={12}> <h2 id="code-window">Code Window</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Wrap a code block in the <code class="code">CodeWindow</code> component to
@@ -568,7 +568,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Animation</h3> </Column>
+  <Column xlg={12}> <h2 id="animation">Animation</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Use <code class="code">Typewriter</code> inside
@@ -625,7 +625,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Streaming</h3> </Column>
+  <Column xlg={12}> <h2 id="streaming">Streaming</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Rendering LLM chat output is the dominant new syntax-highlighting use
@@ -713,7 +713,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Large Documents</h3> </Column>
+  <Column xlg={12}> <h2 id="large-documents">Large Documents</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       <code class="code">HighlightVirtual</code>
@@ -784,7 +784,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Terminal Output</h3> </Column>
+  <Column xlg={12}> <h2 id="terminal-output">Terminal Output</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       <code class="code">AnsiOutput</code>
@@ -807,7 +807,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Editable</h3> </Column>
+  <Column xlg={12}> <h2 id="editable">Editable</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       <code class="code">HighlightEditable</code>
@@ -908,7 +908,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>File Tabs</h3> </Column>
+  <Column xlg={12}> <h2 id="file-tabs">File Tabs</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       <code class="code">FileTabs</code>
@@ -934,7 +934,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Language Targeting</h3> </Column>
+  <Column xlg={12}> <h2 id="language-targeting">Language Targeting</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       All <code class="code">Highlight</code> components apply a
@@ -958,7 +958,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Language Tags</h3> </Column>
+  <Column xlg={12}> <h2 id="language-tags">Language Tags</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       All <code class="code">Highlight</code> components allow for a tag to be
@@ -1026,7 +1026,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Custom Language</h3> </Column>
+  <Column xlg={12}> <h2 id="custom-language">Custom Language</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       <code class="code">fromHighlightJs</code>
@@ -1053,7 +1053,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Loading a Language by Name</h3> </Column>
+  <Column xlg={12}> <h2 id="loading-a-language-by-name">Loading a Language by Name</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Import a language as a static string when you know it ahead of time—the
@@ -1101,7 +1101,7 @@ export { add, mul };\`,
 </Row>
 
 <Row class="mb-9">
-  <Column xlg={12}> <h3>Static Mode</h3> </Column>
+  <Column xlg={12}> <h2 id="static-mode">Static Mode</h2> </Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       <code class="code">svelte-highlight/static</code>
@@ -1276,7 +1276,7 @@ export { add, mul };\`,
 </Row>
 
 <Row>
-  <Column xlg={12}><h3>Examples</h3></Column>
+  <Column xlg={12}><h2 id="examples">Examples</h2></Column>
   <Column xlg={6} lg={6} md={12}>
     <p class="mb-5">
       Get started with{" "}

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -1337,6 +1337,25 @@ export { add, mul };\`,
   </Column>
 </Row>
 
+<Row class="mb-9">
+  <Column xlg={12}> <h2 id="headless-usage">Headless usage</h2> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">svelte-highlight/engine</code>
+      exposes the same scope-event stream every
+      <code class="code">Highlight</code>-family component renders from --
+      <code class="code">createRegistry</code>,
+      <code class="code">registerAll</code>,
+      <code class="code">renderHtml</code>,
+      <code class="code">tokenLines</code>, and streaming
+      <code class="code">StreamSession</code>s -- with zero Svelte dependency,
+      so it works in any JS runtime: server routes, build pipelines, tests, or a
+      plain script tag.
+    </p>
+    <Link size="lg" href="/preview-engine">Try the headless engine</Link>
+  </Column>
+</Row>
+
 <Row>
   <Column xlg={12}><h2 id="examples">Examples</h2></Column>
   <Column xlg={6} lg={6} md={12}>

--- a/www/components/globals/Languages.svelte
+++ b/www/components/globals/Languages.svelte
@@ -5,6 +5,7 @@
   import languages from "@www/data/languages.json";
   import {
     Column,
+    Link,
     Row,
     StructuredList,
     StructuredListBody,
@@ -13,6 +14,11 @@
     StructuredListRow,
   } from "carbon-components-svelte";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const previewPages = import.meta.glob("../../pages/preview-*.astro");
+  const previewSlugs = new Set(
+    Object.keys(previewPages).map((p) => p.match(/preview-(.+)\.astro$/)[1]),
+  );
 </script>
 
 <svelte:head> {@html atomOneDark} </svelte:head>
@@ -51,6 +57,10 @@
                   <div class="label-01 mb-3">Module name</div>
                   <CodeSnippet type="inline" code={language.moduleName} />
                 </div>
+
+                {#if previewSlugs.has(language.name)}
+                  <Link href="/preview-{language.name}">Preview</Link>
+                {/if}
               </StructuredListCell>
               <StructuredListCell>
                 <ScopedLanguage

--- a/www/components/globals/Languages.svelte
+++ b/www/components/globals/Languages.svelte
@@ -15,9 +15,11 @@
   } from "carbon-components-svelte";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
 
+  const PREVIEW_PAGE_NAME = /preview-(.+)\.astro$/;
+
   const previewPages = import.meta.glob("../../pages/preview-*.astro");
   const previewSlugs = new Set(
-    Object.keys(previewPages).map((p) => p.match(/preview-(.+)\.astro$/)[1]),
+    Object.keys(previewPages).map((p) => p.match(PREVIEW_PAGE_NAME)[1]),
   );
 </script>
 

--- a/www/layouts/Layout.astro
+++ b/www/layouts/Layout.astro
@@ -6,9 +6,13 @@ import "@www/data/scoped-styles.css";
 
 interface Props {
   title: string;
+  description?: string;
 }
 
-const { title } = Astro.props;
+const {
+  title,
+  description = `${title} — svelte-highlight, a zero-runtime-dependency Svelte syntax-highlighting library.`,
+} = Astro.props;
 ---
 
 <!doctype html>
@@ -18,10 +22,11 @@ const { title } = Astro.props;
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <link rel="icon" type="image/svg+xml" href="/favicon.svg">
-    <meta
-      name="description"
-      content="Syntax Highlighting for Svelte using highlight.js"
-    >
+    <meta name="description" content={description}>
+    <meta property="og:title" content={title}>
+    <meta property="og:description" content={description}>
+    <meta property="og:type" content="website">
+    <meta name="twitter:card" content="summary">
     <title>{title}</title>
     <style is:global>
       body {

--- a/www/pages/index.astro
+++ b/www/pages/index.astro
@@ -3,4 +3,9 @@ import IndexLayout from "@components/globals/Index.svelte";
 import Layout from "@layouts/Layout.astro";
 ---
 
-<Layout title="Svelte Highlight"> <IndexLayout client:idle /> </Layout>
+<Layout
+  title="Svelte Highlight"
+  description="Syntax highlighting for Svelte using highlight.js, plus a zero-runtime-dependency headless engine. 342 languages, no bundled highlight.js at runtime."
+>
+  <IndexLayout client:idle />
+</Layout>

--- a/www/pages/languages.astro
+++ b/www/pages/languages.astro
@@ -3,4 +3,9 @@ import LanguagesLayout from "@components/globals/Languages.svelte";
 import Layout from "@layouts/Layout.astro";
 ---
 
-<Layout title="Languages"> <LanguagesLayout client:idle /> </Layout>
+<Layout
+  title="Languages"
+  description="Browse all 342 languages supported by svelte-highlight, with per-language import syntax and preview pages."
+>
+  <LanguagesLayout client:idle />
+</Layout>

--- a/www/pages/preview-engine.astro
+++ b/www/pages/preview-engine.astro
@@ -1,0 +1,8 @@
+---
+import EnginePreview from "@components/EnginePreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="Headless engine preview">
+  <EnginePreview client:idle />
+</Layout>

--- a/www/pages/preview-engine.astro
+++ b/www/pages/preview-engine.astro
@@ -3,6 +3,9 @@ import EnginePreview from "@components/EnginePreview.svelte";
 import Layout from "@layouts/Layout.astro";
 ---
 
-<Layout title="Headless engine preview">
+<Layout
+  title="Headless engine preview"
+  description="Try svelte-highlight/engine live: createRegistry, registerAll, renderHtml, tokenLines, and streaming StreamSessions, with zero Svelte dependency."
+>
   <EnginePreview client:idle />
 </Layout>

--- a/www/pages/styles.astro
+++ b/www/pages/styles.astro
@@ -3,4 +3,9 @@ import StylesLayout from "@components/globals/Styles.svelte";
 import Layout from "@layouts/Layout.astro";
 ---
 
-<Layout title="Styles"> <StylesLayout client:idle /> </Layout>
+<Layout
+  title="Styles"
+  description="Browse all 348 highlight.js themes supported by svelte-highlight, rendered live against sample code."
+>
+  <StylesLayout client:idle />
+</Layout>

--- a/www/public/llms.txt
+++ b/www/public/llms.txt
@@ -1,0 +1,22 @@
+# svelte-highlight
+
+> Svelte components for syntax highlighting, backed by a zero-runtime-dependency
+> headless highlighting engine. 342 languages ship as build-time-converted JSON
+> IR (`src/languages/*.js`); no `highlight.js`, TextMate grammar, or tree-sitter
+> parser is bundled or imported at runtime.
+
+Because the engine converts highlight.js grammars into its own IR at build
+time and then walks that IR itself, it's easy for a coding agent to conflate
+this package with runtime engines like Shiki or Prism, or to assume
+`highlight.js` is a runtime dependency. The sections below are the ones most
+likely to be misread — read them before proposing a fix or feature that
+touches highlighting, streaming, or bundle size.
+
+- [Headless usage](https://github.com/metonym/svelte-highlight/blob/master/README.md#headless-usage)
+- [Custom Language](https://github.com/metonym/svelte-highlight/blob/master/README.md#custom-language)
+- [Streaming](https://github.com/metonym/svelte-highlight/blob/master/README.md#streaming)
+- [Static mode](https://github.com/metonym/svelte-highlight/blob/master/README.md#static-mode)
+- [Styling with CSS variables](https://github.com/metonym/svelte-highlight/blob/master/README.md#styling-with-css-variables)
+- [Component API](https://github.com/metonym/svelte-highlight/blob/master/README.md#component-api)
+- [Supported Languages](https://github.com/metonym/svelte-highlight/blob/master/SUPPORTED_LANGUAGES.md)
+- [Supported Styles](https://github.com/metonym/svelte-highlight/blob/master/SUPPORTED_STYLES.md)

--- a/www/public/robots.txt
+++ b/www/public/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Allow: /
+
+Sitemap: https://svhe.onrender.com/sitemap-index.xml


### PR DESCRIPTION
Bundles the docs-site backlog: a CSS-variable reference for
CopyButton/CodeWindow, a README table of contents, real heading
hierarchy and an in-page nav on the homepage, the 143 language
preview pages linked from /languages, CopyButton on every code demo,
a live headless-engine playground, a sitemap/robots.txt, per-page
OpenGraph/Twitter meta, and llms.txt.