### PR TITLE
fix: force LTR code text under dir=rtl containers

### DIFF
--- a/src/LangTag.svelte
+++ b/src/LangTag.svelte
@@ -32,4 +32,8 @@
 
 <style>
   @import "./langtag.css";
+
+  pre {
+    direction: ltr;
+  }
 </style>

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -140,6 +140,7 @@
 
   pre {
     margin: 0;
+    direction: ltr;
   }
 
   table,


### PR DESCRIPTION
Block boxes establish their own bidi paragraph from the inherited
direction, so pre inside a dir="rtl" ancestor let the Unicode bidi
algorithm reorder trailing neutral characters (like a semicolon) to
the visual start of a line, even though the code itself is LTR.
Pinning pre to direction: ltr keeps only layout (gutter position,
borders) responding to dir="rtl".

Before, in the RTL LineNumbers example:

    ;"import Highlight, { LineNumbers } from "svelte-highlight

After:

    "import Highlight, { LineNumbers } from "svelte-highlight";