### PR TITLE
feat(diff): add parseUnifiedDiff and diffLines to svelte-highlight/diff

### DIFF
--- a/README.md
+++ b/README.md
@@ -2127,7 +2127,7 @@ Pass `diff` (unified diff text, parsed with `parseUnifiedDiff`) or `before`/`aft
 <HighlightDiff {before} {after} language={typescript} />
 ```
 
-`gutter` controls which line-number column(s) render: `"both"` (default) shows the new-file number plus the old-file number in a secondary column to its left; `"new"` shows only the new-file number; `"none"` hides numbers but keeps the markers and code. `context` (default `Infinity`) collapses a maximal run of consecutive unchanged lines longer than it behind a single "N unchanged lines" button, which expands to individual rows on click -- pass a small number (e.g. `3`) for large files with small changes. `hunkHeaders` (default `true`) renders a row for each hunk's `@@ ... @@` header and, when `diff` provides a path, each file's header.
+`gutter` controls which line-number column(s) render: `"both"` (default) shows the new-file number plus the old-file number in a secondary column to its left -- the two-column convention GitHub, GitLab, and Bitbucket use in their unified diff view; `"new"` shows only the new-file number, blank for removed lines; `"unified"` is a single column like `"new"`, but falls back to the old-file number for removed lines instead of leaving them blank; `"none"` hides numbers but keeps the markers and code. `context` (default `Infinity`) collapses a maximal run of consecutive unchanged lines longer than it behind a single "N unchanged lines" button, which expands to individual rows on click -- pass a small number (e.g. `3`) for large files with small changes. `hunkHeaders` (default `true`) renders a row for each hunk's `@@ ... @@` header and, when `diff` provides a path, each file's header.
 
 ### Copying the result
 
@@ -2419,7 +2419,7 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 | before      | `string`                      | `undefined`      |
 | after       | `string`                      | `undefined`      |
 | language    | `LanguageType<string>`        | N/A (required)   |
-| gutter      | `"both" \| "new" \| "none"`   | `"both"`         |
+| gutter      | `"both" \| "new" \| "unified" \| "none"` | `"both"` |
 | context     | `number`                      | `Infinity`       |
 | hunkHeaders | `boolean`                     | `true`           |
 

--- a/README.md
+++ b/README.md
@@ -558,6 +558,17 @@ These apply when `langtag` is set to `true`.
 | --tab-active-background | Background color of the active tab                               | the highlighted code's background              |
 | --tab-focus-outline     | Keyboard focus outline of a tab                                   | `2px solid currentColor`                       |
 
+### `HighlightDiff` variables
+
+| Variable                 | Description                                | Default value                     |
+| :------------------------ | :------------------------------------------ | :--------------------------------- |
+| --diff-add-background    | Background of added lines                  | `rgba(46, 204, 113, 0.15)`         |
+| --diff-del-background    | Background of removed lines                | `rgba(231, 76, 60, 0.15)`          |
+| --diff-marker-color      | Color of the `+`/`-` gutter markers        | `currentColor`                     |
+| --diff-hunk-background   | Background of hunk/file header rows        | `transparent`                      |
+| --diff-hunk-color        | Text color of hunk/file header rows        | `inherit`                          |
+| --diff-collapsed-color   | Text color of the collapsed-run button     | `inherit`                          |
+
 ## Svelte Syntax Highlighting
 
 Use the `HighlightSvelte` component for Svelte syntax highlighting. Its grammar understands Svelte 5 runes (`$state`, `$derived`, `$effect` and its suffixed forms, `$props.id`, `$inspect.trace`), store auto-subscription (`$store`, `$store()`, `$store.prop`), `lang="ts"`/`context="module"` script-block resolution, and directive shorthand (`on:`, `bind:`, `use:`, and friends) — genuinely ahead of generic HTML-plus-embedded-JS Svelte highlighting, which has no notion that runes exist.
@@ -764,6 +775,8 @@ Use `--line-added-background` and `--line-removed-background` to customize the b
   />
 </Highlight>
 ```
+
+`numbers` and `secondaryNumbers` override the gutter with explicit per-row values (`null` for a blank cell) instead of the default `i + startingLineNumber` sequence -- see [Diffs](#diffs), which uses them to show independent old-file/new-file line numbers side by side.
 
 ### Custom Styles
 
@@ -2067,6 +2080,64 @@ Browser Cmd+F can't see rows a virtualized view (`HighlightVirtual`, `HighlightS
 
 `highlightMatches(root, matches, { current, name })` paints `matches` into `root`, restricted to whatever rows are currently rendered there -- resolved per match's line via `[data-line]` (the row shape `HighlightVirtual`/`HighlightStream` render), then the `line`-th `.line` element (the shape `highlightFence`/fenced code renders), then the whole `<code>` split on `"\n"`; matches whose line resolves to nothing are skipped. It uses the CSS Custom Highlight API when available (two `Highlight`s: `name`, defaulting to `"shl-search"`, and `${name}-current` for the match at index `current`), or falls back to wrapping text in `<mark data-shl-search>` (plus `data-shl-search-current`) when it isn't. It paints once per call and returns `{ dispose() }` -- there's no diffing against a previous call, so a consumer disposes and re-runs it after the rendered window changes (`on:windowchange`) or the query changes (`onChange`), as in the example above. It's a no-op on the server. `import "svelte-highlight/search.css"` is optional and styles both highlight names via the `--search-match-background`/`--search-current-background` CSS variables; passing a custom `name` bypasses it, since the stylesheet only targets the default names.
 
+## Diffs
+
+`HighlightDiff` renders a unified diff or a before/after pair with syntax-highlighted payload lines, `+`/`-` gutter markers, and independent old-file/new-file line numbers -- the piece `stripDiffMarkers` (a `CopyButton` copy transform, see [Copy Button](#copy-button)) doesn't cover, since that's a prefix-stripping heuristic with no hunk awareness or rendering.
+
+Pass `diff` (unified diff text, parsed with `parseUnifiedDiff`) or `before`/`after` (diffed with `diffLines`) -- `diff` wins if both are given.
+
+```svelte
+<script>
+  import { HighlightDiff } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import atomOneDark from "svelte-highlight/styles/atom-one-dark";
+
+  const diff = `--- a/greet.ts
++++ b/greet.ts
+@@ -1,3 +1,3 @@
+ function greet(name: string) {
+-  return "Hello, " + name;
++  return "Hello, " + name + "!";
+ }
+`;
+</script>
+
+<svelte:head>
+  {@html atomOneDark}
+</svelte:head>
+
+<HighlightDiff {diff} language={typescript} />
+```
+
+`before`/`after` tokenize the whole document on each side, so multi-line constructs (a block comment, a template literal) always highlight correctly -- `diff` tokenizes each hunk independently, since the full pre-/post-image files aren't available from diff text alone, so a construct spanning a hunk boundary can mis-tokenize:
+
+```svelte
+<script>
+  import { HighlightDiff } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const before = `function greet(name: string) {
+  return "Hello, " + name;
+}`;
+  const after = `function greet(name: string) {
+  return "Hello, " + name + "!";
+}`;
+</script>
+
+<HighlightDiff {before} {after} language={typescript} />
+```
+
+`gutter` controls which line-number column(s) render: `"both"` (default) shows the new-file number plus the old-file number in a secondary column to its left; `"new"` shows only the new-file number; `"none"` hides numbers but keeps the markers and code. `context` (default `Infinity`) collapses a maximal run of consecutive unchanged lines longer than it behind a single "N unchanged lines" button, which expands to individual rows on click -- pass a small number (e.g. `3`) for large files with small changes. `hunkHeaders` (default `true`) renders a row for each hunk's `@@ ... @@` header and, when `diff` provides a path, each file's header.
+
+### Copying the result
+
+`stripDiffMarkers` exists for hand-typed `+`/`-` snippets that were never structured diffs -- it strips a leading marker character by convention, with no idea whether a line actually came from a diff. A `HighlightDiff` rendered from `before`/`after` already has the clean text on hand, so pair it with `CopyButton` directly instead of running it through `stripDiffMarkers`:
+
+```svelte
+<HighlightDiff {before} {after} language={typescript} />
+<CopyButton code={after} />
+```
+
 ## Terminal Output
 
 Use `AnsiOutput` to render terminal output that still contains ANSI [SGR](https://en.wikipedia.org/wiki/ANSI_escape_code#SGR_(Select_Graphic_Rendition)_parameters) escape codes. Colors, bold, dim, italic, and underline become styled HTML, along with OSC 8 hyperlinks, carriage-return overwrites, and reverse/strikethrough. The parser is separate from highlight.js, so reach for it with build logs, CLI output, and test runners.
@@ -2253,6 +2324,8 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 | startingLineNumber | `number`                                                     | `1`                                  |
 | highlightedLines   | `number[]`                                                   | `[]`                                 |
 | lineStates         | `Record<number, "highlighted" \| "focus" \| "added" \| "removed">` | `{}`                           |
+| numbers            | `(number \| null)[]`                                         | `undefined`                          |
+| secondaryNumbers   | `(number \| null)[]`                                         | `undefined`                          |
 | langtag            | `boolean`                                                    | `false`                              |
 | languageName       | `string`                                                     | `"plaintext"`                        |
 
@@ -2335,6 +2408,22 @@ The default slot exposes `{ scopeClass }`. `$$restProps` are forwarded to the to
 | --prompt-font-family  | Font family of the terminal prompt       | `ui-monospace, monospace`           |
 | --prompt-font-weight  | Font weight of the terminal prompt       | `700`                               |
 | --prompt-color        | Color of the terminal prompt             | `inherit`                           |
+
+### `HighlightDiff`
+
+#### Props
+
+| Name        | Type                          | Default value   |
+| :---------- | :---------------------------- | :--------------- |
+| diff        | `string`                      | `undefined`      |
+| before      | `string`                      | `undefined`      |
+| after       | `string`                      | `undefined`      |
+| language    | `LanguageType<string>`        | N/A (required)   |
+| gutter      | `"both" \| "new" \| "none"`   | `"both"`         |
+| context     | `number`                      | `Infinity`       |
+| hunkHeaders | `boolean`                     | `true`           |
+
+No events or slots. `$$restProps` are forwarded to the underlying `LineNumbers` component.
 
 ### `AnsiOutput`
 
@@ -2643,7 +2732,7 @@ See it as a complete page in [examples/cdn](examples/cdn).
 
 ### Stability tiers
 
-- **Stable, semver-governed:** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`, `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`, `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`, `Registry` and its methods, `createRegistry`, `registerAll`, `StreamSession`, `TokenizedDocument`, `createTokenizedDocument`, `TextSegment`, `FenceSegment`, `MarkdownSegment`, `FenceSplitter`, `createFenceSplitter`, `SearchMatch`, `SearchOptions`, `Search`, `createSearch`, `highlightMatches`, `UnknownLanguageError`, `TokenizerLoopError`. `Snapshot` is a serializable format that round-trips within one library version, but is **not** guaranteed stable across versions — a snapshot from an older release may be rejected on resume. The same caveat applies to `TokenizedDocument`: its method surface (`setCode`/`append`/`lineCount`/`lineRange`/`tokenizedThrough`/`checkpointCount`) is stable and semver-governed, but internally it resumes from `Snapshot`s the same way `StreamSession` does, so anything that tried to serialize and later resume a `TokenizedDocument`'s internal state directly would hit the same cross-version instability -- the public API doesn't expose that today.
+- **Stable, semver-governed:** `ScopeEvent`, `TEXT`/`OPEN`/`CLOSE`, `TokenRange`, `HighlightResult`, `LineToken`, `Renderer`, `renderHtml`, `toRanges`, `extendLines`, `tokenLines`, `escapeHtml`, `createHtmlRenderer`, `createRangeRenderer`, `createLineRenderer`, `Registry` and its methods, `createRegistry`, `registerAll`, `StreamSession`, `TokenizedDocument`, `createTokenizedDocument`, `TextSegment`, `FenceSegment`, `MarkdownSegment`, `FenceSplitter`, `createFenceSplitter`, `SearchMatch`, `SearchOptions`, `Search`, `createSearch`, `highlightMatches`, `DiffLine`, `DiffHunk`, `DiffFile`, `ParsedDiff`, `parseUnifiedDiff`, `diffLines`, `UnknownLanguageError`, `TokenizerLoopError`. `Snapshot` is a serializable format that round-trips within one library version, but is **not** guaranteed stable across versions — a snapshot from an older release may be rejected on resume. The same caveat applies to `TokenizedDocument`: its method surface (`setCode`/`append`/`lineCount`/`lineRange`/`tokenizedThrough`/`checkpointCount`) is stable and semver-governed, but internally it resumes from `Snapshot`s the same way `StreamSession` does, so anything that tried to serialize and later resume a `TokenizedDocument`'s internal state directly would hit the same cross-version instability -- the public API doesn't expose that today.
 - **Generated data, versioned with the library:** `GrammarIR`/`GrammarState`. These come from the build pipeline and are consumed by `registerAll`; treat them as opaque payloads whose field-level structure may change in any minor release. Always load grammars from the same package version as the engine.
 - **Experimental, may change in a minor release:** `createWorkerHighlighter`, `serveHighlighter`, `PostMessageTarget`, `WorkerHighlighter`, `WorkerSession`, `ServeHighlighterOptions` (`svelte-highlight/worker`). The wire protocol between the two halves is not part of the public contract — only the documented function behavior is.
 

--- a/scripts/npm-package.ts
+++ b/scripts/npm-package.ts
@@ -38,6 +38,14 @@ pkgJson.exports = {
     types: "./fence.d.ts",
     import: "./fence.js",
   },
+  "./diff": {
+    types: "./diff.d.ts",
+    import: "./diff.js",
+  },
+  "./diff.js": {
+    types: "./diff.d.ts",
+    import: "./diff.js",
+  },
   "./*.svelte": {
     types: "./*.svelte.d.ts",
     import: "./*.svelte",

--- a/src/HighlightDiff.svelte
+++ b/src/HighlightDiff.svelte
@@ -1,0 +1,299 @@
+<script>
+  import { diffLines, parseUnifiedDiff } from "./diff.js";
+  import { escapeHtml, scopeToCssClass, tokenLines } from "./engine.js";
+  import LineNumbers from "./LineNumbers.svelte";
+  import { ensureRegistered, registry } from "./registry.js";
+
+  /** @type {string | undefined} */
+  export let diff = undefined;
+
+  /** @type {string | undefined} */
+  export let before = undefined;
+
+  /** @type {string | undefined} */
+  export let after = undefined;
+
+  /** @type {import("./languages").LanguageType<string>} */
+  export let language;
+
+  /** @type {"both" | "new" | "none"} */
+  export let gutter = "both";
+
+  /** @type {number} */
+  export let context = Number.POSITIVE_INFINITY;
+
+  /** @type {boolean} */
+  export let hunkHeaders = true;
+
+  const ADDED_BACKGROUND = "rgba(46, 204, 113, 0.15)";
+  const REMOVED_BACKGROUND = "rgba(231, 76, 60, 0.15)";
+  const MARKER_TEXT = { add: "+", del: "-", ctx: " " };
+
+  /** @type {Set<string>} */
+  let expandedRuns = new Set();
+
+  /** @type {string[]} */
+  let lines = [];
+  /** @type {(number | null)[]} */
+  let numbers = [];
+  /** @type {(number | null)[] | undefined} */
+  let secondaryNumbers;
+  /** @type {Record<number, "added" | "removed">} */
+  let lineStates = {};
+
+  /**
+   * Local copy of fence.js's unexported renderToken -- escapes the token
+   * text and wraps it in a `<span class="hljs-...">` per open scope,
+   * innermost first.
+   * @param {import("./engine.d.ts").LineToken} token
+   */
+  function renderToken(token) {
+    let html = escapeHtml(token.text);
+    for (let i = token.scopes.length - 1; i >= 0; i -= 1) {
+      const scope = /** @type {string} */ (token.scopes[i]);
+      html = `<span class="${scopeToCssClass(scope, "hljs-")}">${html}</span>`;
+    }
+    return html;
+  }
+
+  /** @param {import("./engine.d.ts").LineToken[]} tokens */
+  function renderLine(tokens) {
+    return tokens.map(renderToken).join("");
+  }
+
+  /** @param {string} text */
+  function tokenizeText(text) {
+    const { events } = registry.highlight(text, { language: language.name });
+    return tokenLines(events);
+  }
+
+  /** @param {"add" | "del" | "ctx"} type */
+  function markerSpan(type) {
+    return `<span class="shl-diff-marker" data-diff="${type}" aria-hidden="true">${MARKER_TEXT[type]}</span>`;
+  }
+
+  /**
+   * @param {string | undefined} diff
+   * @param {string | undefined} before
+   * @param {string | undefined} after
+   * @returns {import("./diff.d.ts").DiffFile[]}
+   */
+  function getFiles(diff, before, after) {
+    if (diff !== undefined) return parseUnifiedDiff(diff).files;
+    if (before !== undefined || after !== undefined) {
+      return [
+        {
+          oldPath: undefined,
+          newPath: undefined,
+          hunks: [diffLines(before ?? "", after ?? "")],
+        },
+      ];
+    }
+    return [];
+  }
+
+  /** @param {import("./diff.d.ts").DiffFile} file */
+  function fileHeaderText(file) {
+    if (file.oldPath === undefined && file.newPath === undefined) return null;
+    return `${file.oldPath ?? file.newPath} → ${file.newPath ?? file.oldPath}`;
+  }
+
+  /**
+   * Builds the four parallel arrays `LineNumbers` needs: one entry per
+   * rendered row (a code line, a collapsed run, or a hunk/file header).
+   * @param {import("./diff.d.ts").DiffFile[]} files
+   * @param {Set<string>} expandedRuns
+   */
+  function buildRows(files, expandedRuns) {
+    /** @type {string[]} */
+    const lines = [];
+    /** @type {(number | null)[]} */
+    const numbers = [];
+    /** @type {(number | null)[] | undefined} */
+    const secondaryNumbers = gutter === "both" ? [] : undefined;
+    /** @type {Record<number, "added" | "removed">} */
+    const lineStates = {};
+
+    /**
+     * @param {string} html
+     * @param {number | null} newNumber
+     * @param {number | null} oldNumber
+     * @param {"added" | "removed" | undefined} state
+     */
+    const pushRow = (html, newNumber, oldNumber, state) => {
+      const index = lines.length;
+      lines.push(html);
+      numbers.push(gutter === "none" ? null : newNumber);
+      secondaryNumbers?.push(oldNumber);
+      if (state) lineStates[index] = state;
+    };
+
+    /** @param {string} text */
+    const pushHeader = (text) => {
+      pushRow(
+        `<span class="shl-diff-hunk" aria-hidden="true">${escapeHtml(text)}</span>`,
+        null,
+        null,
+        undefined,
+      );
+    };
+
+    files.forEach((file, fileIndex) => {
+      const headerText = fileHeaderText(file);
+      if (hunkHeaders && headerText !== null) pushHeader(headerText);
+
+      file.hunks.forEach((hunk, hunkIndex) => {
+        if (hunkHeaders) pushHeader(hunk.header);
+
+        const beforeText = hunk.lines
+          .filter((l) => l.type !== "add")
+          .map((l) => l.text)
+          .join("\n");
+        const afterText = hunk.lines
+          .filter((l) => l.type !== "del")
+          .map((l) => l.text)
+          .join("\n");
+        const beforeTokLines = tokenizeText(beforeText);
+        const afterTokLines = tokenizeText(afterText);
+
+        let oldLine = hunk.oldStart;
+        let newLine = hunk.newStart;
+        let beforeIdx = 0;
+        let afterIdx = 0;
+
+        const meta = hunk.lines.map((diffLine) => {
+          /** @type {number | null} */
+          let oldNumber = null;
+          /** @type {number | null} */
+          let newNumber = null;
+          /** @type {"added" | "removed" | undefined} */
+          let state;
+          /** @type {string} */
+          let html;
+          if (diffLine.type === "ctx") {
+            oldNumber = oldLine++;
+            newNumber = newLine++;
+            html = renderLine(
+              /** @type {import("./engine.d.ts").LineToken[]} */ (
+                beforeTokLines[beforeIdx++]
+              ),
+            );
+          } else if (diffLine.type === "del") {
+            oldNumber = oldLine++;
+            state = "removed";
+            html = renderLine(
+              /** @type {import("./engine.d.ts").LineToken[]} */ (
+                beforeTokLines[beforeIdx++]
+              ),
+            );
+          } else {
+            newNumber = newLine++;
+            state = "added";
+            html = renderLine(
+              /** @type {import("./engine.d.ts").LineToken[]} */ (
+                afterTokLines[afterIdx++]
+              ),
+            );
+          }
+          return {
+            type: diffLine.type,
+            oldNumber,
+            newNumber,
+            state,
+            html: markerSpan(diffLine.type) + html,
+          };
+        });
+
+        let i = 0;
+        while (i < meta.length) {
+          const row = /** @type {(typeof meta)[number]} */ (meta[i]);
+          if (row.type === "ctx") {
+            let j = i;
+            while (
+              j < meta.length &&
+              /** @type {(typeof meta)[number]} */ (meta[j]).type === "ctx"
+            ) {
+              j++;
+            }
+            const runLength = j - i;
+            const runId = `${fileIndex}-${hunkIndex}-${i}`;
+            if (runLength > context && !expandedRuns.has(runId)) {
+              pushRow(
+                `<button type="button" class="shl-diff-collapsed" data-diff-collapsed data-run="${runId}">${runLength} unchanged lines</button>`,
+                null,
+                null,
+                undefined,
+              );
+            } else {
+              for (let k = i; k < j; k++) {
+                const m = /** @type {(typeof meta)[number]} */ (meta[k]);
+                pushRow(m.html, m.newNumber, m.oldNumber, m.state);
+              }
+            }
+            i = j;
+          } else {
+            pushRow(row.html, row.newNumber, row.oldNumber, row.state);
+            i++;
+          }
+        }
+      });
+    });
+
+    return { lines, numbers, secondaryNumbers, lineStates };
+  }
+
+  /** @param {MouseEvent} event */
+  function handleClick(event) {
+    const target = /** @type {HTMLElement | null} */ (event.target);
+    const button = target?.closest("[data-diff-collapsed]");
+    if (!button) return;
+    const runId = button.getAttribute("data-run");
+    if (runId == null) return;
+    expandedRuns = new Set(expandedRuns).add(runId);
+  }
+
+  $: files = getFiles(diff, before, after);
+  $: {
+    ensureRegistered(language);
+    ({ lines, numbers, secondaryNumbers, lineStates } = buildRows(
+      files,
+      expandedRuns,
+    ));
+  }
+</script>
+
+<div on:click={handleClick}>
+  <LineNumbers
+    {...$$restProps}
+    {lines}
+    {numbers}
+    {secondaryNumbers}
+    {lineStates}
+    languageName={language.name}
+    style="--line-added-background: var(--diff-add-background, {ADDED_BACKGROUND}); --line-removed-background: var(--diff-del-background, {REMOVED_BACKGROUND})"
+  />
+</div>
+
+<style>
+  div {
+    display: contents;
+  }
+
+  :global(.shl-diff-marker) {
+    user-select: none;
+    color: var(--diff-marker-color, currentColor);
+  }
+
+  :global(.shl-diff-hunk) {
+    user-select: none;
+    background: var(--diff-hunk-background, transparent);
+    color: var(--diff-hunk-color, inherit);
+  }
+
+  :global(.shl-diff-collapsed) {
+    all: unset;
+    cursor: pointer;
+    user-select: none;
+    color: var(--diff-collapsed-color, inherit);
+  }
+</style>

--- a/src/HighlightDiff.svelte
+++ b/src/HighlightDiff.svelte
@@ -173,11 +173,16 @@
           if (diffLine.type === "ctx") {
             oldNumber = oldLine++;
             newNumber = newLine++;
+            // A ctx line occupies a slot in both the before and after
+            // reconstructions, so both indices must advance even though its
+            // HTML is only read from one of them -- otherwise a later add
+            // line reads a stale (pre-ctx) afterTokLines slot.
             html = renderLine(
               /** @type {import("./engine.d.ts").LineToken[]} */ (
                 beforeTokLines[beforeIdx++]
               ),
             );
+            afterIdx++;
           } else if (diffLine.type === "del") {
             oldNumber = oldLine++;
             state = "removed";
@@ -262,6 +267,10 @@
   }
 </script>
 
+<!-- The only interactive elements inside are real <button>s (already
+     keyboard-operable); this div only delegates their click events. -->
+<!-- svelte-ignore a11y-click-events-have-key-events -->
+<!-- svelte-ignore a11y-no-static-element-interactions -->
 <div on:click={handleClick}>
   <LineNumbers
     {...$$restProps}

--- a/src/HighlightDiff.svelte
+++ b/src/HighlightDiff.svelte
@@ -16,7 +16,7 @@
   /** @type {import("./languages").LanguageType<string>} */
   export let language;
 
-  /** @type {"both" | "new" | "none"} */
+  /** @type {"both" | "new" | "unified" | "none"} */
   export let gutter = "both";
 
   /** @type {number} */
@@ -123,7 +123,9 @@
     const pushRow = (html, newNumber, oldNumber, state) => {
       const index = lines.length;
       lines.push(html);
-      numbers.push(gutter === "none" ? null : newNumber);
+      if (gutter === "none") numbers.push(null);
+      else if (gutter === "unified") numbers.push(newNumber ?? oldNumber);
+      else numbers.push(newNumber);
       secondaryNumbers?.push(oldNumber);
       if (state) lineStates[index] = state;
     };

--- a/src/HighlightDiff.svelte.d.ts
+++ b/src/HighlightDiff.svelte.d.ts
@@ -1,0 +1,111 @@
+import type { SvelteComponentTyped } from "svelte";
+import type { HTMLAttributes } from "svelte/elements";
+import type { LanguageType } from "./languages";
+
+export type HighlightDiffProps = HTMLAttributes<HTMLDivElement> & {
+  /**
+   * Unified diff text, parsed with `parseUnifiedDiff`. Wins over `before`/
+   * `after` when both are given.
+   *
+   * Each hunk is tokenized independently from its own `+`/`-`/` ` lines
+   * (the full pre-/post-image files aren't available from diff text alone),
+   * so a multi-line construct (a block comment, a template literal) that
+   * spans a hunk boundary may highlight incorrectly. Pass `before`/`after`
+   * instead when that matters.
+   * @default undefined
+   */
+  diff?: string;
+
+  /**
+   * Full pre-image text. Diffed against `after` with `diffLines` when
+   * `diff` isn't set. Tokenized as a whole document, so multi-line
+   * constructs always highlight correctly.
+   * @default undefined
+   */
+  before?: string;
+
+  /**
+   * Full post-image text. See `before`.
+   * @default undefined
+   */
+  after?: string;
+
+  /**
+   * highlight.js language module.
+   * Import languages from `svelte-highlight/languages/*`.
+   * @example
+   * import typescript from "svelte-highlight/languages/typescript";
+   */
+  language: LanguageType<string>;
+
+  /**
+   * Which gutter number column(s) to show. `"both"` shows the new-file
+   * number (primary column) and the old-file number (secondary column to
+   * its left); `"new"` shows only the new-file number; `"none"` hides
+   * numbers entirely but keeps the `+`/`-` markers and code.
+   * @default "both"
+   */
+  gutter?: "both" | "new" | "none";
+
+  /**
+   * A maximal run of consecutive unchanged (`"ctx"`) lines longer than this
+   * collapses to a single "N unchanged lines" button that expands on click.
+   * @default Infinity
+   */
+  context?: number;
+
+  /**
+   * Render a row for each hunk header (e.g. `@@ -3,5 +3,7 @@`) and, when
+   * `diff` provides a path, one row per file header.
+   * @default true
+   */
+  hunkHeaders?: boolean;
+
+  /**
+   * Background of added lines. Forwarded to `LineNumbers`'
+   * `--line-added-background`.
+   * @default "rgba(46, 204, 113, 0.15)"
+   */
+  "--diff-add-background"?: string;
+
+  /**
+   * Background of removed lines. Forwarded to `LineNumbers`'
+   * `--line-removed-background`.
+   * @default "rgba(231, 76, 60, 0.15)"
+   */
+  "--diff-del-background"?: string;
+
+  /**
+   * Color of the `+`/`-` gutter markers.
+   * @default currentColor
+   */
+  "--diff-marker-color"?: string;
+
+  /**
+   * Background of hunk/file header rows.
+   * @default transparent
+   */
+  "--diff-hunk-background"?: string;
+
+  /**
+   * Text color of hunk/file header rows.
+   * @default inherit
+   */
+  "--diff-hunk-color"?: string;
+
+  /**
+   * Text color of the collapsed-run button.
+   * @default inherit
+   */
+  "--diff-collapsed-color"?: string;
+};
+
+export type HighlightDiffEvents = {};
+
+export type HighlightDiffSlots = {};
+
+export default class HighlightDiff extends SvelteComponentTyped<
+  HighlightDiffProps,
+  HighlightDiffEvents,
+  HighlightDiffSlots
+> {}

--- a/src/HighlightDiff.svelte.d.ts
+++ b/src/HighlightDiff.svelte.d.ts
@@ -41,11 +41,15 @@ export type HighlightDiffProps = HTMLAttributes<HTMLDivElement> & {
   /**
    * Which gutter number column(s) to show. `"both"` shows the new-file
    * number (primary column) and the old-file number (secondary column to
-   * its left); `"new"` shows only the new-file number; `"none"` hides
-   * numbers entirely but keeps the `+`/`-` markers and code.
+   * its left) -- the two-column convention GitHub, GitLab, and Bitbucket
+   * use in their unified diff view. `"new"` shows only the new-file
+   * number, blank for removed lines. `"unified"` is a single column like
+   * `"new"`, but falls back to the old-file number for removed lines
+   * instead of leaving it blank. `"none"` hides numbers entirely but
+   * keeps the `+`/`-` markers and code.
    * @default "both"
    */
-  gutter?: "both" | "new" | "none";
+  gutter?: "both" | "new" | "unified" | "none";
 
   /**
    * A maximal run of consecutive unchanged (`"ctx"`) lines longer than this

--- a/src/LineNumbers.svelte
+++ b/src/LineNumbers.svelte
@@ -43,6 +43,26 @@
    */
   export let lineStates = {};
 
+  /**
+   * Per-row primary gutter number, indexed like `lines`. Overrides
+   * `i + startingLineNumber`; `null` renders a blank cell for that row
+   * (e.g. an added line has no old-file number). A unified diff needs this
+   * because hunks start at arbitrary offsets and no single formula produces
+   * the right number for every row.
+   * @type {(number | null)[] | undefined}
+   */
+  export let numbers = undefined;
+
+  /**
+   * Per-row secondary gutter number, indexed like `lines`. When set, renders
+   * an extra gutter column to the left of the primary one (order: secondary,
+   * primary, code) and becomes the sticky `inset-inline-start: 0` column
+   * instead of the primary gutter. `null` renders a blank cell, same as
+   * `numbers`.
+   * @type {(number | null)[] | undefined}
+   */
+  export let secondaryNumbers = undefined;
+
   /** @type {import('./languages').LanguageName | (string & {})} */
   export let languageName = "plaintext";
 
@@ -78,15 +98,30 @@
     return undefined;
   }
 
+  /** @param {(number | null)[] | undefined} values */
+  function maxDigits(values) {
+    let max = 0;
+    for (const value of values ?? []) {
+      if (value == null) continue;
+      const len = value.toString().length;
+      if (len > max) max = len;
+    }
+    return max;
+  }
+
   $: renderedLines = lines ?? splitLines(highlighted ?? "");
   $: stateByIndex = buildStateByIndex(highlightedLines, lineStates);
   $: focusMode = stateByIndex.size > 0;
-  $: len_digits = (
+  $: defaultDigits = (
     startingLineNumber +
     (lineCount ?? renderedLines.length) -
     1
   ).toString().length;
-  $: len = len_digits - MIN_DIGITS < 1 ? MIN_DIGITS : len_digits;
+  $: primaryDigits = numbers ? maxDigits(numbers) : defaultDigits;
+  $: len = primaryDigits - MIN_DIGITS < 1 ? MIN_DIGITS : primaryDigits;
+  $: secondaryDigits = maxDigits(secondaryNumbers);
+  $: secondaryLen =
+    secondaryDigits - MIN_DIGITS < 1 ? MIN_DIGITS : secondaryDigits;
 </script>
 
 <div
@@ -102,22 +137,42 @@
   <table>
     <tbody class:hljs={true}>
       {#each renderedLines as line, i}
-        {@const lineNumber = i + startingLineNumber}
+        {@const lineNumber = numbers ? numbers[i] : i + startingLineNumber}
+        {@const secondaryLineNumber = secondaryNumbers?.[i]}
         {@const lineState = stateByIndex.get(i)}
         {@const background = lineBackground(lineState)}
         <tr class:dimmed={focusMode && !lineState}>
+          {#if secondaryNumbers}
+            <td
+              aria-hidden="true"
+              class:hljs={true}
+              class:hideBorder
+              style:position="sticky"
+              style:inset-inline-start="0"
+              style:text-align="end"
+              style:user-select="none"
+              style:width={`calc(${secondaryLen} * var(--line-number-digit-width, 0.6em))`}
+            >
+              <code style:color="var(--line-number-color, currentColor)">
+                {secondaryLineNumber ?? ""}
+              </code>
+              {#if background}
+                <div class:line-background={true} style:background></div>
+              {/if}
+            </td>
+          {/if}
           <td
             aria-hidden="true"
             class:hljs={true}
             class:hideBorder
-            style:position="sticky"
-            style:inset-inline-start="0"
+            style:position={secondaryNumbers ? undefined : "sticky"}
+            style:inset-inline-start={secondaryNumbers ? undefined : "0"}
             style:text-align="end"
             style:user-select="none"
             style:width={`calc(${len} * var(--line-number-digit-width, 0.6em))`}
           >
             <code style:color="var(--line-number-color, currentColor)">
-              {lineNumber}
+              {lineNumber ?? ""}
             </code>
             {#if background}
               <div class:line-background={true} style:background></div>

--- a/src/LineNumbers.svelte.d.ts
+++ b/src/LineNumbers.svelte.d.ts
@@ -79,6 +79,28 @@ export type LineNumbersProps = HTMLAttributes<HTMLDivElement> &
     lineStates?: Record<number, "highlighted" | "focus" | "added" | "removed">;
 
     /**
+     * Per-row primary gutter number, indexed like `lines`. Overrides
+     * `i + startingLineNumber`; `null` renders a blank cell for that row
+     * (e.g. an added line has no old-file number). A unified diff needs
+     * this because hunks start at arbitrary offsets and no single formula
+     * produces the right number for every row.
+     * @default undefined
+     * @example [10, null, 12, 13, null]
+     */
+    numbers?: (number | null)[];
+
+    /**
+     * Per-row secondary gutter number, indexed like `lines`. When set,
+     * renders an extra gutter column to the left of the primary one (order:
+     * secondary, primary, code) and becomes the sticky
+     * `inset-inline-start: 0` column instead of the primary gutter. `null`
+     * renders a blank cell, same as `numbers`.
+     * @default undefined
+     * @example [1, 2, null, null, 5]
+     */
+    secondaryNumbers?: (number | null)[];
+
+    /**
      * Line number text color.
      * Defaults to the current theme color applied to `.hljs code`.
      * @default currentColor

--- a/src/diff.d.ts
+++ b/src/diff.d.ts
@@ -1,0 +1,44 @@
+export interface DiffLine {
+  type: "add" | "del" | "ctx";
+  text: string;
+}
+
+export interface DiffHunk {
+  oldStart: number;
+  oldLines: number;
+  newStart: number;
+  newLines: number;
+  header: string;
+  lines: DiffLine[];
+}
+
+export interface DiffFile {
+  oldPath: string | undefined;
+  newPath: string | undefined;
+  hunks: DiffHunk[];
+}
+
+export interface ParsedDiff {
+  files: DiffFile[];
+}
+
+/**
+ * Parses unified diff text (`git diff` output, a bare `diff -u`, or a lone
+ * pasted hunk) into files and hunks. Tolerates missing `diff --git`/`---`/
+ * `+++` headers (a lone hunk starts a file with both paths `undefined`),
+ * CRLF line endings, and a trailing `\ No newline at end of file` marker.
+ * @param text unified diff text
+ */
+export declare function parseUnifiedDiff(text: string): ParsedDiff;
+
+/**
+ * Line-level diff of two strings (a Myers shortest-edit-script over lines,
+ * after trimming a common prefix/suffix of unchanged lines). Returns a
+ * single `DiffHunk` covering the whole documents (`oldStart`/`newStart` are
+ * both `1`). `hunk.lines` reconstructs `before`/`after` exactly:
+ * `hunk.lines.filter(l => l.type !== "del").map(l => l.text).join("\n") === after`
+ * (and the `"add"`/`before` mirror for `"del"`).
+ * @param before
+ * @param after
+ */
+export declare function diffLines(before: string, after: string): DiffHunk;

--- a/src/diff.js
+++ b/src/diff.js
@@ -1,0 +1,273 @@
+/**
+ * Zero-dependency unified-diff parsing and line-level diffing. No Svelte
+ * import; pure JS, safe to use headlessly.
+ * @typedef {import("./diff.d.ts").DiffLine} DiffLine
+ * @typedef {import("./diff.d.ts").DiffHunk} DiffHunk
+ * @typedef {import("./diff.d.ts").DiffFile} DiffFile
+ * @typedef {import("./diff.d.ts").ParsedDiff} ParsedDiff
+ */
+
+const GIT_HEADER_RE = /^diff --git a\/(.+) b\/(.+)$/;
+const HUNK_RE = /^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@/;
+const LINE_SPLIT_RE = /\r\n|\n/;
+const TRAILING_CR_RE = /\r$/;
+const NO_NEWLINE_MARKER = "\\ No newline at end of file";
+
+/**
+ * @param {string} text
+ * @returns {DiffLine}
+ */
+function ctxLine(text) {
+  return { type: "ctx", text };
+}
+
+/**
+ * @param {string} raw text after "--- " or "+++ "
+ * @param {string} gitPrefix "a/" or "b/"
+ * @param {boolean} stripGitPrefix
+ * @returns {string | undefined}
+ */
+function parsePath(raw, gitPrefix, stripGitPrefix) {
+  // Plain `diff -u` output (unlike `git diff`) may append a tab-separated
+  // timestamp after the path.
+  const trimmed = (raw.split("\t")[0] ?? "").trim();
+  if (trimmed === "/dev/null") return undefined;
+  if (stripGitPrefix && trimmed.startsWith(gitPrefix)) {
+    return trimmed.slice(gitPrefix.length);
+  }
+  return trimmed;
+}
+
+/**
+ * Parses unified diff text into files and hunks.
+ * @param {string} text
+ * @returns {ParsedDiff}
+ */
+export function parseUnifiedDiff(text) {
+  const rawLines = text
+    .split(LINE_SPLIT_RE)
+    .map((line) => line.replace(TRAILING_CR_RE, ""));
+  // A trailing newline in `text` splits to a final "" that is not itself a
+  // line (just the terminator) -- drop it so it isn't mistaken for a blank
+  // context line with no leading space.
+  if (rawLines.length > 0 && rawLines[rawLines.length - 1] === "") {
+    rawLines.pop();
+  }
+
+  /** @type {DiffFile[]} */
+  const files = [];
+  let file = /** @type {DiffFile | null} */ (null);
+  let hunk = /** @type {DiffHunk | null} */ (null);
+  let currentHasGitHeader = false;
+
+  const startFile = () => {
+    file = { oldPath: undefined, newPath: undefined, hunks: [] };
+    files.push(file);
+    hunk = null;
+    currentHasGitHeader = false;
+  };
+
+  for (const rawLine of rawLines) {
+    const gitMatch = GIT_HEADER_RE.exec(rawLine);
+    if (gitMatch) {
+      startFile();
+      currentHasGitHeader = true;
+      // file was just assigned by startFile().
+      const f = /** @type {DiffFile} */ (file);
+      f.oldPath = gitMatch[1];
+      f.newPath = gitMatch[2];
+      continue;
+    }
+
+    if (rawLine.startsWith("--- ")) {
+      if (!file || file.hunks.length > 0) startFile();
+      const f = /** @type {DiffFile} */ (file);
+      f.oldPath = parsePath(rawLine.slice(4), "a/", currentHasGitHeader);
+      continue;
+    }
+
+    if (rawLine.startsWith("+++ ")) {
+      if (!file) startFile();
+      const f = /** @type {DiffFile} */ (file);
+      f.newPath = parsePath(rawLine.slice(4), "b/", currentHasGitHeader);
+      continue;
+    }
+
+    const hunkMatch = HUNK_RE.exec(rawLine);
+    if (hunkMatch) {
+      if (!file) startFile();
+      hunk = {
+        oldStart: Number(hunkMatch[1]),
+        oldLines: hunkMatch[2] === undefined ? 1 : Number(hunkMatch[2]),
+        newStart: Number(hunkMatch[3]),
+        newLines: hunkMatch[4] === undefined ? 1 : Number(hunkMatch[4]),
+        header: rawLine.trim(),
+        lines: [],
+      };
+      /** @type {DiffFile} */ (file).hunks.push(hunk);
+      continue;
+    }
+
+    if (!hunk) {
+      // Git metadata (index/mode/similarity/rename/binary) or anything else
+      // outside a hunk: not represented in the parsed shape, skip.
+      continue;
+    }
+
+    if (rawLine === NO_NEWLINE_MARKER) continue;
+    if (rawLine.startsWith("+")) {
+      hunk.lines.push({ type: "add", text: rawLine.slice(1) });
+    } else if (rawLine.startsWith("-")) {
+      hunk.lines.push({ type: "del", text: rawLine.slice(1) });
+    } else if (rawLine.startsWith(" ")) {
+      hunk.lines.push({ type: "ctx", text: rawLine.slice(1) });
+    } else if (rawLine === "") {
+      hunk.lines.push({ type: "ctx", text: "" });
+    }
+  }
+
+  return { files };
+}
+
+/**
+ * Myers shortest-edit-script trace (see "An O(ND) Difference Algorithm and
+ * Its Variations"). `trace[d]` is the frontier state at the start of depth
+ * `d`, so backtracking from the returned trace reconstructs the edit path.
+ * @param {string[]} a
+ * @param {string[]} b
+ * @returns {Map<number, number>[]}
+ */
+function buildTrace(a, b) {
+  const n = a.length;
+  const m = b.length;
+  const max = n + m;
+  const v = new Map([[1, 0]]);
+  /** @type {Map<number, number>[]} */
+  const trace = [];
+
+  for (let d = 0; d <= max; d++) {
+    trace.push(new Map(v));
+    for (let k = -d; k <= d; k += 2) {
+      let x;
+      if (k === -d || (k !== d && (v.get(k - 1) ?? 0) < (v.get(k + 1) ?? 0))) {
+        x = v.get(k + 1) ?? 0;
+      } else {
+        x = (v.get(k - 1) ?? 0) + 1;
+      }
+      let y = x - k;
+      while (x < n && y < m && a[x] === b[y]) {
+        x++;
+        y++;
+      }
+      v.set(k, x);
+      if (x >= n && y >= m) return trace;
+    }
+  }
+  return trace;
+}
+
+/**
+ * @param {string[]} a
+ * @param {string[]} b
+ * @param {Map<number, number>[]} trace
+ * @returns {DiffLine[]}
+ */
+function backtrack(a, b, trace) {
+  let x = a.length;
+  let y = b.length;
+  /** @type {DiffLine[]} */
+  const edits = [];
+
+  for (let d = trace.length - 1; d >= 0; d--) {
+    const v = /** @type {Map<number, number>} */ (trace[d]);
+    const k = x - y;
+    const prevK =
+      k === -d || (k !== d && (v.get(k - 1) ?? 0) < (v.get(k + 1) ?? 0))
+        ? k + 1
+        : k - 1;
+    const prevX = v.get(prevK) ?? 0;
+    const prevY = prevX - prevK;
+
+    while (x > prevX && y > prevY) {
+      edits.push({ type: "ctx", text: /** @type {string} */ (a[x - 1]) });
+      x--;
+      y--;
+    }
+    if (d > 0) {
+      if (x === prevX) {
+        edits.push({ type: "add", text: /** @type {string} */ (b[y - 1]) });
+      } else {
+        edits.push({ type: "del", text: /** @type {string} */ (a[x - 1]) });
+      }
+    }
+    x = prevX;
+    y = prevY;
+  }
+
+  return edits.reverse();
+}
+
+/**
+ * @param {string[]} a
+ * @param {string[]} b
+ * @returns {DiffLine[]}
+ */
+function myersDiff(a, b) {
+  return backtrack(a, b, buildTrace(a, b));
+}
+
+/**
+ * Line-level diff of two strings, trimming a common prefix/suffix of
+ * unchanged lines before running Myers on the (usually much smaller)
+ * differing middle.
+ * @param {string} before
+ * @param {string} after
+ * @returns {DiffHunk}
+ */
+export function diffLines(before, after) {
+  const beforeLines = before.split("\n");
+  const afterLines = after.split("\n");
+
+  /** @type {DiffLine[]} */
+  let lines;
+  if (before === after) {
+    lines = beforeLines.map(ctxLine);
+  } else {
+    let prefix = 0;
+    const maxPrefix = Math.min(beforeLines.length, afterLines.length);
+    while (prefix < maxPrefix && beforeLines[prefix] === afterLines[prefix]) {
+      prefix++;
+    }
+
+    let suffix = 0;
+    const maxSuffix = maxPrefix - prefix;
+    while (
+      suffix < maxSuffix &&
+      beforeLines[beforeLines.length - 1 - suffix] ===
+        afterLines[afterLines.length - 1 - suffix]
+    ) {
+      suffix++;
+    }
+
+    const middleBefore = beforeLines.slice(prefix, beforeLines.length - suffix);
+    const middleAfter = afterLines.slice(prefix, afterLines.length - suffix);
+
+    lines = [
+      ...beforeLines.slice(0, prefix).map(ctxLine),
+      ...myersDiff(middleBefore, middleAfter),
+      ...beforeLines.slice(beforeLines.length - suffix).map(ctxLine),
+    ];
+  }
+
+  const oldLines = beforeLines.length;
+  const newLines = afterLines.length;
+
+  return {
+    oldStart: 1,
+    newStart: 1,
+    oldLines,
+    newLines,
+    header: `@@ -1,${oldLines} +1,${newLines} @@`,
+    lines,
+  };
+}

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -9,6 +9,7 @@ export { stripDiffMarkers, stripPrompts } from "./copy-transforms";
 export { default as FileTabs } from "./FileTabs.svelte";
 export { default as Highlight, default } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
+export { default as HighlightDiff } from "./HighlightDiff.svelte";
 export { default as HighlightEditable } from "./HighlightEditable.svelte";
 export { default as HighlightStream } from "./HighlightStream.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";

--- a/src/index.js
+++ b/src/index.js
@@ -7,6 +7,7 @@ export { stripDiffMarkers, stripPrompts } from "./copy-transforms.js";
 export { default as FileTabs } from "./FileTabs.svelte";
 export { default, default as Highlight } from "./Highlight.svelte";
 export { default as HighlightAuto } from "./HighlightAuto.svelte";
+export { default as HighlightDiff } from "./HighlightDiff.svelte";
 export { default as HighlightEditable } from "./HighlightEditable.svelte";
 export { default as HighlightStream } from "./HighlightStream.svelte";
 export { default as HighlightStyle } from "./HighlightStyle.svelte";

--- a/tests/diff.test.ts
+++ b/tests/diff.test.ts
@@ -1,0 +1,287 @@
+import { diffLines, parseUnifiedDiff } from "../src/diff.js";
+
+describe("parseUnifiedDiff", () => {
+  it("parses real `git diff` output", () => {
+    const diff = `diff --git a/src/foo.ts b/src/foo.ts
+index 83db48f..bf269f4 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -1,3 +1,4 @@
+ const a = 1;
+-const b = 2;
++const b = 3;
++const c = 4;
+ const d = 5;
+`;
+
+    expect(parseUnifiedDiff(diff)).toEqual({
+      files: [
+        {
+          oldPath: "src/foo.ts",
+          newPath: "src/foo.ts",
+          hunks: [
+            {
+              oldStart: 1,
+              oldLines: 3,
+              newStart: 1,
+              newLines: 4,
+              header: "@@ -1,3 +1,4 @@",
+              lines: [
+                { type: "ctx", text: "const a = 1;" },
+                { type: "del", text: "const b = 2;" },
+                { type: "add", text: "const b = 3;" },
+                { type: "add", text: "const c = 4;" },
+                { type: "ctx", text: "const d = 5;" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("parses a plain `diff -u` (no `diff --git`)", () => {
+    const diff = `--- foo.txt
++++ foo.txt
+@@ -1,2 +1,2 @@
+-old line
++new line
+ unchanged
+`;
+
+    expect(parseUnifiedDiff(diff)).toEqual({
+      files: [
+        {
+          oldPath: "foo.txt",
+          newPath: "foo.txt",
+          hunks: [
+            {
+              oldStart: 1,
+              oldLines: 2,
+              newStart: 1,
+              newLines: 2,
+              header: "@@ -1,2 +1,2 @@",
+              lines: [
+                { type: "del", text: "old line" },
+                { type: "add", text: "new line" },
+                { type: "ctx", text: "unchanged" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("tolerates CRLF line endings", () => {
+    const diff =
+      "--- a/foo.txt\r\n+++ b/foo.txt\r\n@@ -1,1 +1,1 @@\r\n-old\r\n+new\r\n";
+
+    expect(parseUnifiedDiff(diff)).toEqual({
+      files: [
+        {
+          oldPath: "a/foo.txt",
+          newPath: "b/foo.txt",
+          hunks: [
+            {
+              oldStart: 1,
+              oldLines: 1,
+              newStart: 1,
+              newLines: 1,
+              header: "@@ -1,1 +1,1 @@",
+              lines: [
+                { type: "del", text: "old" },
+                { type: "add", text: "new" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("consumes `\\ No newline at end of file` on both sides", () => {
+    const diff = `--- a/foo.txt
++++ b/foo.txt
+@@ -1,1 +1,1 @@
+-old
+\\ No newline at end of file
++new
+\\ No newline at end of file
+`;
+
+    expect(parseUnifiedDiff(diff)).toEqual({
+      files: [
+        {
+          oldPath: "a/foo.txt",
+          newPath: "b/foo.txt",
+          hunks: [
+            {
+              oldStart: 1,
+              oldLines: 1,
+              newStart: 1,
+              newLines: 1,
+              header: "@@ -1,1 +1,1 @@",
+              lines: [
+                { type: "del", text: "old" },
+                { type: "add", text: "new" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+
+  it("parses two files in one diff", () => {
+    const diff = `diff --git a/one.txt b/one.txt
+--- a/one.txt
++++ b/one.txt
+@@ -1,1 +1,1 @@
+-one
++ONE
+diff --git a/two.txt b/two.txt
+--- a/two.txt
++++ b/two.txt
+@@ -1,1 +1,1 @@
+-two
++TWO
+`;
+
+    const parsed = parseUnifiedDiff(diff);
+    expect(parsed.files).toHaveLength(2);
+    expect(parsed.files[0]?.oldPath).toBe("one.txt");
+    expect(parsed.files[0]?.newPath).toBe("one.txt");
+    expect(parsed.files[0]?.hunks[0]?.lines).toEqual([
+      { type: "del", text: "one" },
+      { type: "add", text: "ONE" },
+    ]);
+    expect(parsed.files[1]?.oldPath).toBe("two.txt");
+    expect(parsed.files[1]?.newPath).toBe("two.txt");
+    expect(parsed.files[1]?.hunks[0]?.lines).toEqual([
+      { type: "del", text: "two" },
+      { type: "add", text: "TWO" },
+    ]);
+  });
+
+  it("parses a pure-addition hunk", () => {
+    const diff = `--- a/foo.txt
++++ b/foo.txt
+@@ -0,0 +1,2 @@
++line one
++line two
+`;
+
+    const parsed = parseUnifiedDiff(diff);
+    expect(parsed.files[0]?.hunks[0]).toEqual({
+      oldStart: 0,
+      oldLines: 0,
+      newStart: 1,
+      newLines: 2,
+      header: "@@ -0,0 +1,2 @@",
+      lines: [
+        { type: "add", text: "line one" },
+        { type: "add", text: "line two" },
+      ],
+    });
+  });
+
+  it("starts a file at the first `@@` when no headers precede it", () => {
+    const diff = `@@ -1,1 +1,1 @@
+-old
++new
+`;
+
+    expect(parseUnifiedDiff(diff)).toEqual({
+      files: [
+        {
+          oldPath: undefined,
+          newPath: undefined,
+          hunks: [
+            {
+              oldStart: 1,
+              oldLines: 1,
+              newStart: 1,
+              newLines: 1,
+              header: "@@ -1,1 +1,1 @@",
+              lines: [
+                { type: "del", text: "old" },
+                { type: "add", text: "new" },
+              ],
+            },
+          ],
+        },
+      ],
+    });
+  });
+});
+
+describe("diffLines", () => {
+  it("marks identical strings as all `ctx`", () => {
+    const hunk = diffLines("same", "same");
+    expect(hunk.lines.every((line) => line.type === "ctx")).toBe(true);
+  });
+
+  it("round-trips before/after through the returned lines", () => {
+    const before = "const a = 1;\nconst b = 2;\nconst c = 3;";
+    const after = "const a = 1;\nconst b = two;\nconst c = 3;\nconst d = 4;";
+    const hunk = diffLines(before, after);
+
+    expect(
+      hunk.lines
+        .filter((l) => l.type !== "del")
+        .map((l) => l.text)
+        .join("\n"),
+    ).toBe(after);
+    expect(
+      hunk.lines
+        .filter((l) => l.type !== "add")
+        .map((l) => l.text)
+        .join("\n"),
+    ).toBe(before);
+  });
+
+  it("round-trips 200 random string pairs, with and without trailing newlines and astral Unicode", () => {
+    const words = ["const", "let", "foo", "bar", "😀", "𐈀", "() =>", "{", "}"];
+    let seed = 42;
+    const random = () => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    const randomLine = () =>
+      Array.from(
+        { length: 1 + Math.floor(random() * 3) },
+        () => words[Math.floor(random() * words.length)],
+      ).join(" ");
+    const randomString = () => {
+      const lineCount = Math.floor(random() * 5);
+      const lines = Array.from({ length: lineCount }, randomLine);
+      const text = lines.join("\n");
+      return random() < 0.5 ? text : `${text}\n`;
+    };
+
+    for (let i = 0; i < 200; i++) {
+      const before = randomString();
+      const after = randomString();
+      const hunk = diffLines(before, after);
+
+      expect(
+        hunk.lines
+          .filter((l) => l.type !== "del")
+          .map((l) => l.text)
+          .join("\n"),
+      ).toBe(after);
+      expect(
+        hunk.lines
+          .filter((l) => l.type !== "add")
+          .map((l) => l.text)
+          .join("\n"),
+      ).toBe(before);
+    }
+  });
+
+  it("round-trips empty strings", () => {
+    const hunk = diffLines("", "");
+    expect(hunk.lines).toEqual([{ type: "ctx", text: "" }]);
+  });
+});

--- a/tests/e2e/HighlightDiff.test.svelte
+++ b/tests/e2e/HighlightDiff.test.svelte
@@ -7,7 +7,8 @@
   export let before: string | undefined = undefined;
   export let after: string | undefined = undefined;
   export let context: number | undefined = undefined;
-  export let gutter: "both" | "new" | "none" | undefined = undefined;
+  export let gutter: "both" | "new" | "unified" | "none" | undefined =
+    undefined;
 </script>
 
 <svelte:head> {@html horizonDark} </svelte:head>

--- a/tests/e2e/HighlightDiff.test.svelte
+++ b/tests/e2e/HighlightDiff.test.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+  import { HighlightDiff } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+
+  export let diff: string | undefined = undefined;
+  export let before: string | undefined = undefined;
+  export let after: string | undefined = undefined;
+  export let context: number | undefined = undefined;
+  export let gutter: "both" | "new" | "none" | undefined = undefined;
+</script>
+
+<svelte:head> {@html horizonDark} </svelte:head>
+
+<HighlightDiff
+  {diff}
+  {before}
+  {after}
+  {context}
+  {gutter}
+  language={typescript}
+/>

--- a/tests/e2e/LineNumbers.secondaryNumbers.test.svelte
+++ b/tests/e2e/LineNumbers.secondaryNumbers.test.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+  import Highlight, { LineNumbers } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+  import horizonDark from "svelte-highlight/styles/horizon-dark";
+
+  const code = `const a = 1;
+const b = 2;
+const c = 3;
+const d = 4;
+const e = 5;`;
+</script>
+
+<svelte:head> {@html horizonDark} </svelte:head>
+
+<Highlight language={typescript} {code} let:highlighted>
+  <LineNumbers
+    {highlighted}
+    numbers={[10, null, 12, 13, null]}
+    secondaryNumbers={[1, 2, null, null, 5]}
+  />
+</Highlight>

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -26,6 +26,7 @@ import HighlightAutoLanguageRestriction from "./HighlightAuto.languageRestrictio
 import HighlightAutoNoCandidate from "./HighlightAuto.noCandidate.test.svelte";
 import HighlightAutoSecondBest from "./HighlightAuto.secondBest.test.svelte";
 import HighlightAuto from "./HighlightAuto.test.svelte";
+import HighlightDiff from "./HighlightDiff.test.svelte";
 import HighlightEditableBinding from "./HighlightEditable.binding.test.svelte";
 import HighlightEditableCssHighlights from "./HighlightEditable.cssHighlights.test.svelte";
 import HighlightEditableLanguageSwap from "./HighlightEditable.languageSwap.test.svelte";
@@ -843,6 +844,127 @@ test("LineNumbers - omitting numbers and secondaryNumbers keeps the existing sin
   await expect(page.locator("tbody > tr")).toHaveCount(1);
   await expect(page.locator("td.hljs")).toHaveCount(1);
   await expect(page.locator("td.hljs").first()).toHaveText("1");
+});
+
+test("HighlightDiff - renders added and removed line backgrounds with +/- markers", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightDiff, {
+    props: {
+      before: "const a = 1;\nconst b = 2;",
+      after: "const a = 2;\nconst b = 2;",
+    },
+  });
+
+  // 1 hunk-header row (hunkHeaders defaults to true) + del/add/ctx.
+  const rows = page.locator("tbody > tr");
+  await expect(rows).toHaveCount(4);
+
+  const markers = await page.locator(".shl-diff-marker").allTextContents();
+  expect(markers).toEqual(["-", "+", " "]);
+
+  await expect(rows.nth(1).locator("td:last-child .line-background")).toHaveCSS(
+    "background-color",
+    "rgba(231, 76, 60, 0.15)",
+  );
+  await expect(rows.nth(2).locator("td:last-child .line-background")).toHaveCSS(
+    "background-color",
+    "rgba(46, 204, 113, 0.15)",
+  );
+  await expect(rows.nth(3).locator(".line-background")).toHaveCount(0);
+});
+
+test("HighlightDiff - shows independent old and new line number gutters", async ({
+  mount,
+  page,
+}) => {
+  await mount(HighlightDiff, {
+    props: {
+      before: "const a = 1;\nconst b = 2;",
+      after: "const a = 2;\nconst b = 2;",
+      gutter: "both",
+    },
+  });
+
+  const secondary = await page
+    .locator("tbody > tr > td:nth-child(1)")
+    .allTextContents();
+  const primary = await page
+    .locator("tbody > tr > td:nth-child(2)")
+    .allTextContents();
+
+  // 1 hunk-header row (both numbers null) + del/add/ctx.
+  expect(secondary.map((text) => text.trim())).toEqual(["", "1", "", "2"]);
+  expect(primary.map((text) => text.trim())).toEqual(["", "", "1", "2"]);
+});
+
+test("HighlightDiff - a collapsed unchanged run expands on click", async ({
+  mount,
+  page,
+}) => {
+  const fileLines = Array.from(
+    { length: 40 },
+    (_, i) => `const line${i + 1} = ${i + 1};`,
+  );
+  const before = fileLines.join("\n");
+  const afterLines = [...fileLines];
+  afterLines[19] = "const line20 = 999;";
+  const after = afterLines.join("\n");
+
+  await mount(HighlightDiff, {
+    props: { before, after, context: 3 },
+  });
+
+  const collapsedButtons = page.locator("[data-diff-collapsed]");
+  await expect(collapsedButtons).toHaveCount(2);
+  await expect(collapsedButtons.first()).toHaveText("19 unchanged lines");
+  await expect(collapsedButtons.last()).toHaveText("20 unchanged lines");
+
+  await collapsedButtons.first().click();
+
+  await expect(page.locator("[data-diff-collapsed]")).toHaveCount(1);
+  const ctxCount = await page
+    .locator('.shl-diff-marker[data-diff="ctx"]')
+    .count();
+  expect(ctxCount).toBeGreaterThanOrEqual(19);
+});
+
+test("HighlightDiff - before/after props render the same rows as an equivalent unified diff", async ({
+  mount,
+  page,
+}) => {
+  const before = "const a = 1;\nconst b = 2;";
+  const after = "const a = 2;\nconst b = 2;";
+  // No "---"/"+++"/"diff --git" headers, so this parses with undefined
+  // paths, matching before/after mode's lack of a file-header row.
+  const diff = "@@ -1,2 +1,2 @@\n-const a = 1;\n+const a = 2;\n const b = 2;\n";
+
+  const beforeAfterComponent = await mount(HighlightDiff, {
+    props: { before, after },
+  });
+  const beforeAfterMarkers = await page
+    .locator(".shl-diff-marker")
+    .evaluateAll((els) =>
+      els.map((el) => [el.getAttribute("data-diff"), el.textContent]),
+    );
+  const beforeAfterNumbers = await page
+    .locator("tbody > tr > td:nth-child(1), tbody > tr > td:nth-child(2)")
+    .allTextContents();
+  await beforeAfterComponent.unmount();
+
+  await mount(HighlightDiff, { props: { diff } });
+  const diffMarkers = await page
+    .locator(".shl-diff-marker")
+    .evaluateAll((els) =>
+      els.map((el) => [el.getAttribute("data-diff"), el.textContent]),
+    );
+  const diffNumbers = await page
+    .locator("tbody > tr > td:nth-child(1), tbody > tr > td:nth-child(2)")
+    .allTextContents();
+
+  expect(beforeAfterMarkers).toEqual(diffMarkers);
+  expect(beforeAfterNumbers).toEqual(diffNumbers);
 });
 
 test("Language tag styling", async ({ mount, page }) => {

--- a/tests/e2e/e2e.test.ts
+++ b/tests/e2e/e2e.test.ts
@@ -59,6 +59,7 @@ import LineNumbersLineStates from "./LineNumbers.lineStates.test.svelte";
 import LineNumbersLinesInput from "./LineNumbers.linesInput.test.svelte";
 import LineNumbersMultilineSpan from "./LineNumbers.multilineSpan.test.svelte";
 import LineNumbersRtl from "./LineNumbers.rtl.test.svelte";
+import LineNumbersSecondaryNumbers from "./LineNumbers.secondaryNumbers.test.svelte";
 import LineNumbers from "./LineNumbers.test.svelte";
 import LineNumbersWrapLines from "./LineNumbers.wrapLines.test.svelte";
 import MarkdownStream from "./MarkdownStream.test.svelte";
@@ -808,6 +809,40 @@ test("LineNumbers - lineStates colors added/removed lines and exempts focus line
   await expect(rows.nth(0)).toHaveClass(/dimmed/);
   await expect(rows.nth(3)).toHaveClass(/dimmed/);
   await expect(rows.nth(0).locator("pre")).toHaveCSS("opacity", "0.4");
+});
+
+test("LineNumbers - numbers and secondaryNumbers override the gutter with blanks for null entries", async ({
+  mount,
+  page,
+}) => {
+  await mount(LineNumbersSecondaryNumbers);
+
+  const secondary = await page
+    .locator("tbody > tr > td:nth-child(1)")
+    .allTextContents();
+  const primary = await page
+    .locator("tbody > tr > td:nth-child(2)")
+    .allTextContents();
+
+  expect(primary.map((text) => text.trim())).toEqual([
+    "10",
+    "",
+    "12",
+    "13",
+    "",
+  ]);
+  expect(secondary.map((text) => text.trim())).toEqual(["1", "2", "", "", "5"]);
+});
+
+test("LineNumbers - omitting numbers and secondaryNumbers keeps the existing single auto-incrementing gutter", async ({
+  mount,
+  page,
+}) => {
+  await mount(LineNumbers);
+
+  await expect(page.locator("tbody > tr")).toHaveCount(1);
+  await expect(page.locator("td.hljs")).toHaveCount(1);
+  await expect(page.locator("td.hljs").first()).toHaveText("1");
 });
 
 test("Language tag styling", async ({ mount, page }) => {

--- a/tests/highlight-diff-ssr.test.ts
+++ b/tests/highlight-diff-ssr.test.ts
@@ -86,4 +86,35 @@ diff --git a/two.ts b/two.ts
 
     expect(body).toContain("hljs-keyword");
   });
+
+  it("keeps add-line content aligned to its own row when a ctx line separates two changes in one hunk", async () => {
+    const { default: HighlightDiff } = await compileForServer();
+
+    // A ctx line between two add/del pairs: the after-side reconstruction is
+    // [ctx, add, ctx, add], so the second add must read index 3, not 1 --
+    // regression coverage for a bug where ctx lines only advanced the
+    // before-side index, shifting every later add onto the wrong row.
+    const before = "const a = 1;\nconst mid = 0;\nconst b = 2;";
+    const after = "const a = 100;\nconst mid = 0;\nconst b = 200;";
+
+    const { body } = render(HighlightDiff, {
+      props: { before, after, language: typescript },
+    });
+
+    const addMarkerIndex = body.indexOf('data-diff="add"');
+    const firstAddRow = body.slice(addMarkerIndex, addMarkerIndex + 200);
+    expect(firstAddRow).toContain("100");
+    expect(firstAddRow).not.toContain("200");
+
+    const secondAddMarkerIndex = body.indexOf(
+      'data-diff="add"',
+      addMarkerIndex + 1,
+    );
+    const secondAddRow = body.slice(
+      secondAddMarkerIndex,
+      secondAddMarkerIndex + 200,
+    );
+    expect(secondAddRow).toContain("200");
+    expect(secondAddRow).not.toContain("100");
+  });
 });

--- a/tests/highlight-diff-ssr.test.ts
+++ b/tests/highlight-diff-ssr.test.ts
@@ -1,0 +1,89 @@
+import fs from "node:fs";
+import path from "node:path";
+import { pathToFileURL } from "node:url";
+import { compile } from "svelte/compiler";
+import { render } from "svelte/server";
+import typescript from "../src/languages/typescript.js";
+
+const componentPath = path.join(import.meta.dir, "../src/HighlightDiff.svelte");
+const lineNumbersPath = path.join(import.meta.dir, "../src/LineNumbers.svelte");
+
+async function compileForServer() {
+  // HighlightDiff imports LineNumbers.svelte, so compiling only HighlightDiff
+  // leaves a raw, un-compiled ".svelte" import in the output. Compile
+  // LineNumbers too and rewrite the import to point at its compiled output.
+  const lineNumbersJs = compile(fs.readFileSync(lineNumbersPath, "utf-8"), {
+    generate: "server",
+    filename: "LineNumbers.svelte",
+  }).js.code;
+  const lineNumbersOutPath = path.join(
+    import.meta.dir,
+    "../src/.tmp-line-numbers.server.js",
+  );
+  fs.writeFileSync(lineNumbersOutPath, lineNumbersJs);
+
+  const source = fs.readFileSync(componentPath, "utf-8");
+  const { js } = compile(source, {
+    generate: "server",
+    filename: "HighlightDiff.svelte",
+  });
+  const code = js.code.replace(
+    '"./LineNumbers.svelte"',
+    '"./.tmp-line-numbers.server.js"',
+  );
+
+  // Written alongside the component (not in tests/) so its relative imports
+  // resolve.
+  const outPath = path.join(
+    import.meta.dir,
+    "../src/.tmp-highlight-diff.server.js",
+  );
+  fs.writeFileSync(outPath, code);
+  try {
+    return await import(pathToFileURL(outPath).href);
+  } finally {
+    fs.unlinkSync(outPath);
+    fs.unlinkSync(lineNumbersOutPath);
+  }
+}
+
+describe("HighlightDiff SSR", () => {
+  it("renders both gutters' numbers and both markers as plain text, with no undefined/null leaks", async () => {
+    const { default: HighlightDiff } = await compileForServer();
+
+    const diff = `diff --git a/one.ts b/one.ts
+--- a/one.ts
++++ b/one.ts
+@@ -1,2 +1,2 @@
+-const a = 1;
++const a = 2;
+ const b = 2;
+diff --git a/two.ts b/two.ts
+--- a/two.ts
++++ b/two.ts
+@@ -1,2 +1,2 @@
+-const c = 3;
++const c = 4;
+ const d = 4;
+`;
+
+    const { body } = render(HighlightDiff, {
+      props: { diff, language: typescript },
+    });
+
+    expect(body).not.toContain("undefined");
+    expect(body).not.toContain("null");
+
+    expect(body).toContain('data-diff="add"');
+    expect(body).toContain('data-diff="del"');
+    expect(body).toContain('data-diff="ctx"');
+
+    // Old-file (secondary) and new-file (primary) gutter numbers for both
+    // hunks, including the ones only reachable on one side of a change.
+    for (const n of [1, 2]) {
+      expect(body).toContain(`>${n}<`);
+    }
+
+    expect(body).toContain("hljs-keyword");
+  });
+});

--- a/tests/highlight-diff-ssr.test.ts
+++ b/tests/highlight-diff-ssr.test.ts
@@ -117,4 +117,27 @@ diff --git a/two.ts b/two.ts
     expect(secondAddRow).toContain("200");
     expect(secondAddRow).not.toContain("100");
   });
+
+  it("gutter=unified renders one gutter column, falling back to the old-file number for removed lines", async () => {
+    const { default: HighlightDiff } = await compileForServer();
+
+    const before = "const a = 1;\nconst b = 2;";
+    const after = "const a = 2;\nconst b = 2;";
+
+    const { body } = render(HighlightDiff, {
+      props: { before, after, gutter: "unified", language: typescript },
+    });
+
+    // One gutter <td> per row (not two, like "both" would render).
+    const rowCount = (body.match(/<tr/g) ?? []).length;
+    const gutterCellCount = (body.match(/<td aria-hidden="true"/g) ?? [])
+      .length;
+    expect(gutterCellCount).toBe(rowCount);
+
+    // The removed line has no new-file number, so it falls back to its
+    // old-file number (1) instead of a blank cell.
+    const delMarkerIndex = body.indexOf('data-diff="del"');
+    const delRow = body.slice(delMarkerIndex - 400, delMarkerIndex);
+    expect(delRow).toContain(">1<");
+  });
 });

--- a/www/components/HighlightDiff/BeforeAfter.svelte
+++ b/www/components/HighlightDiff/BeforeAfter.svelte
@@ -1,0 +1,23 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { HighlightDiff } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const lines = Array.from(
+    { length: 24 },
+    (_, i) => `const line${i + 1} = ${i + 1};`,
+  );
+  const before = lines.join("\n");
+
+  const afterLines = [...lines];
+  afterLines[11] = "const line12 = 1200;";
+  const after = afterLines.join("\n");
+</script>
+
+<HighlightDiff
+  {before}
+  {after}
+  context={3}
+  language={typescript}
+  class={THEME_MODULE_NAME}
+/>

--- a/www/components/HighlightDiff/MultipleChanges.svelte
+++ b/www/components/HighlightDiff/MultipleChanges.svelte
@@ -1,0 +1,34 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { HighlightDiff } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const beforeLines = Array.from(
+    { length: 15 },
+    (_, i) => `const line${i + 1} = ${i + 1};`,
+  );
+  const before = beforeLines.join("\n");
+
+  const afterLines = [...beforeLines];
+  afterLines[2] = "const line3 = 300;";
+  afterLines[7] = "const line8 = 800;";
+  afterLines[12] = "const line13 = 1300;";
+  const after = afterLines.join("\n");
+
+  /** @type {("both" | "new" | "unified" | "none")[]} */
+  const gutters = ["both", "new", "unified", "none"];
+</script>
+
+{#each gutters as gutter}
+  <p class="label-01 mb-2">gutter="{gutter}"</p>
+  <div class="mb-5">
+    <HighlightDiff
+      {before}
+      {after}
+      {gutter}
+      context={2}
+      language={typescript}
+      class={THEME_MODULE_NAME}
+    />
+  </div>
+{/each}

--- a/www/components/HighlightDiff/PureAddition.svelte
+++ b/www/components/HighlightDiff/PureAddition.svelte
@@ -1,0 +1,31 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { HighlightDiff } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const diff = `diff --git a/src/greet.ts b/src/greet.ts
+new file mode 100644
+--- /dev/null
++++ b/src/greet.ts
+@@ -0,0 +1,5 @@
++export function greet(name: string) {
++  return "Hello, " + name + "!";
++}
++
++export const farewell = (name: string) => "Bye, " + name + ".";`;
+
+  /** @type {("both" | "new" | "unified" | "none")[]} */
+  const gutters = ["both", "new", "unified", "none"];
+</script>
+
+{#each gutters as gutter}
+  <p class="label-01 mb-2">gutter="{gutter}"</p>
+  <div class="mb-5">
+    <HighlightDiff
+      {diff}
+      {gutter}
+      language={typescript}
+      class={THEME_MODULE_NAME}
+    />
+  </div>
+{/each}

--- a/www/components/HighlightDiff/PureDeletion.svelte
+++ b/www/components/HighlightDiff/PureDeletion.svelte
@@ -1,0 +1,29 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { HighlightDiff } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const diff = `diff --git a/src/legacy.ts b/src/legacy.ts
+deleted file mode 100644
+--- a/src/legacy.ts
++++ /dev/null
+@@ -1,3 +0,0 @@
+-export function legacy() {
+-  return "deprecated";
+-}`;
+
+  /** @type {("both" | "new" | "unified" | "none")[]} */
+  const gutters = ["both", "new", "unified", "none"];
+</script>
+
+{#each gutters as gutter}
+  <p class="label-01 mb-2">gutter="{gutter}"</p>
+  <div class="mb-5">
+    <HighlightDiff
+      {diff}
+      {gutter}
+      language={typescript}
+      class={THEME_MODULE_NAME}
+    />
+  </div>
+{/each}

--- a/www/components/HighlightDiff/Unified.svelte
+++ b/www/components/HighlightDiff/Unified.svelte
@@ -1,0 +1,26 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { HighlightDiff } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const diff = `diff --git a/src/greet.ts b/src/greet.ts
+--- a/src/greet.ts
++++ b/src/greet.ts
+@@ -1,5 +1,5 @@
+ export function greet(name: string) {
+-  return "Hello, " + name;
++  return "Hello, " + name + "!";
+ }
+
+-export const farewell = (name: string) => "Bye, " + name;
++export const farewell = (name: string) => "Bye, " + name + ".";
+diff --git a/src/index.ts b/src/index.ts
+--- a/src/index.ts
++++ b/src/index.ts
+@@ -1,2 +1,3 @@
+ import { greet } from "./greet";
+
++console.log(greet("world"));`;
+</script>
+
+<HighlightDiff {diff} language={typescript} class={THEME_MODULE_NAME} />

--- a/www/components/HighlightDiff/UnifiedGutter.svelte
+++ b/www/components/HighlightDiff/UnifiedGutter.svelte
@@ -1,0 +1,20 @@
+<script>
+  import { THEME_MODULE_NAME } from "@www/constants";
+  import { HighlightDiff } from "svelte-highlight";
+  import typescript from "svelte-highlight/languages/typescript";
+
+  const before = `export function greet(name: string) {
+  return "Hello, " + name;
+}`;
+  const after = `export function greet(name: string) {
+  return "Hello, " + name + "!";
+}`;
+</script>
+
+<HighlightDiff
+  {before}
+  {after}
+  gutter="unified"
+  language={typescript}
+  class={THEME_MODULE_NAME}
+/>

--- a/www/components/HighlightDiffPreview.svelte
+++ b/www/components/HighlightDiffPreview.svelte
@@ -1,6 +1,7 @@
 <script>
   import DiffBeforeAfter from "@components/HighlightDiff/BeforeAfter.svelte";
   import DiffUnified from "@components/HighlightDiff/Unified.svelte";
+  import DiffUnifiedGutter from "@components/HighlightDiff/UnifiedGutter.svelte";
   import { Column, Row } from "carbon-components-svelte";
 </script>
 
@@ -14,4 +15,11 @@
     <h3>Before/after, with a collapsed unchanged run</h3>
   </Column>
   <Column xlg={12} lg={12} md={12}> <DiffBeforeAfter /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}>
+    <h3>gutter="unified" (single column, falls back to the old-file number)</h3>
+  </Column>
+  <Column xlg={12} lg={12} md={12}> <DiffUnifiedGutter /> </Column>
 </Row>

--- a/www/components/HighlightDiffPreview.svelte
+++ b/www/components/HighlightDiffPreview.svelte
@@ -1,0 +1,17 @@
+<script>
+  import DiffBeforeAfter from "@components/HighlightDiff/BeforeAfter.svelte";
+  import DiffUnified from "@components/HighlightDiff/Unified.svelte";
+  import { Column, Row } from "carbon-components-svelte";
+</script>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Unified diff</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <DiffUnified /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}>
+    <h3>Before/after, with a collapsed unchanged run</h3>
+  </Column>
+  <Column xlg={12} lg={12} md={12}> <DiffBeforeAfter /> </Column>
+</Row>

--- a/www/components/HighlightDiffPreview.svelte
+++ b/www/components/HighlightDiffPreview.svelte
@@ -1,5 +1,8 @@
 <script>
   import DiffBeforeAfter from "@components/HighlightDiff/BeforeAfter.svelte";
+  import DiffMultipleChanges from "@components/HighlightDiff/MultipleChanges.svelte";
+  import DiffPureAddition from "@components/HighlightDiff/PureAddition.svelte";
+  import DiffPureDeletion from "@components/HighlightDiff/PureDeletion.svelte";
   import DiffUnified from "@components/HighlightDiff/Unified.svelte";
   import DiffUnifiedGutter from "@components/HighlightDiff/UnifiedGutter.svelte";
   import { Column, Row } from "carbon-components-svelte";
@@ -22,4 +25,21 @@
     <h3>gutter="unified" (single column, falls back to the old-file number)</h3>
   </Column>
   <Column xlg={12} lg={12} md={12}> <DiffUnifiedGutter /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Pure addition, all four gutter modes</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <DiffPureAddition /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h3>Pure deletion, all four gutter modes</h3> </Column>
+  <Column xlg={12} lg={12} md={12}> <DiffPureDeletion /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}>
+    <h3>Multiple separate changes in one hunk, all four gutter modes</h3>
+  </Column>
+  <Column xlg={12} lg={12} md={12}> <DiffMultipleChanges /> </Column>
 </Row>

--- a/www/components/globals/Header.svelte
+++ b/www/components/globals/Header.svelte
@@ -69,6 +69,7 @@
     "/preview-d2": "D2 language preview",
     "/preview-bibtex": "BibTeX language preview",
     "/preview-ansi": "AnsiOutput preview",
+    "/preview-diff": "HighlightDiff preview",
     "/preview-dual-theme": "Dual light/dark HighlightStyle preview",
     "/preview-editable": "Editable highlight preview",
     "/preview-highlight-stream": "HighlightStream preview",

--- a/www/components/globals/Index.svelte
+++ b/www/components/globals/Index.svelte
@@ -12,6 +12,8 @@
   import FileTabs from "@components/FileTabs.svelte";
   import HighlightWrap from "@components/Highlight/Wrap.svelte";
   import HighlightAction from "@components/HighlightAction.svelte";
+  import DiffBeforeAfter from "@components/HighlightDiff/BeforeAfter.svelte";
+  import DiffUnified from "@components/HighlightDiff/Unified.svelte";
   import EditableBasic from "@components/HighlightEditable/Basic.svelte";
   import EditableCommands from "@components/HighlightEditable/Commands.svelte";
   import EditableComposition from "@components/HighlightEditable/Composition.svelte";
@@ -899,6 +901,31 @@ export { add, mul };\`,
     </p>
   </Column>
   <Column xlg={10} lg={10} md={12}> <AnsiOutputExamples /> </Column>
+</Row>
+
+<Row class="mb-9">
+  <Column xlg={12}> <h2 id="diffs">Diffs</h2> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">HighlightDiff</code>
+      renders a unified diff -- or a
+      <code class="code">before</code>/<code class="code">after</code>
+      pair -- with syntax-highlighted payload lines, +/- gutter markers, and
+      independent old-file/new-file line numbers.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <DiffUnified /> </Column>
+  <Column xlg={6} lg={6} md={12}>
+    <p class="mb-5">
+      <code class="code">before</code>/<code class="code">after</code>
+      diffs the whole documents with <code class="code">diffLines</code>, so
+      multi-line constructs always highlight correctly. A small
+      <code class="code">context</code>
+      collapses long unchanged runs behind a clickable "N unchanged lines"
+      button.
+    </p>
+  </Column>
+  <Column xlg={10} lg={10} md={12}> <DiffBeforeAfter /> </Column>
 </Row>
 
 <Row class="mb-9">

--- a/www/pages/preview-diff.astro
+++ b/www/pages/preview-diff.astro
@@ -1,0 +1,8 @@
+---
+import HighlightDiffPreview from "@components/HighlightDiffPreview.svelte";
+import Layout from "@layouts/Layout.astro";
+---
+
+<Layout title="HighlightDiff preview">
+  <HighlightDiffPreview client:idle />
+</Layout>


### PR DESCRIPTION
Also extends LineNumbers with numbers/secondaryNumbers gutter props,
and adds a HighlightDiff component built on top of them: renders a
unified diff or a before/after pair with syntax-highlighted payload
lines, +/- gutter markers, independent old/new line numbers, and
collapsible unchanged runs.

```svelte
<HighlightDiff {diff} language={typescript} />
<!-- or -->
<HighlightDiff {before} {after} language={typescript} />
```