### PR TITLE
fix(components): give CodeWindow's truncated title a native tooltip

### DIFF
--- a/README.md
+++ b/README.md
@@ -1598,6 +1598,8 @@ added 1 package in 1.2s`;
 
 ### Theming the chrome
 
+The title bar is a three-column flex row (leading chrome, title, a mirrored trailing spacer), so the title stays centered in the space actually left over without overlapping the dots or prompt even at narrow widths -- this doesn't apply to `plain`, which has no leading chrome to mirror.
+
 Every part of the chrome is driven by CSS variables (see [`CodeWindow` variables](#codewindow-variables)). Pass them as style props to restyle the window without `:global` overrides. For example, give the default square window rounded corners with `--window-radius`:
 
 ```svelte

--- a/README.md
+++ b/README.md
@@ -1675,6 +1675,34 @@ Or layer a `CopyButton` over it by wrapping both in a relatively-positioned cont
 </div>
 ```
 
+Put a `FileTabs` strip in the `titlebar` slot to switch between files without leaving the title bar:
+
+```svelte
+<script>
+  import Highlight, { CodeWindow, FileTabs } from "svelte-highlight";
+  import javascript from "svelte-highlight/languages/javascript";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const sources = {
+    "App.svelte": { language: typescript, code: "const answer = 42;" },
+    "index.js": { language: javascript, code: "export default answer;" },
+  };
+
+  const files = Object.keys(sources);
+  let active = files[0];
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<CodeWindow variant="macos">
+  <FileTabs {files} bind:active slot="titlebar" />
+  <Highlight language={sources[active].language} code={sources[active].code} />
+</CodeWindow>
+```
+
 ## Animation
 
 Use `Typewriter` inside `Highlight`'s default slot with the `highlighted` prop. It prints the code one character at a time, syntax highlighting included. A blinking caret marks the end of the typed text and hides when typing stops.
@@ -2314,6 +2342,10 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 | title   | `string`                           | `""`          |
 
 `$$restProps` are forwarded to the top-level `div` element.
+
+#### Slots
+
+- **titlebar**: optional content rendered in the mirrored trailing region of the title bar (empty by default, which keeps the title centered)
 
 #### CSS Variables
 

--- a/README.md
+++ b/README.md
@@ -1552,7 +1552,7 @@ The action dispatches `highlighted` (`detail: { html, language }`) on success an
 
 Wrap a code block in `CodeWindow` to frame it with window chrome. It's purely cosmetic; the default slot renders your content unchanged.
 
-Use the `variant` prop to choose the chrome style: `"macos"` (default) renders traffic-light dots, `"terminal"` renders a prompt, and `"plain"` renders just the title bar. The optional `title` is shown in the title bar.
+Use the `variant` prop to choose the chrome style: `"macos"` (default) renders traffic-light dots, `"terminal"` renders a prompt, and `"plain"` renders just the title bar. The optional `title` is shown in the title bar, and is also exposed as a native tooltip via the HTML `title` attribute so a truncated title is readable on hover or focus.
 
 ```svelte
 <script>

--- a/src/CodeWindow.svelte
+++ b/src/CodeWindow.svelte
@@ -27,7 +27,11 @@
     {/if}
 
     {#if variant !== "plain"}
-      <span class="titlebar-end"></span>
+      <!-- titlebar content wider than the leading chrome will unbalance the
+           centering above -- an accepted trade-off, not a bug. -->
+      <span class="titlebar-end"><slot name="titlebar" /></span>
+    {:else}
+      <slot name="titlebar" />
     {/if}
   </div>
 

--- a/src/CodeWindow.svelte
+++ b/src/CodeWindow.svelte
@@ -9,17 +9,25 @@
 <div class="code-window {variant}" {...$$restProps}>
   <div class="titlebar">
     {#if variant === "macos"}
-      <span class="dots" aria-hidden="true">
-        <span class="dot close"></span>
-        <span class="dot minimize"></span>
-        <span class="dot maximize"></span>
+      <span class="titlebar-lead">
+        <span class="dots" aria-hidden="true">
+          <span class="dot close"></span>
+          <span class="dot minimize"></span>
+          <span class="dot maximize"></span>
+        </span>
       </span>
     {:else if variant === "terminal"}
-      <span class="prompt" aria-hidden="true">&gt;_</span>
+      <span class="titlebar-lead">
+        <span class="prompt" aria-hidden="true">&gt;_</span>
+      </span>
     {/if}
 
     {#if title}
       <span class="title" {title}>{title}</span>
+    {/if}
+
+    {#if variant !== "plain"}
+      <span class="titlebar-end"></span>
     {/if}
   </div>
 
@@ -84,12 +92,24 @@
     color: var(--prompt-color, inherit);
   }
 
+  .titlebar-lead,
+  .titlebar-end {
+    display: flex;
+    align-items: center;
+    flex: 1 1 0;
+    min-width: 0;
+  }
+
+  .titlebar-end {
+    justify-content: flex-end;
+  }
+
   .title {
-    /* Center title across titlebar, ignoring dots/prompt. */
-    position: absolute;
-    left: 50%;
-    transform: translateX(-50%);
-    max-width: 70%;
+    /* Sandwiched between equal-width .titlebar-lead/.titlebar-end, so it
+       centers in the space actually left over instead of the full bar. */
+    flex: 1 1 0;
+    min-width: 0;
+    text-align: center;
     overflow: hidden;
     white-space: nowrap;
     text-overflow: ellipsis;

--- a/src/CodeWindow.svelte
+++ b/src/CodeWindow.svelte
@@ -19,7 +19,7 @@
     {/if}
 
     {#if title}
-      <span class="title">{title}</span>
+      <span class="title" {title}>{title}</span>
     {/if}
   </div>
 

--- a/src/CodeWindow.svelte.d.ts
+++ b/src/CodeWindow.svelte.d.ts
@@ -9,7 +9,8 @@ export type CodeWindowProps = HTMLAttributes<HTMLDivElement> & {
   variant?: "macos" | "terminal" | "plain";
 
   /**
-   * Title bar text.
+   * Title bar text. Also becomes the title bar's native HTML `title`
+   * attribute, so a truncated title is readable as a hover/focus tooltip.
    * @default ""
    */
   title?: string;

--- a/src/CodeWindow.svelte.d.ts
+++ b/src/CodeWindow.svelte.d.ts
@@ -128,6 +128,11 @@ export type CodeWindowEvents = {};
 
 export type CodeWindowSlots = {
   default: {};
+
+  /**
+   * Optional content rendered in the mirrored trailing region of the title bar.
+   */
+  titlebar: {};
 };
 
 export default class CodeWindow extends SvelteComponentTyped<

--- a/tests/e2e/CodeWindow.test.svelte
+++ b/tests/e2e/CodeWindow.test.svelte
@@ -19,3 +19,23 @@
 <CodeWindow variant="plain" title="plain.ts" data-testid="plain">
   <Highlight language={typescript} {code} />
 </CodeWindow>
+
+<div style="width: 160px">
+  <CodeWindow
+    variant="macos"
+    title="a-very-long-file-name-that-overflows.ts"
+    data-testid="narrow-macos"
+  >
+    <Highlight language={typescript} {code} />
+  </CodeWindow>
+</div>
+
+<div style="width: 160px">
+  <CodeWindow
+    variant="terminal"
+    title="a-very-long-file-name-that-overflows.ts"
+    data-testid="narrow-terminal"
+  >
+    <Highlight language={typescript} {code} />
+  </CodeWindow>
+</div>

--- a/tests/e2e/CodeWindow.test.svelte
+++ b/tests/e2e/CodeWindow.test.svelte
@@ -39,3 +39,8 @@
     <Highlight language={typescript} {code} />
   </CodeWindow>
 </div>
+
+<CodeWindow variant="macos" title="example.ts" data-testid="with-toolbar">
+  <Highlight language={typescript} {code} />
+  <span slot="titlebar" data-testid="toolbar-slot">tools</span>
+</CodeWindow>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -207,6 +207,21 @@ test("CodeWindow - renders each variant wrapping a Highlight", async ({
   await expect(plain.locator(".prompt")).toHaveCount(0);
 });
 
+test("CodeWindow - truncated title carries a native tooltip", async ({
+  mount,
+  page,
+}) => {
+  await mount(CodeWindow);
+
+  const macos = page.getByTestId("macos");
+  const terminal = page.getByTestId("terminal");
+  const plain = page.getByTestId("plain");
+
+  await expect(macos.locator(".title")).toHaveAttribute("title", "example.ts");
+  await expect(terminal.locator(".title")).toHaveAttribute("title", "bash");
+  await expect(plain.locator(".title")).toHaveAttribute("title", "plain.ts");
+});
+
 test("AnsiOutput - renders styled spans inside a terminal window", async ({
   mount,
   page,

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -222,6 +222,38 @@ test("CodeWindow - truncated title carries a native tooltip", async ({
   await expect(plain.locator(".title")).toHaveAttribute("title", "plain.ts");
 });
 
+test("CodeWindow - long title never overlaps the leading chrome at narrow widths", async ({
+  mount,
+  page,
+}) => {
+  await mount(CodeWindow);
+
+  const narrowMacos = page.getByTestId("narrow-macos");
+  const narrowTerminal = page.getByTestId("narrow-terminal");
+
+  const pairs = [
+    [narrowMacos, ".dots"],
+    [narrowTerminal, ".prompt"],
+  ] as const;
+
+  const boxes = await Promise.all(
+    pairs.map(([window, leadSelector]) =>
+      Promise.all([
+        window.locator(leadSelector).boundingBox(),
+        window.locator(".title").boundingBox(),
+      ]),
+    ),
+  );
+
+  for (const [leadBox, titleBox] of boxes) {
+    if (!leadBox || !titleBox) {
+      throw new Error("expected bounding boxes for lead chrome and title");
+    }
+
+    expect(titleBox.x).toBeGreaterThanOrEqual(leadBox.x + leadBox.width);
+  }
+});
+
 test("AnsiOutput - renders styled spans inside a terminal window", async ({
   mount,
   page,

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -254,6 +254,30 @@ test("CodeWindow - long title never overlaps the leading chrome at narrow widths
   }
 });
 
+test("CodeWindow - titlebar slot renders custom content in the title bar", async ({
+  mount,
+  page,
+}) => {
+  await mount(CodeWindow);
+
+  const withToolbar = page.getByTestId("with-toolbar");
+  const toolbarSlot = withToolbar.getByTestId("toolbar-slot");
+
+  await expect(toolbarSlot).toBeVisible();
+
+  const titlebarBox = await withToolbar.locator(".titlebar").boundingBox();
+  const toolbarBox = await toolbarSlot.boundingBox();
+
+  if (!titlebarBox || !toolbarBox) {
+    throw new Error("expected bounding boxes for titlebar and slot content");
+  }
+
+  expect(toolbarBox.y).toBeGreaterThanOrEqual(titlebarBox.y);
+  expect(toolbarBox.y + toolbarBox.height).toBeLessThanOrEqual(
+    titlebarBox.y + titlebarBox.height,
+  );
+});
+
 test("AnsiOutput - renders styled spans inside a terminal window", async ({
   mount,
   page,

--- a/www/components/CodeWindowPreview.svelte
+++ b/www/components/CodeWindowPreview.svelte
@@ -100,6 +100,19 @@ $ npm run build`;
 {/each}
 
 <p class="mb-5">
+  The title bar is a three-column flex row, so a long title stays centered
+  without overlapping the traffic-light dots even in a narrow window:
+</p>
+
+<div class="mb-5" style="max-width: 220px">
+  <HighlightStyle theme={atomOneDark}>
+    <CodeWindow variant="macos" title="a-very-long-component-name.svelte">
+      <Highlight language={typescript} code={tsCode} />
+    </CodeWindow>
+  </HighlightStyle>
+</div>
+
+<p class="mb-5">
   Every part of the chrome is themable with style props. The window is square by
   default; give it rounded corners with
   <code class="code">--window-radius</code>

--- a/www/components/CodeWindowPreview.svelte
+++ b/www/components/CodeWindowPreview.svelte
@@ -2,10 +2,12 @@
   import { THEME_MODULE_NAME } from "@www/constants";
   import Highlight, {
     CodeWindow,
+    FileTabs,
     HighlightStyle,
     HighlightSvelte,
   } from "svelte-highlight";
   import bash from "svelte-highlight/languages/bash";
+  import javascript from "svelte-highlight/languages/javascript";
   import json from "svelte-highlight/languages/json";
   import typescript from "svelte-highlight/languages/typescript";
   import atomOneDark from "svelte-highlight/styles/atom-one-dark";
@@ -24,6 +26,17 @@ added 1 package in 1.2s
 $ npm run build`;
 
   const tsCode = "const add = (a: number, b: number) => a + b;";
+
+  const titlebarSources = {
+    "App.svelte": { language: typescript, code: tsCode },
+    "index.js": {
+      language: javascript,
+      code: "export default add;",
+    },
+  };
+
+  const titlebarFiles = Object.keys(titlebarSources);
+  let titlebarActive = titlebarFiles[0];
 
   const snippet = `<script>
   import Highlight, { CodeWindow } from "svelte-highlight";
@@ -135,3 +148,25 @@ $ npm run build`;
     <Highlight language={typescript} code={tsCode} />
   </CodeWindow>
 </HighlightStyle>
+
+<p class="mb-5 mt-5">
+  Fill the <code class="code">titlebar</code> slot to add custom toolbar
+  content, like a <code class="code">FileTabs</code> strip, to the mirrored
+  trailing region of the title bar:
+</p>
+
+<div class="mb-5">
+  <HighlightStyle theme={atomOneDark}>
+    <CodeWindow variant="macos">
+      <FileTabs
+        files={titlebarFiles}
+        bind:active={titlebarActive}
+        slot="titlebar"
+      />
+      <Highlight
+        language={titlebarSources[titlebarActive].language}
+        code={titlebarSources[titlebarActive].code}
+      />
+    </CodeWindow>
+  </HighlightStyle>
+</div>


### PR DESCRIPTION
CodeWindow's title now carries a native `title` attribute (so a
truncated one is readable via tooltip), the title bar is a
three-column flex row so long titles never overlap the dots/prompt
chrome at narrow widths, and a new `titlebar` slot lets you drop
custom toolbar content (like a `FileTabs` strip) into the mirrored
trailing region.

```svelte
<CodeWindow variant="macos">
  <FileTabs {files} bind:active slot="titlebar" />
  <Highlight language={sources[active].language} code={sources[active].code} />
</CodeWindow>
```
