### PR TITLE
feat(components): add an absolute prop to CopyButton

### DIFF
--- a/README.md
+++ b/README.md
@@ -558,6 +558,32 @@ These apply when `langtag` is set to `true`.
 | --tab-active-background | Background color of the active tab                               | the highlighted code's background              |
 | --tab-focus-outline     | Keyboard focus outline of a tab                                   | `2px solid currentColor`                       |
 
+### `CodeToolbar` variables
+
+| Variable              | Description                    | Default value                 |
+| :--------------------- | :------------------------------- | :------------------------------ |
+| --toolbar-background  | Background color of the toolbar| `inherit`                     |
+| --toolbar-color       | Text color of the toolbar      | `inherit`                     |
+| --toolbar-border      | Bottom border of the toolbar   | `1px solid rgba(0, 0, 0, 0.1)`|
+| --toolbar-padding     | Padding of the toolbar         | `0.5em 1em`                    |
+| --toolbar-gap         | Gap between toolbar children   | `0.5em`                        |
+| --toolbar-height      | Minimum height of the toolbar  | `2.5em`                        |
+| --toolbar-font-family | Font family of the toolbar     | `inherit`                     |
+| --toolbar-font-size   | Font size of the toolbar       | `inherit`                     |
+| --toolbar-z-index     | Stacking order of the toolbar  | `2`                            |
+
+### `WrapToggle` variables
+
+| Variable                    | Description                    | Default value  |
+| :---------------------------- | :-------------------------------- | :--------------- |
+| --wrap-toggle-gap           | Gap between the button's content | `0.4em`        |
+| --wrap-toggle-padding       | Padding of the button           | `0.5em 0.75em` |
+| --wrap-toggle-background    | Background color of the button  | `inherit`      |
+| --wrap-toggle-color         | Text color of the button        | `inherit`      |
+| --wrap-toggle-border-radius | Corner radius of the button     | `4px`          |
+| --wrap-toggle-border        | Border of the button            | `none`         |
+| --wrap-toggle-font-size     | Font size of the button         | `inherit`      |
+
 ## Svelte Syntax Highlighting
 
 Use the `HighlightSvelte` component for Svelte syntax highlighting. Its grammar understands Svelte 5 runes (`$state`, `$derived`, `$effect` and its suffixed forms, `$props.id`, `$inspect.trace`), store auto-subscription (`$store`, `$store()`, `$store.prop`), `lang="ts"`/`context="module"` script-block resolution, and directive shorthand (`on:`, `bind:`, `use:`, and friends) — genuinely ahead of generic HTML-plus-embedded-JS Svelte highlighting, which has no notion that runes exist.
@@ -1709,6 +1735,61 @@ Put a `FileTabs` strip in the `titlebar` slot to switch between files without le
 </CodeWindow>
 ```
 
+## Code Toolbar
+
+Compose `CodeToolbar` inside `Highlight`'s default slot to add a sticky bar with a language badge on one side and controls -- like `WrapToggle` and `CopyButton` -- on the other. It's zero-JS layout: a `role="toolbar"` `<div>` with a `start` named slot for content next to the badge and an unnamed default slot for trailing controls, with no roving-tabindex/arrow-key navigation (children are ordinary tabbable buttons, per the lightweight [WAI-ARIA toolbar pattern](https://www.w3.org/WAI/ARIA/apg/patterns/toolbar/)).
+
+```svelte
+<script>
+  import Highlight, {
+    CodeToolbar,
+    CopyButton,
+    LineNumbers,
+    WrapToggle,
+  } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import github from "svelte-highlight/styles/github";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+
+  let wrap = false;
+</script>
+
+<svelte:head>
+  {@html github}
+</svelte:head>
+
+<!-- max-height + overflow-y: auto give the container something to scroll,
+     which is what CodeToolbar's sticky positioning pins itself to. -->
+<div style="max-height: 320px; overflow-y: auto;">
+  <Highlight {code} language={typescript} {wrap} let:highlighted let:languageName>
+    <CodeToolbar {languageName} title="app.ts">
+      <WrapToggle bind:wrap />
+      <CopyButton {code} absolute={false} />
+    </CodeToolbar>
+    <LineNumbers {highlighted} wrapLines={wrap} />
+  </Highlight>
+</div>
+```
+
+`sticky` (default `true`) is what keeps the toolbar pinned; it only has something to stick to when a scrollable ancestor exists, which is why the recipe above wraps everything in the `max-height`/`overflow-y: auto` container -- `LineNumbers` sets no height of its own, so nothing scrolls without it.
+
+### Composing with CodeWindow
+
+The same recipe drops into `CodeWindow`'s default slot unchanged. The toolbar lives in the window body, above the code, rather than in the window's title bar:
+
+```svelte
+<CodeWindow variant="macos" title="example.ts">
+  <Highlight {code} language={typescript} {wrap} let:highlighted let:languageName>
+    <CodeToolbar {languageName} title="app.ts">
+      <WrapToggle bind:wrap />
+      <CopyButton {code} absolute={false} />
+    </CodeToolbar>
+    <LineNumbers {highlighted} wrapLines={wrap} />
+  </Highlight>
+</CodeWindow>
+```
+
 ## Animation
 
 Use `Typewriter` inside `Highlight`'s default slot with the `highlighted` prop. It prints the code one character at a time, syntax highlighting included. A blinking caret marks the end of the typed text and hides when typing stops.
@@ -2376,6 +2457,66 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 | --prompt-font-family  | Font family of the terminal prompt       | `ui-monospace, monospace`           |
 | --prompt-font-weight  | Font weight of the terminal prompt       | `700`                               |
 | --prompt-color        | Color of the terminal prompt             | `inherit`                           |
+
+### `CodeToolbar`
+
+#### Props
+
+| Name         | Type      | Default value |
+| :----------- | :-------- | :------------ |
+| languageName | `string`  | `undefined`    |
+| title        | `string`  | `""`           |
+| sticky       | `boolean` | `true`         |
+| label        | `string`  | `undefined`    |
+
+`$$restProps` are forwarded to the top-level `div` element.
+
+#### Slots
+
+- **start**: rendered next to the language badge/title
+- default: rendered in the trailing/"end" region
+
+#### CSS Variables
+
+| Variable              | Description                        | Default value                |
+| :--------------------- | :---------------------------------- | :---------------------------- |
+| --toolbar-background  | Background color of the toolbar    | `inherit`                    |
+| --toolbar-color        | Text color of the toolbar           | `inherit`                    |
+| --toolbar-border       | Bottom border of the toolbar        | `1px solid rgba(0, 0, 0, 0.1)`|
+| --toolbar-padding      | Padding of the toolbar              | `0.5em 1em`                   |
+| --toolbar-gap          | Gap between toolbar children        | `0.5em`                       |
+| --toolbar-height       | Minimum height of the toolbar       | `2.5em`                       |
+| --toolbar-font-family  | Font family of the toolbar          | `inherit`                    |
+| --toolbar-font-size    | Font size of the toolbar            | `inherit`                    |
+| --toolbar-z-index      | Stacking order of the toolbar       | `2`                           |
+
+### `WrapToggle`
+
+#### Props
+
+| Name        | Type      | Default value |
+| :---------- | :-------- | :------------- |
+| wrap        | `boolean` | `false`        |
+| text        | `string`  | `"Wrap"`       |
+| pressedText | `string`  | `"Wrapped"`    |
+
+`wrap` is bindable (`bind:wrap`). `$$restProps` are forwarded to the top-level `button` element.
+
+#### Slots
+
+- default: exposes `wrap`, falls back to `text` regardless of pressed state
+
+#### CSS Variables
+
+| Variable                     | Description                       | Default value |
+| :---------------------------- | :---------------------------------- | :------------- |
+| --wrap-toggle-gap            | Gap between the button's content  | `0.4em`        |
+| --wrap-toggle-padding        | Padding of the button             | `0.5em 0.75em` |
+| --wrap-toggle-background     | Background color of the button    | `inherit`      |
+| --wrap-toggle-color          | Text color of the button          | `inherit`      |
+| --wrap-toggle-border-radius  | Corner radius of the button       | `4px`          |
+| --wrap-toggle-border         | Border of the button              | `none`         |
+| --wrap-toggle-font-size      | Font size of the button           | `inherit`      |
 
 ### `AnsiOutput`
 

--- a/README.md
+++ b/README.md
@@ -917,6 +917,12 @@ Use `--copy-*` style props to customize the button.
 />
 ```
 
+Set `absolute={false}` to lay the button out in normal document flow instead of overlaying its container.
+
+```svelte
+<CopyButton {code} absolute={false} />
+```
+
 ### With Line Numbers
 
 Compose `CopyButton` with `LineNumbers` by wrapping both in a relatively-positioned container.
@@ -2300,6 +2306,7 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 | timeout    | `number`                                   | `2000`                                       |
 | text       | `string`                                   | `"Copy"`                                     |
 | copiedText | `string`                                   | `"Copied!"`                                  |
+| absolute   | `boolean`                                  | `true`                                       |
 
 `$$restProps` are forwarded to the top-level `button` element.
 

--- a/src/CodeToolbar.svelte
+++ b/src/CodeToolbar.svelte
@@ -1,0 +1,74 @@
+<script>
+  /** @type {string | undefined} */
+  export let languageName = undefined;
+
+  /** @type {string} */
+  export let title = "";
+
+  /** @type {boolean} */
+  export let sticky = true;
+
+  /** @type {string | undefined} */
+  export let label = undefined;
+</script>
+
+<div
+  class="shl-toolbar"
+  role="toolbar"
+  aria-label={label}
+  style:position={sticky ? "sticky" : "static"}
+  style:top={sticky ? "0" : undefined}
+  {...$$restProps}
+>
+  <div class="shl-toolbar-start">
+    {#if languageName}
+      <span class="shl-toolbar-badge" data-language={languageName}
+        >{languageName}</span
+      >
+    {/if}
+    {#if title}
+      <span class="shl-toolbar-title" {title}>{title}</span>
+    {/if}
+    <slot name="start" />
+  </div>
+  <div class="shl-toolbar-end"><slot /></div>
+</div>
+
+<style>
+  .shl-toolbar {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: var(--toolbar-gap, 0.5em);
+    min-height: var(--toolbar-height, 2.5em);
+    padding: var(--toolbar-padding, 0.5em 1em);
+    background: var(--toolbar-background, inherit);
+    color: var(--toolbar-color, inherit);
+    border-bottom: var(--toolbar-border, 1px solid rgba(0, 0, 0, 0.1));
+    font-family: var(--toolbar-font-family, inherit);
+    font-size: var(--toolbar-font-size, inherit);
+    z-index: var(--toolbar-z-index, 2);
+  }
+
+  .shl-toolbar-start,
+  .shl-toolbar-end {
+    display: flex;
+    align-items: center;
+    gap: var(--toolbar-gap, 0.5em);
+    min-width: 0;
+  }
+
+  .shl-toolbar-title {
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+  }
+
+  .shl-toolbar-badge {
+    background: var(--langtag-background, inherit);
+    color: var(--langtag-color, inherit);
+    border-radius: var(--langtag-border-radius, 0);
+    padding: var(--langtag-padding, 1em);
+    font-size: var(--langtag-font-size, inherit);
+  }
+</style>

--- a/src/CodeToolbar.svelte.d.ts
+++ b/src/CodeToolbar.svelte.d.ts
@@ -1,0 +1,95 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+
+export type CodeToolbarProps = HTMLAttributes<HTMLDivElement> & {
+  /**
+   * Language badge text. Omitted entirely when unset.
+   */
+  languageName?: string;
+
+  /**
+   * File name shown next to the badge, with a `title` attribute for
+   * truncation.
+   * @default ""
+   */
+  title?: string;
+
+  /**
+   * Whether the toolbar sticks to the top of its scrolling ancestor via
+   * `position: sticky`.
+   * @default true
+   */
+  sticky?: boolean;
+
+  /**
+   * Accessible name for the `role="toolbar"` root. Omitted when unset.
+   */
+  label?: string;
+
+  /**
+   * Toolbar background.
+   * @default "inherit"
+   */
+  "--toolbar-background"?: string;
+
+  /**
+   * Toolbar text color.
+   * @default "inherit"
+   */
+  "--toolbar-color"?: string;
+
+  /**
+   * Toolbar bottom border.
+   * @default "1px solid rgba(0, 0, 0, 0.1)"
+   */
+  "--toolbar-border"?: string;
+
+  /**
+   * Toolbar padding.
+   * @default "0.5em 1em"
+   */
+  "--toolbar-padding"?: string;
+
+  /**
+   * Gap between toolbar children.
+   * @default "0.5em"
+   */
+  "--toolbar-gap"?: string;
+
+  /**
+   * Minimum height of the toolbar.
+   * @default "2.5em"
+   */
+  "--toolbar-height"?: string;
+
+  /**
+   * Toolbar font family.
+   * @default "inherit"
+   */
+  "--toolbar-font-family"?: string;
+
+  /**
+   * Toolbar font size.
+   * @default "inherit"
+   */
+  "--toolbar-font-size"?: string;
+
+  /**
+   * Toolbar stacking order.
+   * @default 2
+   */
+  "--toolbar-z-index"?: string | number;
+};
+
+export type CodeToolbarEvents = {};
+
+export type CodeToolbarSlots = {
+  start: {};
+  default: {};
+};
+
+export default class CodeToolbar extends SvelteComponentTyped<
+  CodeToolbarProps,
+  CodeToolbarEvents,
+  CodeToolbarSlots
+> {}

--- a/src/CopyButton.svelte
+++ b/src/CopyButton.svelte
@@ -2,6 +2,9 @@
   /** @type {string} */
   export let code;
 
+  /** @type {boolean} */
+  export let absolute = true;
+
   /**
    * Override copy behavior. Defaults to `navigator.clipboard.writeText`.
    * @type {(code: string) => void | Promise<void>}
@@ -66,6 +69,7 @@
   on:click={handleClick}
   on:mouseenter
   on:mouseleave
+  style:position={absolute ? "absolute" : "static"}
   {...$$restProps}
 >
   <slot {copied} {copying}>
@@ -104,7 +108,6 @@
 
 <style>
   button {
-    position: absolute;
     top: var(--copy-top, 0.5em);
     right: var(--copy-right, 0.5em);
     display: flex;

--- a/src/CopyButton.svelte.d.ts
+++ b/src/CopyButton.svelte.d.ts
@@ -41,6 +41,13 @@ export type CopyButtonProps = HTMLButtonAttributes & {
   copiedText?: string;
 
   /**
+   * Whether the button is positioned absolutely (overlaying its container)
+   * or laid out in normal document flow.
+   * @default true
+   */
+  absolute?: boolean;
+
+  /**
    * Top offset.
    * @default "0.5em"
    */

--- a/src/WrapToggle.svelte
+++ b/src/WrapToggle.svelte
@@ -1,0 +1,36 @@
+<script>
+  /** @type {boolean} */
+  export let wrap = false;
+
+  /** @type {string} */
+  export let text = "Wrap";
+
+  /** @type {string} */
+  export let pressedText = "Wrapped";
+</script>
+
+<button
+  type="button"
+  aria-pressed={wrap}
+  aria-label={wrap ? pressedText : text}
+  on:click={() => (wrap = !wrap)}
+  {...$$restProps}
+>
+  <slot {wrap}>{text}</slot>
+</button>
+
+<style>
+  button {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    cursor: pointer;
+    gap: var(--wrap-toggle-gap, 0.4em);
+    padding: var(--wrap-toggle-padding, 0.5em 0.75em);
+    background: var(--wrap-toggle-background, inherit);
+    color: var(--wrap-toggle-color, inherit);
+    border-radius: var(--wrap-toggle-border-radius, 4px);
+    border: var(--wrap-toggle-border, none);
+    font-size: var(--wrap-toggle-font-size, inherit);
+  }
+</style>

--- a/src/WrapToggle.svelte.d.ts
+++ b/src/WrapToggle.svelte.d.ts
@@ -1,0 +1,82 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLButtonAttributes } from "svelte/elements";
+
+export type WrapToggleProps = HTMLButtonAttributes & {
+  /**
+   * Whether wrapping is enabled. Bindable.
+   * @default false
+   */
+  wrap?: boolean;
+
+  /**
+   * Unpressed `aria-label` and default slot fallback text.
+   * @default "Wrap"
+   */
+  text?: string;
+
+  /**
+   * Pressed `aria-label`. The default slot fallback text stays `text`
+   * regardless of state.
+   * @default "Wrapped"
+   */
+  pressedText?: string;
+
+  /**
+   * Gap between the button's content.
+   * @default "0.4em"
+   */
+  "--wrap-toggle-gap"?: string;
+
+  /**
+   * Button padding.
+   * @default "0.5em 0.75em"
+   */
+  "--wrap-toggle-padding"?: string;
+
+  /**
+   * Button background.
+   * @default "inherit"
+   */
+  "--wrap-toggle-background"?: string;
+
+  /**
+   * Button color.
+   * @default "inherit"
+   */
+  "--wrap-toggle-color"?: string;
+
+  /**
+   * Button border radius.
+   * @default "4px"
+   */
+  "--wrap-toggle-border-radius"?: string;
+
+  /**
+   * Button border.
+   * @default "none"
+   */
+  "--wrap-toggle-border"?: string;
+
+  /**
+   * Button font size.
+   * @default "inherit"
+   */
+  "--wrap-toggle-font-size"?: string;
+};
+
+export type WrapToggleEvents = {};
+
+export type WrapToggleSlots = {
+  default: {
+    /**
+     * Current wrap state.
+     */
+    wrap: boolean;
+  };
+};
+
+export default class WrapToggle extends SvelteComponentTyped<
+  WrapToggleProps,
+  WrapToggleEvents,
+  WrapToggleSlots
+> {}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -39,3 +39,4 @@ export {
   easeOutSine,
   linear,
 } from "./typewriter-easing";
+export { default as WrapToggle } from "./WrapToggle.svelte";

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -3,6 +3,7 @@ export type { HighlightActionParameters } from "./action";
 export { highlight } from "./action";
 export type { AnsiColor, AnsiSegment, AnsiStyle } from "./ansi";
 export { parseAnsi } from "./ansi";
+export { default as CodeToolbar } from "./CodeToolbar.svelte";
 export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { stripDiffMarkers, stripPrompts } from "./copy-transforms";

--- a/src/index.js
+++ b/src/index.js
@@ -35,3 +35,4 @@ export {
   easeOutSine,
   linear,
 } from "./typewriter-easing.js";
+export { default as WrapToggle } from "./WrapToggle.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,7 @@
 export { default as AnsiOutput } from "./AnsiOutput.svelte";
 export { highlight } from "./action.js";
 export { parseAnsi } from "./ansi.js";
+export { default as CodeToolbar } from "./CodeToolbar.svelte";
 export { default as CodeWindow } from "./CodeWindow.svelte";
 export { default as CopyButton } from "./CopyButton.svelte";
 export { stripDiffMarkers, stripPrompts } from "./copy-transforms.js";

--- a/tests/code-toolbar-ssr.test.ts
+++ b/tests/code-toolbar-ssr.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+
+const componentPath = path.join(import.meta.dir, "../src/CodeToolbar.svelte");
+
+async function compileForServer() {
+  const source = fs.readFileSync(componentPath, "utf-8");
+  const { js } = compile(source, {
+    generate: "server",
+    filename: "CodeToolbar.svelte",
+  });
+
+  const outPath = path.join(
+    import.meta.dir,
+    "../src/.tmp-code-toolbar.server.js",
+  );
+  fs.writeFileSync(outPath, js.code);
+  try {
+    return await import(pathToFileURL(outPath).href);
+  } finally {
+    fs.unlinkSync(outPath);
+  }
+}
+
+describe("CodeToolbar SSR", () => {
+  it("renders the language badge and title, with no aria-label when label is unset", async () => {
+    const { default: CodeToolbar } = await compileForServer();
+
+    const { body } = render(CodeToolbar, {
+      props: { languageName: "typescript", title: "app.ts" },
+    });
+
+    expect(body).toContain('role="toolbar"');
+    expect(body).toContain('data-language="typescript"');
+    expect(body).toContain("typescript");
+    expect(body).toContain('title="app.ts"');
+    expect(body).not.toContain("aria-label");
+  });
+
+  it("renders aria-label when label is set", async () => {
+    const { default: CodeToolbar } = await compileForServer();
+
+    const { body } = render(CodeToolbar, {
+      props: { label: "Code actions" },
+    });
+
+    expect(body).toContain('aria-label="Code actions"');
+  });
+
+  it("omits position:sticky from the inline style when sticky is false", async () => {
+    const { default: CodeToolbar } = await compileForServer();
+
+    const { body } = render(CodeToolbar, {
+      props: { sticky: false },
+    });
+
+    expect(body).not.toContain("position:sticky");
+  });
+});

--- a/tests/e2e/CodeToolbar.test.svelte
+++ b/tests/e2e/CodeToolbar.test.svelte
@@ -19,7 +19,13 @@
 <svelte:head>{@html atomOneDark}</svelte:head>
 
 <div style="height: 200px; overflow-y: auto;" data-testid="scroll-container">
-  <Highlight language={typescript} {code} {wrap} let:highlighted let:languageName>
+  <Highlight
+    language={typescript}
+    {code}
+    {wrap}
+    let:highlighted
+    let:languageName
+  >
     <CodeToolbar {languageName} title="app.ts">
       <WrapToggle bind:wrap />
       <CopyButton {code} absolute={false} />

--- a/tests/e2e/CodeToolbar.test.svelte
+++ b/tests/e2e/CodeToolbar.test.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+  import Highlight, {
+    CodeToolbar,
+    CopyButton,
+    LineNumbers,
+    WrapToggle,
+  } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = Array.from(
+    { length: 200 },
+    (_, i) => `const line${i} = ${i};`,
+  ).join("\n");
+
+  let wrap = false;
+</script>
+
+<svelte:head>{@html atomOneDark}</svelte:head>
+
+<div style="height: 200px; overflow-y: auto;" data-testid="scroll-container">
+  <Highlight language={typescript} {code} {wrap} let:highlighted let:languageName>
+    <CodeToolbar {languageName} title="app.ts">
+      <WrapToggle bind:wrap />
+      <CopyButton {code} absolute={false} />
+    </CodeToolbar>
+    <LineNumbers {highlighted} wrapLines={wrap} />
+  </Highlight>
+</div>

--- a/tests/e2e/CopyButton.absolute.test.svelte
+++ b/tests/e2e/CopyButton.absolute.test.svelte
@@ -1,0 +1,12 @@
+<script lang="ts">
+  import Highlight, { CopyButton } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+</script>
+
+<svelte:head> {@html atomOneDark} </svelte:head>
+
+<Highlight language={typescript} {code} />
+<CopyButton {code} absolute={false} />

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -4,6 +4,7 @@ import AnsiOutputLink from "./AnsiOutput.link.test.svelte";
 import AnsiOutputStreaming from "./AnsiOutput.streaming.test.svelte";
 import AnsiOutput from "./AnsiOutput.test.svelte";
 import CodeWindow from "./CodeWindow.test.svelte";
+import CopyButtonAbsolute from "./CopyButton.absolute.test.svelte";
 import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
 import CopyButtonCustomCopy from "./CopyButton.customCopy.test.svelte";
 import CopyButton from "./CopyButton.test.svelte";
@@ -1081,6 +1082,18 @@ test("CopyButton - transform strips decoration before copying and reporting on:c
   const clipboard = await page.evaluate(() => navigator.clipboard.readText());
   expect(clipboard).toBe("npm i\nadded 1 package");
   await expect(page.getByTestId("detail")).toHaveText("npm i\nadded 1 package");
+});
+
+test("CopyButton - absolute false lays out inline instead of overlaying", async ({
+  mount,
+  page,
+}) => {
+  await mount(CopyButtonAbsolute);
+
+  await expect(page.getByRole("button", { name: "Copy" })).toHaveCSS(
+    "position",
+    "static",
+  );
 });
 
 test("HighlightEditable - renders an editable, highlighted block", async ({

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -3,6 +3,7 @@ import AnsiOutputContrast from "./AnsiOutput.contrast.test.svelte";
 import AnsiOutputLink from "./AnsiOutput.link.test.svelte";
 import AnsiOutputStreaming from "./AnsiOutput.streaming.test.svelte";
 import AnsiOutput from "./AnsiOutput.test.svelte";
+import CodeToolbar from "./CodeToolbar.test.svelte";
 import CodeWindow from "./CodeWindow.test.svelte";
 import CopyButtonAbsolute from "./CopyButton.absolute.test.svelte";
 import CopyButtonAsyncCopy from "./CopyButton.asyncCopy.test.svelte";
@@ -175,6 +176,86 @@ test("HighlightStyle - falls back to the auto-hash when scopeClass is an empty s
     "color",
     "rgb(220, 198, 224)",
   );
+});
+
+test("CodeToolbar - renders a language badge and title", async ({
+  mount,
+  page,
+}) => {
+  await mount(CodeToolbar);
+
+  const badge = page.locator('[data-language="typescript"]');
+  await expect(badge).toBeVisible();
+  await expect(badge).toHaveText("typescript");
+
+  const title = page.locator('[title="app.ts"]');
+  await expect(title).toHaveText("app.ts");
+});
+
+test("CodeToolbar - stays pinned to the top while its container scrolls", async ({
+  mount,
+  page,
+}) => {
+  await mount(CodeToolbar);
+
+  const toolbar = page.getByRole("toolbar");
+  const before = await toolbar.boundingBox();
+  expect(before).not.toBeNull();
+
+  await expect(page.getByText("line0")).toBeInViewport();
+
+  const container = page.getByTestId("scroll-container");
+  await container.evaluate((el) => {
+    el.scrollTop = el.scrollHeight;
+  });
+
+  const after = await toolbar.boundingBox();
+  expect(after).not.toBeNull();
+  expect(Math.abs((after?.y ?? 0) - (before?.y ?? 0))).toBeLessThan(2);
+
+  await expect(page.getByText("line0")).not.toBeInViewport();
+  await expect(page.getByText("line199")).toBeInViewport();
+});
+
+test("CodeToolbar - WrapToggle flips aria-pressed and the bound wrap", async ({
+  mount,
+  page,
+}) => {
+  await mount(CodeToolbar);
+
+  const codeLine = page.locator("table pre").first();
+  await expect(codeLine).toHaveCSS("white-space", "pre");
+
+  const wrapButton = page.getByRole("button", { name: "Wrap" });
+  await wrapButton.click();
+
+  await expect(wrapButton).toHaveAttribute("aria-pressed", "true");
+  await expect(wrapButton).toHaveAttribute("aria-label", "Wrapped");
+  await expect(codeLine).toHaveCSS("white-space", "pre-wrap");
+});
+
+test("CodeToolbar - CopyButton inside it copies the code", async ({
+  mount,
+  page,
+  browserName,
+}) => {
+  test.skip(
+    browserName !== "chromium",
+    "Clipboard permissions are Chromium-only",
+  );
+
+  await page.context().grantPermissions(["clipboard-read", "clipboard-write"]);
+
+  await mount(CodeToolbar);
+
+  await page.getByRole("button", { name: "Copy" }).click();
+
+  const clipboard = await page.evaluate(() => navigator.clipboard.readText());
+  const expected = Array.from(
+    { length: 200 },
+    (_, i) => `const line${i} = ${i};`,
+  ).join("\n");
+  expect(clipboard).toBe(expected);
 });
 
 test("CodeWindow - renders each variant wrapping a Highlight", async ({

--- a/tests/wrap-toggle-ssr.test.ts
+++ b/tests/wrap-toggle-ssr.test.ts
@@ -1,0 +1,48 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+
+const componentPath = path.join(import.meta.dir, "../src/WrapToggle.svelte");
+
+async function compileForServer() {
+  const source = fs.readFileSync(componentPath, "utf-8");
+  const { js } = compile(source, {
+    generate: "server",
+    filename: "WrapToggle.svelte",
+  });
+
+  const outPath = path.join(
+    import.meta.dir,
+    "../src/.tmp-wrap-toggle.server.js",
+  );
+  fs.writeFileSync(outPath, js.code);
+  try {
+    return await import(pathToFileURL(outPath).href);
+  } finally {
+    fs.unlinkSync(outPath);
+  }
+}
+
+describe("WrapToggle SSR", () => {
+  it("renders unpressed by default with the fallback text", async () => {
+    const { default: WrapToggle } = await compileForServer();
+
+    const { body } = render(WrapToggle, { props: {} });
+
+    expect(body).toContain('aria-pressed="false"');
+    expect(body).toContain('aria-label="Wrap"');
+    expect(body).toContain("Wrap");
+  });
+
+  it("renders pressed when wrap is true, with fallback text still Wrap", async () => {
+    const { default: WrapToggle } = await compileForServer();
+
+    const { body } = render(WrapToggle, { props: { wrap: true } });
+
+    expect(body).toContain('aria-pressed="true"');
+    expect(body).toContain('aria-label="Wrapped"');
+    expect(body).toContain(">Wrap<");
+  });
+});

--- a/www/components/CodeToolbar/Basic.svelte
+++ b/www/components/CodeToolbar/Basic.svelte
@@ -1,0 +1,54 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+  import Highlight, {
+    CodeToolbar,
+    CopyButton,
+    HighlightSvelte,
+    LineNumbers,
+    WrapToggle,
+  } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+
+  const snippet = `<script>
+  import Highlight, {
+    CodeToolbar,
+    CopyButton,
+    LineNumbers,
+    WrapToggle,
+  } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+  const code = "const add = (a: number, b: number) => a + b";
+
+  let wrap = false;
+<\/script>
+
+<svelte:head>
+  {@html ${THEME_MODULE_NAME}}
+</svelte:head>
+
+<Highlight language={typescript} {code} {wrap} let:highlighted let:languageName>
+  <CodeToolbar {languageName} title="app.ts">
+    <WrapToggle bind:wrap />
+    <CopyButton {code} absolute={false} />
+  </CodeToolbar>
+  <LineNumbers {highlighted} wrapLines={wrap} />
+</Highlight>`;
+
+  let wrap = false;
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+<Highlight language={typescript} {code} {wrap} let:highlighted let:languageName>
+  <CodeToolbar {languageName} title="app.ts">
+    <WrapToggle bind:wrap />
+    <CopyButton {code} absolute={false} />
+  </CodeToolbar>
+  <LineNumbers {highlighted} wrapLines={wrap} class={THEME_MODULE_NAME} />
+</Highlight>

--- a/www/components/CodeToolbar/InCodeWindow.svelte
+++ b/www/components/CodeToolbar/InCodeWindow.svelte
@@ -1,0 +1,66 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+  import Highlight, {
+    CodeToolbar,
+    CodeWindow,
+    CopyButton,
+    HighlightSvelte,
+    LineNumbers,
+    WrapToggle,
+  } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code = "const add = (a: number, b: number) => a + b;";
+
+  const snippet = `<script>
+  import Highlight, {
+    CodeToolbar,
+    CodeWindow,
+    CopyButton,
+    LineNumbers,
+    WrapToggle,
+  } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+  const code = "const add = (a: number, b: number) => a + b";
+
+  let wrap = false;
+<\/script>
+
+<svelte:head>
+  {@html ${THEME_MODULE_NAME}}
+</svelte:head>
+
+<CodeWindow variant="macos" title="example.ts">
+  <Highlight language={typescript} {code} {wrap} let:highlighted let:languageName>
+    <CodeToolbar {languageName} title="app.ts">
+      <WrapToggle bind:wrap />
+      <CopyButton {code} absolute={false} />
+    </CodeToolbar>
+    <LineNumbers {highlighted} wrapLines={wrap} />
+  </Highlight>
+</CodeWindow>`;
+
+  let wrap = false;
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+<CodeWindow variant="macos" title="example.ts">
+  <Highlight
+    language={typescript}
+    {code}
+    {wrap}
+    let:highlighted
+    let:languageName
+  >
+    <CodeToolbar {languageName} title="app.ts">
+      <WrapToggle bind:wrap />
+      <CopyButton {code} absolute={false} />
+    </CodeToolbar>
+    <LineNumbers {highlighted} wrapLines={wrap} class={THEME_MODULE_NAME} />
+  </Highlight>
+</CodeWindow>

--- a/www/components/CodeToolbar/Sticky.svelte
+++ b/www/components/CodeToolbar/Sticky.svelte
@@ -1,0 +1,68 @@
+<script>
+  import { THEME_MODULE_NAME, THEME_NAME } from "@www/constants";
+  import Highlight, {
+    CodeToolbar,
+    CopyButton,
+    HighlightSvelte,
+    LineNumbers,
+    WrapToggle,
+  } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const code = Array.from(
+    { length: 60 },
+    (_, i) => `const line${i} = ${i};`,
+  ).join("\n");
+
+  const snippet = `<script>
+  import Highlight, {
+    CodeToolbar,
+    CopyButton,
+    LineNumbers,
+    WrapToggle,
+  } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import ${THEME_MODULE_NAME} from "svelte-highlight/styles/${THEME_NAME}";
+
+  const code = "..."; // a long file
+
+  let wrap = false;
+<\/script>
+
+<svelte:head>
+  {@html ${THEME_MODULE_NAME}}
+</svelte:head>
+
+<!-- CodeToolbar's sticky positioning pins it to this scrolling container. -->
+<div style="max-height: 320px; overflow-y: auto;">
+  <Highlight language={typescript} {code} {wrap} let:highlighted let:languageName>
+    <CodeToolbar {languageName} title="app.ts">
+      <WrapToggle bind:wrap />
+      <CopyButton {code} absolute={false} />
+    </CodeToolbar>
+    <LineNumbers {highlighted} wrapLines={wrap} />
+  </Highlight>
+</div>`;
+
+  let wrap = false;
+</script>
+
+<div class="mb-5">
+  <HighlightSvelte code={snippet} class={THEME_MODULE_NAME} />
+</div>
+
+<div style="max-height: 320px; overflow-y: auto;">
+  <Highlight
+    language={typescript}
+    {code}
+    {wrap}
+    let:highlighted
+    let:languageName
+  >
+    <CodeToolbar {languageName} title="app.ts">
+      <WrapToggle bind:wrap />
+      <CopyButton {code} absolute={false} />
+    </CodeToolbar>
+    <LineNumbers {highlighted} wrapLines={wrap} class={THEME_MODULE_NAME} />
+  </Highlight>
+</div>

--- a/www/components/CodeToolbarPreview.svelte
+++ b/www/components/CodeToolbarPreview.svelte
@@ -1,0 +1,21 @@
+<script>
+  import Basic from "@components/CodeToolbar/Basic.svelte";
+  import InCodeWindow from "@components/CodeToolbar/InCodeWindow.svelte";
+  import Sticky from "@components/CodeToolbar/Sticky.svelte";
+  import { Column, Row } from "carbon-components-svelte";
+</script>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Basic</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Basic /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Composing with CodeWindow</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <InCodeWindow /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Sticky in a scrolling container</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <Sticky /> </Column>
+</Row>

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -72,6 +72,7 @@
     "/preview-dual-theme": "Dual light/dark HighlightStyle preview",
     "/preview-editable": "Editable highlight preview",
     "/preview-highlight-stream": "HighlightStream preview",
+    "/preview-code-toolbar": "CodeToolbar preview",
     "/preview-markdown-stream": "MarkdownStream preview",
     "/preview-virtual": "HighlightVirtual preview",
     "/preview-engine": "Headless engine preview",

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -1,6 +1,9 @@
 <script>
   import AnsiOutputExamples from "@components/AnsiOutput/Examples.svelte";
   import CodeSnippet from "@components/CodeSnippet.svelte";
+  import CodeToolbarBasic from "@components/CodeToolbar/Basic.svelte";
+  import CodeToolbarInCodeWindow from "@components/CodeToolbar/InCodeWindow.svelte";
+  import CodeToolbarSticky from "@components/CodeToolbar/Sticky.svelte";
   import CodeWindowPreview from "@components/CodeWindowPreview.svelte";
   import CopyButtonBasic from "@components/CopyButton/Basic.svelte";
   import CopyButtonCustomFunction from "@components/CopyButton/CustomFunction.svelte";
@@ -630,6 +633,50 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <CodeWindowPreview /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h2 id="code-toolbar">Code Toolbar</h2> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      Compose <code class="code">CodeToolbar</code> inside
+      <code class="code">Highlight</code>'s default slot to add a sticky bar
+      with a language badge on one side and controls on the other. It's zero-JS
+      layout: a <code class="code">start</code> named slot for content next to
+      the badge, and an unnamed default slot for trailing controls like
+      <code class="code">WrapToggle</code>
+      and
+      <code class="code">CopyButton</code>.
+    </p>
+    <p class="mb-5">
+      <code class="code">sticky</code>
+      (default <code class="code">true</code>) pins the bar to the top of its
+      nearest scrolling ancestor -- wrap it and
+      <code class="code">LineNumbers</code>
+      in a <code class="code">max-height</code>/<code class="code"
+        >overflow-y: auto</code
+      >
+      container for genuine sticky behavior. No roving-tabindex/arrow-key
+      navigation: children are ordinary tabbable buttons.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CodeToolbarBasic /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      The same recipe drops into
+      <code class="code">CodeWindow</code>'s default slot unchanged -- the
+      toolbar lives in the window body, above the code, rather than in the
+      window's title bar.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CodeToolbarInCodeWindow /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      With a scrollable container, the toolbar stays pinned to the top while the
+      code scrolls underneath it.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <CodeToolbarSticky /> </Column>
 </Row>
 
 <Row class="mb-9">

--- a/www/pages/preview-code-toolbar.astro
+++ b/www/pages/preview-code-toolbar.astro
@@ -1,0 +1,8 @@
+---
+import CodeToolbarPreview from "@components/CodeToolbarPreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="CodeToolbar preview">
+  <CodeToolbarPreview client:idle />
+</Layout>


### PR DESCRIPTION
Adds `CodeToolbar`, a zero-JS sticky bar for a language badge plus
controls like copy/wrap, and `WrapToggle`, a bindable wrap button.
`CopyButton` gets a new `absolute` prop so it can lay out inline
instead of overlaying, which is what lets it sit inside the toolbar.

```svelte
<Highlight {code} language={typescript} let:highlighted let:languageName>
  <CodeToolbar {languageName} title="app.ts">
    <WrapToggle bind:wrap />
    <CopyButton {code} absolute={false} />
  </CodeToolbar>
  <LineNumbers {highlighted} wrapLines={wrap} />
</Highlight>
```